### PR TITLE
Update NC guide with proper routing labels in example

### DIFF
--- a/docs/guides/notification-center.md
+++ b/docs/guides/notification-center.md
@@ -174,7 +174,7 @@ resource "coralogix_alert" "example_with_router" {
   
   labels = {
     "alert_type" = "security"
-    "routing.group" = "teamA" # Routing label to match global routers.
+    "routing.team" = "teamA" # Routing label to match global routers.
     "routing.environment" = "production" # Routing label to match global routers.
   }
   


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

This PR fixes the Notification Center documentation example by updating `routing.group` to `routing.team` since we migrated to use the latter in NC.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
docs: Update NC example code to use proper routing labels
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment