### PR TITLE
fix: coralogix dashboard time relative parsing

### DIFF
--- a/coralogix/resource_coralogix_dashboard_test.go
+++ b/coralogix/resource_coralogix_dashboard_test.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"terraform-provider-coralogix/coralogix/clientset"
 	dashboard "terraform-provider-coralogix/coralogix/clientset/grpc/coralogix-dashboards/v1"
+
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -136,6 +137,11 @@ func testAccCoralogixResourceDashboard() string {
 	return `resource "coralogix_dashboard" test {
   name        = "test"
   description = "dashboards team is messing with this 🗿"
+  time_frame = {
+      relative = {
+        duration = "seconds:900" # 15 minutes
+      }
+  }
   layout      = {
     sections = [
       {
@@ -296,4 +302,15 @@ func testAccCoralogixResourceDashboardFromJson(jsonFilePath string) string {
    		content_json = file("%s")
 	}
 `, jsonFilePath)
+}
+
+func TestParseRelativeTimeDuration(t *testing.T) {
+	res, err := parseRelativeTimeDuration("seconds:900")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Seconds() != 900 {
+		t.Fatalf("expected 900 seconds, got %f", res.Seconds())
+	}
 }


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Fix: ES-85


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix for Error: Provider produced inconsistent result after apply..  produced an unexpected new value: .time_frame:
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment