### PR TITLE
Fix: AlertType conversion bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -970,3 +970,8 @@ Feature:
 
 Feature:
 * Import by `name` is now available
+
+## resource/coralogix_alert
+
+Fix:
+* fixing type conversion for `alert_type` using `foreach`

--- a/coralogix/resource_coralogix_alert.go
+++ b/coralogix/resource_coralogix_alert.go
@@ -1528,14 +1528,24 @@ func (g GroupByValidator) ValidateList(ctx context.Context, request validator.Li
 		response.Diagnostics.Append(diags...)
 		return
 	}
-	var typeDefinition AlertTypeDefinitionModel
+	var typeDefinition types.Object
 	diags = request.Config.GetAttribute(ctx, paths[0], &typeDefinition)
 	if diags.HasError() {
 		response.Diagnostics.Append(diags...)
 		return
 	}
 
-	if !utils.ObjIsNullOrUnknown(typeDefinition.LogsImmediate) || !utils.ObjIsNullOrUnknown(typeDefinition.LogsNewValue) || !utils.ObjIsNullOrUnknown(typeDefinition.TracingImmediate) {
+	if typeDefinition.IsNull() || typeDefinition.IsUnknown() {
+		return
+	}
+
+	var typeDefinitionModel AlertTypeDefinitionModel
+	if diags = typeDefinition.As(ctx, &typeDefinitionModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+		response.Diagnostics.Append(diags...)
+		return
+	}
+
+	if !utils.ObjIsNullOrUnknown(typeDefinitionModel.LogsImmediate) || !utils.ObjIsNullOrUnknown(typeDefinitionModel.LogsNewValue) || !utils.ObjIsNullOrUnknown(typeDefinitionModel.TracingImmediate) {
 		if !(request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown()) {
 			response.Diagnostics.AddError("group_by", "Group by is not allowed for logs_immediate, logs_new_value, tracing_immediate alert types.")
 		}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment