### PR TITLE
patch - adding support for tco_policy archive_retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,3 +221,9 @@ BUG FIXING:
 FEATURES:
 #### resource/coralogix_alert
 * Adding support for `more_than_usual` condition for `metric.promql` alert.
+
+## Release 1.6.2
+
+FEATURES:
+#### resource/coralogix_tco_policy
+* Adding support for `archive_retention_id`.

--- a/coralogix/resource_coralogix_tco_policy_test.go
+++ b/coralogix/resource_coralogix_tco_policy_test.go
@@ -38,6 +38,7 @@ func TestAccCoralogixResourceTCOPolicyCreate(t *testing.T) {
 					resource.TestCheckResourceAttr(tcoPolicyResourceName1, "subsystem_name.0.rules.#", "2"),
 					resource.TestCheckTypeSetElemAttr(tcoPolicyResourceName1, "subsystem_name.0.rules.*", "mobile"),
 					resource.TestCheckTypeSetElemAttr(tcoPolicyResourceName1, "subsystem_name.0.rules.*", "web"),
+					resource.TestCheckTypeSetElemAttr(tcoPolicyResourceName1, "archive_retention_id", "e1c980d0-c910-4c54-8326-67f3cf95645a"),
 
 					resource.TestCheckResourceAttr(tcoPolicyResourceName2, "name", "Example tco_policy from terraform 2"),
 					resource.TestCheckResourceAttr(tcoPolicyResourceName2, "priority", "medium"),
@@ -108,6 +109,7 @@ func testAccCoralogixResourceTCOPolicy() string {
     					is = true
     					rules = ["mobile", "web"]
   					}
+					archive_retention_id = "e1c980d0-c910-4c54-8326-67f3cf95645a"
 				}
 
 				resource "coralogix_tco_policy" test_2 {

--- a/coralogix/resource_coralogix_tco_policy_test.go
+++ b/coralogix/resource_coralogix_tco_policy_test.go
@@ -38,7 +38,7 @@ func TestAccCoralogixResourceTCOPolicyCreate(t *testing.T) {
 					resource.TestCheckResourceAttr(tcoPolicyResourceName1, "subsystem_name.0.rules.#", "2"),
 					resource.TestCheckTypeSetElemAttr(tcoPolicyResourceName1, "subsystem_name.0.rules.*", "mobile"),
 					resource.TestCheckTypeSetElemAttr(tcoPolicyResourceName1, "subsystem_name.0.rules.*", "web"),
-					resource.TestCheckTypeSetElemAttr(tcoPolicyResourceName1, "archive_retention_id", "e1c980d0-c910-4c54-8326-67f3cf95645a"),
+					resource.TestCheckResourceAttr(tcoPolicyResourceName1, "archive_retention_id", "e1c980d0-c910-4c54-8326-67f3cf95645a"),
 
 					resource.TestCheckResourceAttr(tcoPolicyResourceName2, "name", "Example tco_policy from terraform 2"),
 					resource.TestCheckResourceAttr(tcoPolicyResourceName2, "priority", "medium"),

--- a/docs/data-sources/tco_policy.md
+++ b/docs/data-sources/tco_policy.md
@@ -26,6 +26,7 @@ data "coralogix_tco_policy" "imported_coralogix_tco_policy" {
 ### Read-Only
 
 - `application_name` (List of Object) The applications to apply the policy on. Applies the policy on all the applications by default. (see [below for nested schema](#nestedatt--application_name))
+- `archive_retention_id` (String) Allowing logs with a specific retention to be tagged
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
 - `id` (String) The ID of this resource.
 - `name` (String) The policy name. Have to be unique per policy.

--- a/docs/resources/tco_policy.md
+++ b/docs/resources/tco_policy.md
@@ -28,6 +28,7 @@ resource "coralogix_tco_policy" "tco_policy" {
     is    = true
     rules = ["mobile", "web"]
   }
+  archive_retention_id = "e1c980d0-c910-4c54-8326-67f3cf95645a"
 }
 
 resource "coralogix_tco_policy" "tco_policy_2" {
@@ -61,6 +62,7 @@ resource "coralogix_tco_policy" "tco_policy_2" {
 ### Optional
 
 - `application_name` (Block List, Max: 1) The applications to apply the policy on. Applies the policy on all the applications by default. (see [below for nested schema](#nestedblock--application_name))
+- `archive_retention_id` (String) Allowing logs with a specific retention to be tagged.
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
 - `subsystem_name` (Block List, Max: 1) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedblock--subsystem_name))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/examples/tco_policy/main.tf
+++ b/examples/tco_policy/main.tf
@@ -15,7 +15,7 @@ provider "coralogix" {
 resource "coralogix_tco_policy" "tco_policy_1" {
   name       = "Example tco_policy from terraform 1"
   priority   = "low"
-  order      = 2
+  order      = 1
   severities = ["debug", "verbose", "info"]
   application_name {
     starts_with = true
@@ -25,13 +25,14 @@ resource "coralogix_tco_policy" "tco_policy_1" {
     is    = true
     rules = ["mobile", "web"]
   }
+  archive_retention_id = "e1c980d0-c910-4c54-8326-67f3cf95645a"
 }
 
 resource "coralogix_tco_policy" "tco_policy_2" {
   name     = "Example tco_policy from terraform 2"
   priority = "medium"
 
-  order = 3
+  order = 2
 
   severities = ["error", "warning", "critical"]
   application_name {
@@ -48,7 +49,7 @@ resource "coralogix_tco_policy" "tco_policy_3" {
   name     = "Example tco_policy from terraform 3"
   priority = "high"
 
-  order = 1
+  order = 3
   #  currently, for controlling the policies order they have to be created by the order you want them to be.
   #  for this purpose, defining dependency via the 'order' field can control their creation order.
 


### PR DESCRIPTION
e.g. -
```
resource "coralogix_tco_policy" "tco_policy" {
  name       = "Example tco_policy from terraform"
  priority   = "low"
  order      = 1
  severities = ["debug", "verbose", "info"]
  application_name {
    starts_with = true
    rule        = "prod"
  }
  subsystem_name {
    is    = true
    rules = ["mobile", "web"]
  }
  archive_retention_id = "e1c980d0-c910-4c54-8326-67f3cf95645a"
}
```