### PR TITLE
Set integration parameters to match terraform plan

### DIFF
--- a/coralogix/data_source_coralogix_integration.go
+++ b/coralogix/data_source_coralogix_integration.go
@@ -97,12 +97,12 @@ func (d *IntegrationDataSource) Read(ctx context.Context, req datasource.ReadReq
 		resp.Diagnostics.Append(diags...)
 		return
 	}
-	data, diags = integrationDetail(getIntegrationResp, keys)
-	if diags.HasError() {
+	state, e := integrationDetail(getIntegrationResp, keys)
+	if e.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
 	// Set state to fully populated data
-	diags = resp.State.Set(ctx, &data)
+	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 }

--- a/coralogix/resource_coralogix_integration.go
+++ b/coralogix/resource_coralogix_integration.go
@@ -185,6 +185,7 @@ func (r *IntegrationResource) Create(ctx context.Context, req resource.CreateReq
 
 	log.Printf("[INFO] Received Integration: %s", protojson.Format(getIntegrationResp))
 	state, e := integrationDetail(getIntegrationResp, keys)
+	state.Parameters = plan.Parameters
 	if e.HasError() {
 		resp.Diagnostics.Append(e...)
 		return
@@ -397,6 +398,7 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 	state, e := integrationDetail(getIntegrationResp, keys)
+	state.Parameters = plan.Parameters
 	if e.HasError() {
 		resp.Diagnostics.Append(e...)
 		return
@@ -460,6 +462,7 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 	log.Printf("[INFO] Received Integration: %s", protojson.Format(getIntegrationResp))
 	state, e := integrationDetail(getIntegrationResp, keys)
+	state.Parameters = plan.Parameters
 	if e.HasError() {
 		resp.Diagnostics.Append(e...)
 		return


### PR DESCRIPTION
### Description
Service account values are not returned from the integrations API. This caused a mismatch between the state file and terraform plan: I solve the issue by setting the integration parameters in the state file to the value they have in the plan.