### PR TITLE
[PLTD-992] Fix eventbridge documentation

### DIFF
--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -200,10 +200,10 @@ Required:
 - `event_bus_arn` (String) Corresponds to the event bus, which will receive notifications. The policy attached must contain permission to publish.
 - `role_name` (String) Corresponds to the AWS IAM role that will be created in your account.
 - `source` (String) Free text is used to identify the messages Coralogix sends.
+- `detail` (String) Stringified json text that is sent to AWS Event bus
 
-Optional:
+Customisation of the `detail` is same as the generic webhook. More details can be found [here](https://coralogix.com/docs/user-guides/alerting/outbound-webhooks/generic-outbound-webhooks-alert-webhooks/#placeholders).
 
-- `detail` (String)
 
 
 <a id="nestedatt--jira"></a>


### PR DESCRIPTION
### Description
Fixing the documentation for the aws-event-bridge webhook and providing more context on how the `detail` field can be enchanced.

### Acceptance tests
No need for acceptance tests

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
Updating webhooks documentation
```

### References


### Community Note
