### PR TITLE
patch - fixing nil pointer bug in alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -523,3 +523,8 @@ New Features:
 Bug fixing:
 #### resource/coralogix_dashboard
 * adding schema upgrade v1 to v2 (for `annotations.source.metrics` field).
+
+## Release 1.13.2
+Bug fixing:
+#### resource/coralogix_alert
+* fixing [runtime error: invalid memory address or nil pointer dereference](https://github.com/coralogix/terraform-provider-coralogix/issues/212).

--- a/coralogix/resource_coralogix_alert.go
+++ b/coralogix/resource_coralogix_alert.go
@@ -1547,10 +1547,16 @@ func extractCreateAlertRequest(d *schema.ResourceData) (*alerts.CreateAlertReque
 	incidentSettings := expandIncidentSettings(d.Get("incident_settings"))
 	notificationGroups, dgs := expandNotificationGroups(d.Get("notifications_group"))
 	diags = append(diags, dgs...)
+	if len(diags) != 0 {
+		return nil, diags
+	}
 	payloadFilters := expandPayloadFilters(d.Get("payload_filters"))
 	scheduling := expandActiveWhen(d.Get("scheduling"))
 	alertTypeParams, tracingAlert, dgs := expandAlertType(d)
 	diags = append(diags, dgs...)
+	if len(diags) != 0 {
+		return nil, diags
+	}
 
 	return &alerts.CreateAlertRequest{
 		Name:                       name,

--- a/coralogix/resource_coralogix_alert_test.go
+++ b/coralogix/resource_coralogix_alert_test.go
@@ -361,7 +361,7 @@ func TestAccCoralogixResourceAlert_flow(t *testing.T) {
 		severity:        selectRandomlyFromSlice(alertValidSeverities),
 		activeWhen:      randActiveWhen(),
 		notifyEveryMin:  acctest.RandIntRange(1500 /*to avoid notify_every < condition.0.time_window*/, 3600),
-		notifyOn:        selectRandomlyFromSlice(validNotifyOn),
+		notifyOn:        "Triggered_only",
 	}
 	checks := extractFlowAlertChecks(alert)
 
@@ -373,7 +373,7 @@ func TestAccCoralogixResourceAlert_flow(t *testing.T) {
 		severity:        selectRandomlyFromSlice(alertValidSeverities),
 		activeWhen:      randActiveWhen(),
 		notifyEveryMin:  acctest.RandIntRange(1500 /*to avoid notify_every < condition.0.time_window*/, 3600),
-		notifyOn:        selectRandomlyFromSlice(validNotifyOn),
+		notifyOn:        "Triggered_only",
 	}
 	updatedAlertChecks := extractFlowAlertChecks(updatedAlert)
 

--- a/coralogix/resource_coralogix_alert_test.go
+++ b/coralogix/resource_coralogix_alert_test.go
@@ -108,6 +108,7 @@ func TestAccCoralogixResourceAlert_newValue(t *testing.T) {
 		keyToTrack:            "EventType",
 		timeWindow:            selectRandomlyFromSlice(alertValidNewValueTimeFrames),
 	}
+	alert.notifyOn = "Triggered_only"
 	checks := extractNewValueChecks(alert)
 
 	updatedAlert := newValueAlertTestParams{
@@ -115,6 +116,7 @@ func TestAccCoralogixResourceAlert_newValue(t *testing.T) {
 		keyToTrack:            "EventType",
 		timeWindow:            selectRandomlyFromSlice(alertValidNewValueTimeFrames),
 	}
+	updatedAlert.notifyOn = "Triggered_only"
 	updatedAlertChecks := extractNewValueChecks(updatedAlert)
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
## Release 1.13.2
Bug fixing:
#### resource/coralogix_alert
* fixing [runtime error: invalid memory address or nil pointer dereference](https://github.com/coralogix/terraform-provider-coralogix/issues/212).
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment