### PR TITLE
Setting the rule's priority to the alert's priority if not set (P5 by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1001,6 +1001,7 @@ Feature:
 
 Fix:
 * fixing type conversion for `alert_type` using `foreach`
+* setting the rule's priority to the alert's priority if not set.
 
 ## resource/coralogix_team
 

--- a/coralogix/resource_coralogix_alert.go
+++ b/coralogix/resource_coralogix_alert.go
@@ -1681,7 +1681,9 @@ func (c PriorityOverrideFallback) PlanModifyString(ctx context.Context, req plan
 	}
 
 	// Only change if there are changes to the top level priority
-	if !configPriority.Equal(StatePriority) {
+	if configPriority.IsNull() {
+		resp.PlanValue = types.StringValue("P5")
+	} else if !configPriority.Equal(StatePriority) || req.ConfigValue.IsNull() {
 		resp.PlanValue = configPriority
 	}
 }

--- a/coralogix/resource_coralogix_alert.go
+++ b/coralogix/resource_coralogix_alert.go
@@ -1666,25 +1666,21 @@ func (c PriorityOverrideFallback) MarkdownDescription(ctx context.Context) strin
 
 func (c PriorityOverrideFallback) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	// if a priority override is provided, do nothing
-	if !(req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown()) {
+	if !req.ConfigValue.IsNull() {
 		return
 	}
 
-	var configPriority, StatePriority types.String
-	if diags := req.Config.GetAttribute(ctx, path.Root("priority"), &configPriority); diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-	if diags := req.State.GetAttribute(ctx, path.Root("priority"), &StatePriority); diags.HasError() {
+	var topLevelPriorityConfig types.String
+	if diags := req.Config.GetAttribute(ctx, path.Root("priority"), &topLevelPriorityConfig); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
 
-	// Only change if there are changes to the top level priority
-	if configPriority.IsNull() {
+	// if the top level priority and the override priority are both null, set the plan value to "P5". If the top level priority is not null, use that value for the override priority
+	if topLevelPriorityConfig.IsNull() {
 		resp.PlanValue = types.StringValue("P5")
-	} else if !configPriority.Equal(StatePriority) || req.ConfigValue.IsNull() {
-		resp.PlanValue = configPriority
+	} else {
+		resp.PlanValue = topLevelPriorityConfig
 	}
 }
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment