### PR TITLE
[nc]fix preset example

### DIFF
--- a/coralogix/resource_coralogix_global_router_test.go
+++ b/coralogix/resource_coralogix_global_router_test.go
@@ -241,7 +241,7 @@ func testAccResourceCoralogixGlobalRouter() string {
               },
               {
                 field_name = "timestamp"
-                template   = "{{ alertDef.timestamp }}"
+                template   = "{{ alert.timestamp }}"
               }
             ]
           }
@@ -434,7 +434,7 @@ func testAccResourceCoralogixGlobalRouterUpdate() string {
               },
               {
                 field_name = "timestamp"
-                template   = "{{ alertDef.timestamp }}"
+                template   = "{{ alert.timestamp }}"
               }
             ]
           }

--- a/coralogix/resource_coralogix_preset_test.go
+++ b/coralogix/resource_coralogix_preset_test.go
@@ -388,7 +388,7 @@ func testAccResourceCoralogixPagerdutyPreset() string {
               },
               {
                 field_name = "timestamp"
-                template   = "{{ alertDef.timestamp }}"
+                template   = "{{ alert.timestamp }}"
               }
             ]
           }
@@ -436,7 +436,7 @@ func testAccResourceCoralogixPagerdutyPresetUpdate() string {
               },
               {
                 field_name = "timestamp"
-                template   = "{{ alertDef.timestamp }}"
+                template   = "{{ alert.timestamp }}"
               }
             ]
           }

--- a/docs/resources/preset.md
+++ b/docs/resources/preset.md
@@ -110,7 +110,7 @@ resource "coralogix_preset" "pagerduty_example" {
           },
           {
             field_name = "timestamp"
-            template   = "{{ alertDef.timestamp }}"
+            template   = "{{ alert.timestamp }}"
           }
         ]
       }

--- a/examples/resources/coralogix_notification_center/resource.tf
+++ b/examples/resources/coralogix_notification_center/resource.tf
@@ -254,7 +254,7 @@ resource "coralogix_preset" "pagerduty_example" {
           },
           {
             field_name = "timestamp"
-            template   = "{{ alertDef.timestamp }}"
+            template   = "{{ alert.timestamp }}"
           }
         ]
       }

--- a/examples/resources/coralogix_preset/resource.tf
+++ b/examples/resources/coralogix_preset/resource.tf
@@ -95,7 +95,7 @@ resource "coralogix_preset" "pagerduty_example" {
           },
           {
             field_name = "timestamp"
-            template   = "{{ alertDef.timestamp }}"
+            template   = "{{ alert.timestamp }}"
           }
         ]
       }


### PR DESCRIPTION
### Description

Fixing preset example to rely on the `alert.timestamp` instead of the `alertDef.timestamp` since `alertDef` doesn't have `timestamp` field
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment