### PR TITLE
Feature Request: Added abbreviated endpoint support for AP3 Jakarta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,3 +688,9 @@ New Features:
 
 ### data-source/coralogix_webhook
 * Added support for searching by webhook name.
+
+## Release 1.18.3
+
+New Features:
+
+* added abbreviated endpoint for `AP3`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -689,7 +689,7 @@ New Features:
 ### data-source/coralogix_webhook
 * Added support for searching by webhook name.
 
-## Release 1.18.3
+## Release 1.18.8
 
 New Features:
 

--- a/coralogix/provider.go
+++ b/coralogix/provider.go
@@ -43,6 +43,8 @@ var (
 		"AP1":     "ng-api-grpc.app.coralogix.in:443",
 		"APAC2":   "ng-api-grpc.coralogixsg.com:443",
 		"AP2":     "ng-api-grpc.coralogixsg.com:443",
+		"APAC3":   "ng-api-grpc.ap3.coralogix.com:443",
+		"AP3":     "ng-api-grpc.ap3.coralogix.com:443",
 		"EUROPE1": "ng-api-grpc.coralogix.com:443",
 		"EU1":     "ng-api-grpc.coralogix.com:443",
 		"EUROPE2": "ng-api-grpc.eu2.coralogix.com:443",

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ $ export CORALOGIX_DOMAIN="<add the environment you want to work at>"
 |---------|-------|---------------------|
 | APAC1   | AP1   | coralogix.in        |
 | APAC2   | AP2   | coralogixsg.com     |
+| APAC3   | AP3   | ap3.coralogix.com   |
 | EUROPE1 | EU1   | coralogix.com       |
 | EUROPE2 | EU2   | eu2.coralogix.com   |
 | USA1    | US1   | coralogix.us        |
@@ -94,5 +95,5 @@ For more information on the endpoints, check out [https://coralogix.com/docs/cor
   environment. environment variable 'CORALOGIX_API_KEY' can be defined instead.
 - `domain` (String) The Coralogix domain. Conflict With 'env'. environment variable 'CORALOGIX_DOMAIN' can be defined
   instead.
-- `env` (String) The Coralogix API environment. can be one of ["USA1" "USA2" "APAC1" "APAC2" "EUROPE1" "EUROPE2" "US1" "US2" "AP1" "AP2" "EU1" "EU2"]. environment
+- `env` (String) The Coralogix API environment. can be one of ["USA1" "USA2" "APAC1" "APAC2" "EUROPE1" "EUROPE2" "US1" "US2" "AP1" "AP2" "AP3" "EU1" "EU2"]. environment
   variable 'CORALOGIX_ENV' can be defined instead.


### PR DESCRIPTION
### Description

This feature is to add abbreviated endpoint support for AP3 Jakarta needed for our migration.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

N/A
```

## Release 1.18.8

New Features:

* added abbreviated endpoint for `AP3`.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment