### PR TITLE
fix: correct alert scheduler filter logic for all alerts and update required attributes schema #349

### DIFF
--- a/coralogix/resource_coralogix_alerts_scheduler.go
+++ b/coralogix/resource_coralogix_alerts_scheduler.go
@@ -219,7 +219,7 @@ func (r *AlertsSchedulerResource) Schema(_ context.Context, _ resource.SchemaReq
 						},
 					},
 				},
-				Optional:            true,
+				Required:            true,
 				MarkdownDescription: "Alert Scheduler filter. Only one of `meta_labels` or `alerts_unique_ids` can be set. If none of them set, all alerts will be affected.",
 			},
 			"schedule": schema.SingleNestedAttribute{
@@ -301,7 +301,7 @@ func (r *AlertsSchedulerResource) Schema(_ context.Context, _ resource.SchemaReq
 						},
 					},
 				},
-				Optional:            true,
+				Required:            true,
 				MarkdownDescription: "Exactly one of `one_time` or `recurring` must be set.",
 			},
 			"enabled": schema.BoolAttribute{
@@ -870,7 +870,14 @@ func extractFilter(ctx context.Context, filter types.Object) (*cxsdk.AlertSchedu
 		}, nil
 	}
 
-	return nil, nil
+	return &cxsdk.AlertSchedulerFilter{
+		WhatExpression: whatExpression,
+		WhichAlerts: &cxsdk.AlertSchedulerFilterUniqueIDs{
+			AlertUniqueIds: &cxsdk.AlertUniqueIDs{
+				Value: nil,
+			},
+		},
+	}, nil
 }
 
 func extractSchedule(ctx context.Context, schedule types.Object) (*cxsdk.Schedule, diag.Diagnostics) {

--- a/coralogix/resource_coralogix_alerts_scheduler_test.go
+++ b/coralogix/resource_coralogix_alerts_scheduler_test.go
@@ -65,6 +65,38 @@ func TestAccCoralogixResourceResourceAlertsScheduler(t *testing.T) {
 	})
 }
 
+func TestAccCoralogixResourceResourceAlertsSchedulerAllAlerts(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		CheckDestroy:             testAccCheckAlertsSchedulerDestroy,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceAlertsSchedulerAllAlerts(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "name", "example"),
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "filter.what_expression", "source logs | filter true"),
+					resource.TestCheckNoResourceAttr(alertsSchedulerResourceName, "filter.alerts_unique_ids"),
+					resource.TestCheckNoResourceAttr(alertsSchedulerResourceName, "filter.meta_labels"),
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "schedule.operation", "active"),
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "schedule.recurring.dynamic.repeat_every", "2"),
+					resource.TestCheckTypeSetElemAttr(alertsSchedulerResourceName, "schedule.recurring.dynamic.frequency.weekly.days.*", "Sunday"),
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "schedule.recurring.dynamic.time_frame.start_time", "2021-01-04T00:00:00.000"),
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "schedule.recurring.dynamic.time_frame.duration.for_over", "2"),
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "schedule.recurring.dynamic.time_frame.duration.frequency", "hours"),
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "schedule.recurring.dynamic.time_frame.time_zone", "UTC+2"),
+					resource.TestCheckResourceAttr(alertsSchedulerResourceName, "schedule.recurring.dynamic.termination_date", "2025-01-01T00:00:00.000"),
+				),
+			},
+			{
+				ResourceName:      alertsSchedulerResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAlertsSchedulerDestroy(s *terraform.State) error {
 	testAccProvider = OldProvider()
 	rc := terraform2.ResourceConfig{}
@@ -104,6 +136,39 @@ func testAccCoralogixResourceAlertsScheduler() string {
         value = "value"
       }
     ]
+  }
+  schedule = {
+    operation = "active"
+    recurring = {
+      dynamic = {
+        repeat_every = 2
+        frequency = {
+          weekly = {
+            days = ["Sunday"]
+          }
+        }
+        time_frame = {
+          start_time = "2021-01-04T00:00:00.000"
+          duration = {
+            for_over = 2
+            frequency = "hours"
+          }
+          time_zone = "UTC+2"
+        }
+        termination_date = "2025-01-01T00:00:00.000"
+      }
+    }
+  }
+}
+`
+}
+
+func testAccCoralogixResourceAlertsSchedulerAllAlerts() string {
+	return `resource "coralogix_alerts_scheduler" "test" {
+  name        = "example"
+  description = "example"
+  filter      = {
+    what_expression = "source logs | filter true"
   }
   schedule = {
     operation = "active"

--- a/docs/resources/alerts_scheduler.md
+++ b/docs/resources/alerts_scheduler.md
@@ -88,15 +88,15 @@ resource "coralogix_alerts_scheduler" "example_2" {
 
 ### Required
 
+- `filter` (Attributes) Alert Scheduler filter. Only one of `meta_labels` or `alerts_unique_ids` can be set. If none of them set, all alerts will be affected. (see [below for nested schema](#nestedatt--filter))
 - `name` (String) Alert Scheduler name.
+- `schedule` (Attributes) Exactly one of `one_time` or `recurring` must be set. (see [below for nested schema](#nestedatt--schedule))
 
 ### Optional
 
 - `description` (String) Alert Scheduler description.
 - `enabled` (Boolean) Alert Scheduler enabled. If set to `false`, the alert scheduler will be disabled. True by default.
-- `filter` (Attributes) Alert Scheduler filter. Only one of `meta_labels` or `alerts_unique_ids` can be set. If none of them set, all alerts will be affected. (see [below for nested schema](#nestedatt--filter))
 - `meta_labels` (Attributes Set) Alert Scheduler meta labels. (see [below for nested schema](#nestedatt--meta_labels))
-- `schedule` (Attributes) Exactly one of `one_time` or `recurring` must be set. (see [below for nested schema](#nestedatt--schedule))
 
 ### Read-Only
 
@@ -125,18 +125,6 @@ Optional:
 
 - `value` (String)
 
-
-
-<a id="nestedatt--meta_labels"></a>
-### Nested Schema for `meta_labels`
-
-Required:
-
-- `key` (String)
-
-Optional:
-
-- `value` (String)
 
 
 <a id="nestedatt--schedule"></a>
@@ -252,3 +240,19 @@ Required:
 
 - `for_over` (Number) The number of time units to wait before the alert is triggered. For example, if the frequency is set to `hours` and the value is set to `2`, the alert will be triggered after 2 hours.
 - `frequency` (String) The time unit to wait before the alert is triggered. Can be `minutes`, `hours` or `days`.
+
+
+
+
+
+
+<a id="nestedatt--meta_labels"></a>
+### Nested Schema for `meta_labels`
+
+Required:
+
+- `key` (String)
+
+Optional:
+
+- `value` (String)


### PR DESCRIPTION
fix: correct alert scheduler filter logic for all alerts and update required attributes schema #349

When the filter expression doesn't contain `alerts_unique_ids` and `meta_labels` it should then affect all alerts. Validate the required attributes expected by the API at the schema level to capture errors during terraform plan stage.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceResourceAlertsScheduler'
TF_ACC=1 go test -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn" $(go list ./... | grep -v 'vendor') -v -run=TestAccCoralogixResourceResourceAlertsScheduler -timeout 120m
?       terraform-provider-coralogix    [no test files]
?       terraform-provider-coralogix/coralogix/clientset        [no test files]
?       terraform-provider-coralogix/coralogix/clientset/rest   [no test files]
?       terraform-provider-coralogix/coralogix/dashboard_widgets        [no test files]
?       terraform-provider-coralogix/coralogix/utils    [no test files]
=== RUN   TestAccCoralogixResourceResourceAlertsScheduler
--- PASS: TestAccCoralogixResourceResourceAlertsScheduler (3.43s)
=== RUN   TestAccCoralogixResourceResourceAlertsSchedulerAllAlerts
--- PASS: TestAccCoralogixResourceResourceAlertsSchedulerAllAlerts (2.91s)
PASS
ok      terraform-provider-coralogix/coralogix  7.379s
...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment