### PR TITLE
patch - recreate resource on not-found error

### DIFF
--- a/coralogix/data_source_coralogix_action.go
+++ b/coralogix/data_source_coralogix_action.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -73,11 +72,8 @@ func (d *ActionDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
-			resp.Diagnostics.AddWarning(
-				fmt.Sprintf("Action %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
-			)
+			resp.Diagnostics.AddWarning(err.Error(),
+				fmt.Sprintf("Action %q is in state, but no longer exists in Coralogix backend", id))
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Action",

--- a/coralogix/data_source_coralogix_api_key.go
+++ b/coralogix/data_source_coralogix_api_key.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"terraform-provider-coralogix/coralogix/clientset"
@@ -76,10 +75,8 @@ func (d *ApiKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
-			resp.Diagnostics.AddWarning(
+			resp.Diagnostics.AddWarning(err.Error(),
 				fmt.Sprintf("Action %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_archive_logs.go
+++ b/coralogix/data_source_coralogix_archive_logs.go
@@ -68,9 +68,8 @@ func (d *ArchiveLogsDataSource) Read(ctx context.Context, req datasource.ReadReq
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
 			data.ID = types.StringNull()
-			resp.Diagnostics.AddWarning(
+			resp.Diagnostics.AddWarning(err.Error(),
 				fmt.Sprintf("archive-Logs %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_archive_metrics.go
+++ b/coralogix/data_source_coralogix_archive_metrics.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -67,10 +66,9 @@ func (d *ArchiveMetricsDataSource) Read(ctx context.Context, req datasource.Read
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("archive-metrics %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_custom_role.go
+++ b/coralogix/data_source_coralogix_custom_role.go
@@ -81,8 +81,8 @@ func (d *CustomRoleDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("Custom role  %q is in state, but no longer exists in Coralogix backend", roleId),
-				fmt.Sprintf("%v will be recreated when you apply", roleId),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_dashboard.go
+++ b/coralogix/data_source_coralogix_dashboard.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -72,11 +71,8 @@ func (d *DashboardDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
-			resp.Diagnostics.AddWarning(
-				fmt.Sprintf("Dashboard %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
-			)
+			resp.Diagnostics.AddWarning(err.Error(),
+				fmt.Sprintf("Dashboard %q is in state, but no longer exists in Coralogix backend", id))
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Dashboard",

--- a/coralogix/data_source_coralogix_events2meric.go
+++ b/coralogix/data_source_coralogix_events2meric.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -72,10 +71,9 @@ func (d *Events2MetricDataSource) Read(ctx context.Context, req datasource.ReadR
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("Events2Metric %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_group.go
+++ b/coralogix/data_source_coralogix_group.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"terraform-provider-coralogix/coralogix/clientset"
@@ -67,10 +66,9 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("Group %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_recording_rules_group.go
+++ b/coralogix/data_source_coralogix_recording_rules_group.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -71,10 +70,9 @@ func (d *RecordingRuleGroupSetDataSource) Read(ctx context.Context, req datasour
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("recording-rule-group-set %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_sli.go
+++ b/coralogix/data_source_coralogix_sli.go
@@ -79,10 +79,9 @@ func (d *SLIDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("SLI %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_slo.go
+++ b/coralogix/data_source_coralogix_slo.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -70,10 +69,9 @@ func (d *SLODataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("SLO %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_tco_policy_logs.go
+++ b/coralogix/data_source_coralogix_tco_policy_logs.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -73,10 +72,9 @@ func (d *TCOPolicyDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("tco-policy %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_tco_policy_traces.go
+++ b/coralogix/data_source_coralogix_tco_policy_traces.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -73,10 +72,9 @@ func (d *TCOPolicyTracesDataSource) Read(ctx context.Context, req datasource.Rea
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("tco-policy %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_team.go
+++ b/coralogix/data_source_coralogix_team.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -85,10 +84,9 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("Team %q is in state, but no longer exists in Coralogix backend", intId),
-				fmt.Sprintf("%q will be recreated when you apply", intId),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_user.go
+++ b/coralogix/data_source_coralogix_user.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"terraform-provider-coralogix/coralogix/clientset"
@@ -67,10 +66,9 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("User %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/coralogix/data_source_coralogix_webhook.go
+++ b/coralogix/data_source_coralogix_webhook.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -74,10 +73,9 @@ func (d *WebhookDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			data.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
+				err.Error(),
 				fmt.Sprintf("Webhook %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 		} else {
 			reqStr := protojson.Format(getWebhookReq)

--- a/coralogix/resource_coralogix_action.go
+++ b/coralogix/resource_coralogix_action.go
@@ -209,11 +209,11 @@ func (r *ActionResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Action %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Action",
@@ -264,11 +264,11 @@ func (r ActionResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Action %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Action",

--- a/coralogix/resource_coralogix_alerts_scheduler.go
+++ b/coralogix/resource_coralogix_alerts_scheduler.go
@@ -1093,11 +1093,11 @@ func (r *AlertsSchedulerResource) Read(ctx context.Context, req resource.ReadReq
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("alerts-scheduler %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading alerts-scheduler",
@@ -1158,11 +1158,11 @@ func (r *AlertsSchedulerResource) Update(ctx context.Context, req resource.Updat
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("alerts-scheduler %s is in state, but no longer exists in Coralogix backend", *id),
 				fmt.Sprintf("%s will be recreated when you apply", *id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading alerts-scheduler",

--- a/coralogix/resource_coralogix_api_key.go
+++ b/coralogix/resource_coralogix_api_key.go
@@ -335,6 +335,11 @@ func (r *ApiKeyResource) getKeyInfo(ctx context.Context, id *string, keyValue *s
 				"Error getting Api Key",
 				fmt.Sprintf("permission denied for url - %s\ncheck your org-key and permissions", getApiKeyPath),
 			)
+		} else if status.Code(err) == codes.NotFound {
+			diags.AddError(
+				"Error getting Api Key",
+				fmt.Sprintf("Api Key with id %s not found", *id),
+			)
 		} else {
 			diags.AddError(
 				"Error getting Api Key",

--- a/coralogix/resource_coralogix_archive_logs.go
+++ b/coralogix/resource_coralogix_archive_logs.go
@@ -184,11 +184,11 @@ func (r *ArchiveLogsResource) Read(ctx context.Context, req resource.ReadRequest
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("archive-logs %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading archive-logs",

--- a/coralogix/resource_coralogix_archive_metrics.go
+++ b/coralogix/resource_coralogix_archive_metrics.go
@@ -369,11 +369,11 @@ func (r *ArchiveMetricsResource) Read(ctx context.Context, req resource.ReadRequ
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("archiveMetrics %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading archive-metrics",

--- a/coralogix/resource_coralogix_custom_role.go
+++ b/coralogix/resource_coralogix_custom_role.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"terraform-provider-coralogix/coralogix/clientset"
 	roles "terraform-provider-coralogix/coralogix/clientset/grpc/roles"
@@ -145,39 +147,28 @@ func (c *CustomRoleSource) Read(ctx context.Context, req resource.ReadRequest, r
 		resp.Diagnostics.AddError("Invalid Id", "Custom role id must be an int")
 		return
 	}
-	model, done := c.getRoleById(ctx, uint32(roleId))
-
-	if done.HasError() {
-		resp.Diagnostics.Append(diags...)
+	readReq := &roles.GetCustomRoleRequest{RoleId: uint32(roleId)}
+	log.Printf("[INFO] Reading Custom Role: %s", protojson.Format(readReq))
+	role, err := c.client.GetRole(ctx, readReq)
+	if err != nil {
+		log.Printf("[ERROR] Received error: %s", err.Error())
+		if status.Code(err) == codes.NotFound {
+			resp.Diagnostics.AddWarning(
+				fmt.Sprintf("Custom Role %q is in state, but no longer exists in Coralogix backend", roleId),
+				fmt.Sprintf("%d will be recreated when you apply", roleId),
+			)
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError(
+				"Error reading Custom Role",
+				formatRpcErrors(err, getRolePath, protojson.Format(readReq)),
+			)
+		}
 		return
 	}
 
-	diags = resp.State.Set(ctx, model)
+	diags = resp.State.Set(ctx, role)
 	resp.Diagnostics.Append(diags...)
-}
-
-func (c *CustomRoleSource) getRoleById(ctx context.Context, roleId uint32) (*RolesModel, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	getCustomRoleRequest := roles.GetCustomRoleRequest{
-		RoleId: roleId,
-	}
-
-	createCustomRoleResponse, err := c.client.GetRole(ctx, &getCustomRoleRequest)
-	if err != nil {
-		log.Printf("[ERROR] Received error: %s", err.Error())
-		diags.AddError(
-			"Error getting Custom Role",
-			formatRpcErrors(err, getRolePath, protojson.Format(&getCustomRoleRequest)),
-		)
-		return nil, diags
-	}
-
-	model, diags := flatterCustomRole(ctx, createCustomRoleResponse.GetRole())
-	if diags.HasError() {
-		return nil, diags
-	}
-
-	return model, nil
 }
 
 func (c *CustomRoleSource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/coralogix/resource_coralogix_custom_role.go
+++ b/coralogix/resource_coralogix_custom_role.go
@@ -137,8 +137,7 @@ func (c *CustomRoleSource) Create(ctx context.Context, req resource.CreateReques
 
 func (c *CustomRoleSource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var currentState *RolesModel
-	diags := req.State.Get(ctx, &currentState)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &currentState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -147,6 +146,7 @@ func (c *CustomRoleSource) Read(ctx context.Context, req resource.ReadRequest, r
 		resp.Diagnostics.AddError("Invalid Id", "Custom role id must be an int")
 		return
 	}
+
 	readReq := &roles.GetCustomRoleRequest{RoleId: uint32(roleId)}
 	log.Printf("[INFO] Reading Custom Role: %s", protojson.Format(readReq))
 	role, err := c.client.GetRole(ctx, readReq)
@@ -166,24 +166,26 @@ func (c *CustomRoleSource) Read(ctx context.Context, req resource.ReadRequest, r
 		}
 		return
 	}
-
-	diags = resp.State.Set(ctx, role)
-	resp.Diagnostics.Append(diags...)
+	flattenedRule, diags := flatterCustomRole(ctx, role.GetRole())
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, flattenedRule)...)
 }
 
 func (c *CustomRoleSource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var currentState, desiredState *RolesModel
-	diags := req.State.Get(ctx, &currentState)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &currentState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &desiredState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	diags = req.Plan.Get(ctx, &desiredState)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+
 	roleId, err := strconv.Atoi(currentState.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Id", "Custom role id must be an int")
@@ -194,8 +196,7 @@ func (c *CustomRoleSource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	if currentState.ParentRole != desiredState.ParentRole {
-		diags.AddError("Custom role update error", "ParentRole can not be updated!")
-		resp.Diagnostics.Append(diags...)
+		resp.Diagnostics.AddError("Custom role update error", "ParentRole can not be updated!")
 		return
 	}
 
@@ -229,10 +230,6 @@ func (c *CustomRoleSource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	log.Printf("[INFO] Custom Role %v updated", roleId)
-
-	if diags.HasError() {
-		return
-	}
 
 	// Set state to fully populated data
 	resp.Diagnostics.Append(resp.State.Set(ctx, desiredState)...)

--- a/coralogix/resource_coralogix_dashboard.go
+++ b/coralogix/resource_coralogix_dashboard.go
@@ -945,6 +945,7 @@ func (r *DashboardResource) Schema(_ context.Context, req resource.SchemaRequest
 func dashboardSchemaAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"id": schema.StringAttribute{
+			Optional: true,
 			Computed: true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),

--- a/coralogix/resource_coralogix_dashboard.go
+++ b/coralogix/resource_coralogix_dashboard.go
@@ -945,7 +945,6 @@ func (r *DashboardResource) Schema(_ context.Context, req resource.SchemaRequest
 func dashboardSchemaAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"id": schema.StringAttribute{
-			Optional: true,
 			Computed: true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),

--- a/coralogix/resource_coralogix_dashboards_folder.go
+++ b/coralogix/resource_coralogix_dashboards_folder.go
@@ -180,9 +180,10 @@ func (r *DashboardsFolderResource) Read(ctx context.Context, req resource.ReadRe
 	}
 	if dashboardsFolder == nil {
 		log.Printf("[ERROR] Could not find created folder with id: %s", state.ID.ValueString())
-		resp.Diagnostics.AddError("Error Listing Dashboards Folders",
-			fmt.Sprintf("Could not find created folder with id: %s", state.ID.ValueString()),
+		resp.Diagnostics.AddError(fmt.Sprintf("Dashboard folder %q is in state, but no longer exists in Coralogix backend", state.ID.ValueString()),
+			fmt.Sprintf("%s will be recreated when you apply", state.ID.ValueString()),
 		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/coralogix/resource_coralogix_events2metric.go
+++ b/coralogix/resource_coralogix_events2metric.go
@@ -871,11 +871,11 @@ func (r *Events2MetricResource) Read(ctx context.Context, req resource.ReadReque
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Events2Metric %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Events2Metric",
@@ -924,11 +924,11 @@ func (r *Events2MetricResource) Update(ctx context.Context, req resource.UpdateR
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Events2Metric %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Events2Metric",

--- a/coralogix/resource_coralogix_group.go
+++ b/coralogix/resource_coralogix_group.go
@@ -168,11 +168,11 @@ func (r *GroupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Group %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Group",
@@ -231,11 +231,11 @@ func (r *GroupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Group %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Group",

--- a/coralogix/resource_coralogix_recording_rules_groups_set.go
+++ b/coralogix/resource_coralogix_recording_rules_groups_set.go
@@ -386,6 +386,7 @@ func (r *RecordingRuleGroupSetResource) Create(ctx context.Context, req resource
 				fmt.Sprintf("recording-rule-group-set %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading recording-rule-group-set",
@@ -550,6 +551,7 @@ func (r *RecordingRuleGroupSetResource) Read(ctx context.Context, req resource.R
 				fmt.Sprintf("recording-rule-group-set %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading recording-rule-group-set",
@@ -604,6 +606,7 @@ func (r *RecordingRuleGroupSetResource) Update(ctx context.Context, req resource
 				fmt.Sprintf("recording-rule-group-set %q is in state, but no longer exists in Coralogix backend", plan.ID.ValueString()),
 				fmt.Sprintf("%s will be recreated when you apply", plan.ID.ValueString()),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading recording-rule-group-set",
@@ -639,8 +642,9 @@ func (r *RecordingRuleGroupSetResource) Delete(ctx context.Context, req resource
 		if status.Code(err) == codes.NotFound {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("recording-rule-group-set %q is in state, but no longer exists in Coralogix backend", id),
-				"",
+				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error deleting recording-rule-group-set",

--- a/coralogix/resource_coralogix_sli.go
+++ b/coralogix/resource_coralogix_sli.go
@@ -482,11 +482,11 @@ func (r *SLIResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("SLI %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading SLI",
@@ -565,6 +565,7 @@ func (r *SLIResource) Update(ctx context.Context, req resource.UpdateRequest, re
 				fmt.Sprintf("SLI %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading SLI",

--- a/coralogix/resource_coralogix_slo.go
+++ b/coralogix/resource_coralogix_slo.go
@@ -447,6 +447,7 @@ func (r *SLOResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 				fmt.Sprintf("SLO %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading SLO",
@@ -507,6 +508,7 @@ func (r *SLOResource) Update(ctx context.Context, req resource.UpdateRequest, re
 				fmt.Sprintf("SLO %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading SLO",

--- a/coralogix/resource_coralogix_tco_policy_logs.go
+++ b/coralogix/resource_coralogix_tco_policy_logs.go
@@ -545,11 +545,11 @@ func (r *TCOPolicyResource) Read(ctx context.Context, req resource.ReadRequest, 
 			continue
 		}
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("tco-policy %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading tco-policy",
@@ -628,11 +628,11 @@ func (r *TCOPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("tco-policy %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading tco-policy",

--- a/coralogix/resource_coralogix_tco_policy_traces.go
+++ b/coralogix/resource_coralogix_tco_policy_traces.go
@@ -354,11 +354,11 @@ func (r *TCOPolicyTracesResource) Read(ctx context.Context, req resource.ReadReq
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("tco-policy %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			reqStr := protojson.Format(getPolicyReq)
 			resp.Diagnostics.AddError(
@@ -429,11 +429,11 @@ func (r TCOPolicyTracesResource) Update(ctx context.Context, req resource.Update
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("tco-policy %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading tco-policy",

--- a/coralogix/resource_coralogix_team.go
+++ b/coralogix/resource_coralogix_team.go
@@ -209,11 +209,11 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Team %q is in state, but no longer exists in Coralogix backend", intId),
 				fmt.Sprintf("%q will be recreated when you apply", intId),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Team",

--- a/coralogix/resource_coralogix_user.go
+++ b/coralogix/resource_coralogix_user.go
@@ -259,11 +259,11 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("User %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading User",
@@ -335,11 +335,11 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("User %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading User",

--- a/coralogix/resource_coralogix_webhook.go
+++ b/coralogix/resource_coralogix_webhook.go
@@ -772,11 +772,11 @@ func (r *WebhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			state.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Webhook %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Webhook",
@@ -832,11 +832,11 @@ func (r WebhookResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			plan.ID = types.StringNull()
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Webhook %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
+			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Webhook",


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment