### PR TITLE
Downgrade proto reflection errors to warnings in build flags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,30 +4,30 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X coralogix/provider.providerVersion={{.Version}}
+      - -s -w -X coralogix/provider.providerVersion={{.Version}} -X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn
     goos:
       - darwin
       - freebsd
       - linux
       - windows
     goarch:
-      - '386'
+      - "386"
       - amd64
       - arm
       - arm64
     ignore:
-      - goarch: '386'
+      - goarch: "386"
         goos: darwin
-    binary: '{{ .ProjectName }}_{{ .Version }}'
+    binary: "{{ .ProjectName }}_{{ .Version }}"
 archives:
   - format: zip
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum


### PR DESCRIPTION
### Description
I added the build flags found in the Makefile to the goreleaser config file, so that conflicts in the proto field numbers won't break the operator.
