### PR TITLE
Fix: Trigger update instead of replace when changing scope resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,3 +745,11 @@ Breaking Changes:
 
 Revamped the structure of alerts in general. Please consult the guide v1-v2-migration-guide on how to migrate.
 
+# Release 2.0.1
+### resource/coralogix_slo
+* Various SLO fixes
+
+
+# Release 2.0.2
+### resource/coralogix_scope
+* Update scopes in place instead of creating new ones on update

--- a/coralogix/resource_coralogix_scope.go
+++ b/coralogix/resource_coralogix_scope.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"terraform-provider-coralogix/coralogix/clientset"
 
@@ -105,7 +106,7 @@ func (r *ScopeResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: "Associated team.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"filters": schema.ListNestedAttribute{
@@ -232,6 +233,7 @@ func flattenScope(resp *cxsdk.GetScopesResponse) []ScopeResourceModel {
 			DisplayName:       types.StringValue(scope.GetDisplayName()),
 			Description:       description,
 			DefaultExpression: types.StringValue(scope.GetDefaultExpression()),
+			TeamId:            types.StringValue(strconv.Itoa(int(scope.GetTeamId()))),
 			Filters:           flattenScopeFilters(scope.GetFilters()),
 		})
 	}
@@ -284,6 +286,7 @@ func (r *ScopeResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	log.Printf("[INFO] Received Scope: %s", protojson.Format(getScopeResp))
 
 	state := flattenScope(getScopeResp)[0]
+
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ provider "coralogix" {
 
 - `api_key` (String, Sensitive) A key for using coralogix APIs (Auto Generated), appropriate for the defined environment. environment variable 'CORALOGIX_API_KEY' can be defined instead.
 - `domain` (String) The Coralogix domain. Conflict With 'env'. environment variable 'CORALOGIX_DOMAIN' can be defined instead.
-- `env` (String) The Coralogix API environment. can be one of ["USA1" "APAC1" "US2" "AP1" "APAC2" "AP3" "EUROPE1" "EU1" "EU2" "US1" "AP2" "APAC3" "EUROPE2" "USA2"]. environment variable 'CORALOGIX_ENV' can be defined instead.# Getting Started
+- `env` (String) The Coralogix API environment. can be one of ["EUROPE1" "APAC1" "AP2" "APAC3" "EU1" "EUROPE2" "USA1" "US2" "AP1" "APAC2" "AP3" "EU2" "US1" "USA2"]. environment variable 'CORALOGIX_ENV' can be defined instead.# Getting Started
 
 Check out our examples for how to configure the various resources offered by the provider. If you already have Coralogix set up and want to import any existing resources, check out our migration script: [https://github.com/coralogix/coralogix-management-sdk/tree/master/tools/terraform-importer]().
 


### PR DESCRIPTION
### Description
Currently, scope resources get destroyed and recreated whenever they're changed. We need them to be updated in place, and this is what this change is about.

