### PR TITLE
Update alerts-scheduler docs to mention suppression rules

### DIFF
--- a/docs/data-sources/alerts_scheduler.md
+++ b/docs/data-sources/alerts_scheduler.md
@@ -8,7 +8,7 @@ description: |-
 
 # coralogix_alerts_scheduler (Data Source)
 
-Coralogix alerts-scheduler.
+Coralogix alerts-scheduler; also known as Coralogix alert suppression rules.
 
 
 

--- a/docs/resources/alerts_scheduler.md
+++ b/docs/resources/alerts_scheduler.md
@@ -8,7 +8,7 @@ description: |-
 
 # coralogix_alerts_scheduler (Resource)
 
-Coralogix alerts-scheduler.
+Coralogix alerts-scheduler; also known as Coralogix alert suppression rules.
 
 ## Example Usage
 


### PR DESCRIPTION
### Description

A user coming from the UI to Terraform will search for how to use Terraform to create a suppression Rule in coralogix, and not necessarily notice that an alerts-scheduler is exactly this.

This change hopes to disambiguate the docs so anyone coming here will know this creates what the UI will call a Suppression Rule, but also mean that a google search for "Terraform Coralogix Suppression Rule" will bring them to this page.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

No, this is purely a documentation change

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
NONE
```

### References

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment