### PR TITLE
docs: Add GlobalRouter info

### DIFF
--- a/coralogix/resource_coralogix_global_router.go
+++ b/coralogix/resource_coralogix_global_router.go
@@ -108,11 +108,11 @@ func (r *GlobalRouterResource) Schema(_ context.Context, _ resource.SchemaReques
 			"id": schema.StringAttribute{
 				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
-				Description:   "The ID of the GlobalRouter.",
+				Description:   "The ID of the GlobalRouter",
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
-				Description: "Name of the GlobalRouter.",
+				Description: "Name of the GlobalRouter. Set \"router_default\" for picking the default router.",
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,

--- a/docs/data-sources/global_router.md
+++ b/docs/data-sources/global_router.md
@@ -27,8 +27,8 @@ data "coralogix_global_router" "example_data_by_name" {
 
 ### Optional
 
-- `id` (String) The ID of the GlobalRouter.
-- `name` (String) Name of the GlobalRouter.
+- `id` (String) The ID of the GlobalRouter
+- `name` (String) Name of the GlobalRouter. Set "router_default" for picking the default router.
 
 ### Read-Only
 

--- a/docs/guides/notification-center.md
+++ b/docs/guides/notification-center.md
@@ -28,6 +28,7 @@ Just like connectors, presets are tailored for specific platforms like Slack, Pa
 ### Global Router
 Determines how alerts are routed to specific connectors and presets. 
 A Global Router evaluates routing rules based on alert conditions and matches them to appropriate notification targets.
+The default Global Router is called `router_default`, if you name your resource like this, and `terraform apply`, you can simply overtake it instead of having to `terraform import`.
 
 ### Alerts
 There are two ways to configure notification behavior in an alert:

--- a/docs/resources/global_router.md
+++ b/docs/resources/global_router.md
@@ -18,7 +18,7 @@ Coralogix GlobalRouter. **Note:** This resource is in alpha stage.
 ### Required
 
 - `entity_type` (String) Type of the entity. Valid values are: alerts, unspecified
-- `name` (String) Name of the GlobalRouter.
+- `name` (String) Name of the GlobalRouter. Set "router_default" for picking the default router.
 
 ### Optional
 
@@ -29,7 +29,7 @@ Coralogix GlobalRouter. **Note:** This resource is in alpha stage.
 
 ### Read-Only
 
-- `id` (String) The ID of the GlobalRouter.
+- `id` (String) The ID of the GlobalRouter
 
 <a id="nestedatt--fallback"></a>
 ### Nested Schema for `fallback`


### PR DESCRIPTION
### Description
After some issues with implementing GlobalRouter, I decided to add info in the docs, that helped me to workaround.

After applying global router over and over, I couldn't see my rules in `https://<my-place>.coralogix.com/#/notification-center/routers/router_default`, when it hit me: this last URL's piece is the resource ID, what I am creating doesn't match what UI shows me. Coralogix UI led me to `router_default`'s page instead to the page of the router I had created.

As my rule setup is simple enough, I decided to import the GlobalRouter to code and place my rules there, but I found no documentation on how to import this resource. Then I simply tried to apply with the same name I was seeing in my browser. It succeeded and suddenly my rules were listed 🥳 

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment