### PR TITLE
fix: JSON import won't fail on unknown keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -987,6 +987,9 @@ Feature:
 * gauge now has the "decimal" and "display series name" properties
 * Stacked line is now available in line charts
 
+Fix: 
+* JSON import won't fail on unknown keys
+
 ## data_source/coralogix_dashboard_folder
 
 Feature:

--- a/coralogix/resource_coralogix_dashboard.go
+++ b/coralogix/resource_coralogix_dashboard.go
@@ -3431,13 +3431,18 @@ func flattenDashboard(ctx context.Context, plan DashboardResourceModel, dashboar
 		var unmarshalledDashboard = new(cxsdk.Dashboard)
 		// Users can set the folder in the dashbaord's json. In that case, the server will return a folder, but we're not supposed to set it in the plan,
 		// or terraform will panic.
-		err := protojson.Unmarshal([]byte(plan.ContentJson.ValueString()), unmarshalledDashboard)
+		unmarshaller := protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+			AllowPartial:   true,
+		}
+		err := unmarshaller.Unmarshal([]byte(plan.ContentJson.ValueString()), unmarshalledDashboard)
 		if err != nil {
 			return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error Unmarshal Dashboard", err.Error())}
 		}
 		if unmarshalledDashboard.GetFolder() != nil {
 			folder = types.ObjectNull(dashboardFolderModelAttr())
 		}
+
 		_, err = protojson.Marshal(dashboard)
 		if err != nil {
 			return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error Flatten Dashboard", err.Error())}

--- a/examples/resources/coralogix_dashboard/dashboard.json
+++ b/examples/resources/coralogix_dashboard/dashboard.json
@@ -1,6 +1,7 @@
 {
   "name": "OpenTelemetry Collector Dashboard",
   "description": "Gives insights into your Collector stats.",
+  "unknownKey": "should-not-fail",
   "layout": {
     "sections": [
       {


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment