### PR TITLE
Fix again the "none" gauge label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1028,3 +1028,10 @@ Docs:
 Fix: 
 
 * Incorrect mapping for gauge widget units in dashboards 
+
+# Release 2.1.2
+
+## resource/coralogix_dashboard
+
+Fix: 
+* Incorrect mapping for gauge widget units in dashboards, actually

--- a/coralogix/clientset/version.go
+++ b/coralogix/clientset/version.go
@@ -14,4 +14,4 @@
 
 package clientset
 
-const TF_PROVIDER_VERSION = "2.1.1"
+const TF_PROVIDER_VERSION = "2.1.2"

--- a/coralogix/dashboard_widgets/common.go
+++ b/coralogix/dashboard_widgets/common.go
@@ -119,7 +119,7 @@ var (
 
 	DashboardSchemaToProtoGaugeUnit = map[string]cxsdk.GaugeUnit{
 		UNSPECIFIED:    cxsdk.GaugeUnitUnspecified,
-		"none":         cxsdk.GaugeUnitUnspecified,
+		"none":         cxsdk.GaugeUnitNumber,
 		"percent":      cxsdk.GaugeUnitPercent,
 		"microseconds": cxsdk.GaugeUnitMicroseconds,
 		"milliseconds": cxsdk.GaugeUnitMilliseconds,


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment