### PR TITLE
IAC-809: fix errors during the dashboard apply

### DIFF
--- a/coralogix/resource_coralogix_dashboard.go
+++ b/coralogix/resource_coralogix_dashboard.go
@@ -6093,7 +6093,7 @@ func flattenMultiSelectQueryMetricsQueryOperatorSelectedValues(ctx context.Conte
 			diagnostics.Append(diags...)
 			continue
 		}
-		valuesElement, diags := types.ObjectValueFrom(ctx, multiSelectQueryMetricsQueryMetricsLabelFilterOperatorAttr(), flattenedValue)
+		valuesElement, diags := types.ObjectValueFrom(ctx, multiSelectQueryStringOrValueAttr(), flattenedValue)
 		if diags.HasError() {
 			diagnostics.Append(diags...)
 			continue
@@ -6102,10 +6102,10 @@ func flattenMultiSelectQueryMetricsQueryOperatorSelectedValues(ctx context.Conte
 	}
 
 	if diagnostics.HasError() {
-		return types.ListNull(types.ObjectType{AttrTypes: multiSelectQueryMetricsQueryMetricsLabelFilterOperatorAttr()}), diagnostics
+		return types.ListNull(types.ObjectType{AttrTypes: multiSelectQueryStringOrValueAttr()}), diagnostics
 	}
 
-	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: multiSelectQueryMetricsQueryMetricsLabelFilterOperatorAttr()}, flattenedValues)
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: multiSelectQueryStringOrValueAttr()}, flattenedValues)
 }
 
 func flattenMultiSelectQueryMetricsQueryStringOrVariable(ctx context.Context, stringOrVariable *cxsdk.MultiSelectQueryMetricsQueryStringOrVariable) (types.Object, diag.Diagnostics) {

--- a/coralogix/resource_coralogix_dashboard.go
+++ b/coralogix/resource_coralogix_dashboard.go
@@ -4911,7 +4911,7 @@ func flattenDataTableMetricsQuery(ctx context.Context, metrics *cxsdk.DashboardD
 
 	return &dashboardwidgets.DataTableQueryModel{
 		Metrics: &dashboardwidgets.QueryMetricsModel{
-			PromqlQueryType: types.StringValue(metrics.GetPromqlQueryType().String()),
+			PromqlQueryType: types.StringValue(dashboardwidgets.DashboardProtoToSchemaPromQLQueryType[metrics.GetPromqlQueryType()]),
 			PromqlQuery:     utils.WrapperspbStringToTypeString(metrics.GetPromqlQuery().GetValue()),
 			Filters:         filters,
 			TimeFrame:       timeFrame,


### PR DESCRIPTION
### Description

This will fix 2 errors which occur when applying a `coralogix_dashboard` resource.

The original error, posted in IAC-809:

```
│ Error: Value Conversion Error
│
│ An unexpected error was encountered while verifying an attribute value matched its expected type to
│ prevent unexpected behavior or panics. This is always an error in the provider. Please report the
│ following to the provider developer:
│
│ Expected framework type from provider logic:
│ types.ObjectType["selected_values":types.ListType[types.ObjectType["string_value":basetypes.StringType,
│ "variable_name":basetypes.StringType]], "type":basetypes.StringType] / underlying type:
│ tftypes.Object["selected_values":tftypes.List[tftypes.Object["string_value":tftypes.String,
│ "variable_name":tftypes.String]], "type":tftypes.String]
│ Received framework type from provider logic: types.ObjectType["string_value":basetypes.StringType,
│ "variable_name":basetypes.StringType] / underlying type:
│ tftypes.Object["string_value":tftypes.String, "variable_name":tftypes.String]
│ Path:
```

And the other error found during the troubleshooting of the original issue:

```
2025-06-23T14:26:33.332+0200 [ERROR] vertex "coralogix_dashboard.global_adapter_dashboard_tf" error: Provider produced inconsistent result after apply
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to coralogix_dashboard.global_adapter_dashboard_tf,
│ provider "provider[\"locally/debug/coralogix\"]" produced an unexpected new
│ value:
│ .layout.sections[0].rows[0].widgets[0].definition.data_table.query.metrics.promql_query_type:
│ was cty.StringVal("unspecified"), but now
│ cty.StringVal("PROM_QL_QUERY_TYPE_UNSPECIFIED").
│ 
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
╵
```

after those tests, the provider should run without issues.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment