### PR TITLE
fix: added aggregation for spans in line charts

### DIFF
--- a/coralogix/dashboard_widgets/common.go
+++ b/coralogix/dashboard_widgets/common.go
@@ -916,7 +916,11 @@ func FlattenSpansFields(ctx context.Context, spanFields []*cxsdk.SpanField) (typ
 		spanFieldElements = append(spanFieldElements, fieldElement)
 	}
 
-	return types.ListValueMust(types.ObjectType{AttrTypes: SpansFieldModelAttr()}, spanFieldElements), diagnostics
+	if diagnostics.HasError() {
+		return types.ListNull(types.ObjectType{AttrTypes: SpansFieldModelAttr()}), diagnostics
+	}
+
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: SpansFieldModelAttr()}, spanFieldElements)
 }
 
 func FlattenSpansField(field *cxsdk.SpanField) (*SpansFieldModel, diag.Diagnostic) {

--- a/coralogix/resource_coralogix_dashboard_test.go
+++ b/coralogix/resource_coralogix_dashboard_test.go
@@ -195,6 +195,111 @@ func TestAccCoralogixResourceDashboardHexagonWidget(t *testing.T) {
 	})
 }
 
+func TestAccCoralogixResourceDashboardLinechartWidget(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccCoralogixResourceDashboardWithWidget(`{
+            title      = "line-chart"
+            definition = {
+              line_chart = {
+                query_definitions = [{
+                  query = {
+                    spans = {
+                      aggregations = [{
+                        type             = "dimension"
+                        field            = "trace_id"
+                        aggregation_type = "unique_count"
+                      }]
+                      filters = [{
+                        field = {
+                          type  = "metadata"
+                          value = "operation_name"
+                        }
+                        operator = {
+                          type            = "equals"
+                          selected_values = ["device_status_update"]
+                        }
+                      },
+                      {
+                        field = {
+                          type  = "tag"
+                          value = "deviceStatus"
+                        }
+                        operator = {
+                          type            = "equals"
+                          selected_values = ["CANDYBOX_OFFLINE"]
+                        }
+                      }]
+                      group_by = [{
+                        type  = "tag"
+                        value = "deviceName"
+                      }]
+                    }
+                  }
+                  color_scheme = "classic"
+                  is_visible   = true
+                  scale_type   = "linear"
+                }]
+                legend = {
+                  is_visible     = true
+                  group_by_query = true
+                  placement      = "auto"
+                },
+                tooltip = {
+                  show_labels = false
+                  type        = "all"
+                }
+              }
+            }
+            width = 0
+          }`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.title", "line_chart"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.query.spans.aggregations.0.type", "dimension"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.query.spans.group_by.0.type", "tag"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.query.spans.group_by.0.value", "deviceName"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.query.color_scheme", "classic"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.query.is_visible", "true"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.query.scale_type", "linear"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.legend.is_visible", "true"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.legend.group_by_query", "true"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.legend.placement", "auto"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.tooltip.show_labels", "false"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.tooltip.type", "all"),
+
+					resource.TestCheckTypeSetElemNestedAttrs(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.query.spans.filter.*",
+						map[string]string{
+							"field.type":                 "metadata",
+							"field.value":                "operation_name",
+							"operator.type":              "equals",
+							"operator.selected_values.#": "1",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.query.spans.filter.*",
+						map[string]string{
+							"field.type":                 "tag",
+							"field.value":                "deviceStatus",
+							"operator.type":              "equals",
+							"operator.selected_values.#": "1",
+						},
+					),
+				),
+			},
+			{
+				ResourceName:      dashboardResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCoralogixResourceDashboardFromJson(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment