### PR TITLE
feat: support dataprime queries for dashboards

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.3-0.20260201103411-420a674b4871
+	github.com/coralogix/coralogix-management-sdk v1.9.3
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.3-0.20260201103411-420a674b4871 h1:RlpYVEQ9b+EPZV56FOHp6syDuNa/ecFmMON0cae5n8w=
-github.com/coralogix/coralogix-management-sdk v1.9.3-0.20260201103411-420a674b4871/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.3 h1:Abxqic70WwQy3LMEvxwSZE4dCu4lzbEneAJdwzVh3u0=
+github.com/coralogix/coralogix-management-sdk v1.9.3/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -1643,6 +1643,16 @@ func expandGaugeQuery(ctx context.Context, gaugeQuery *dashboardwidgets.GaugeQue
 				Spans: spanQuery,
 			},
 		}, nil
+	case gaugeQuery.DataPrime != nil:
+		dataprimeQuery, diags := expandGaugeQueryDataPrime(ctx, gaugeQuery.DataPrime)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &cxsdk.GaugeQuery{
+			Value: &cxsdk.GaugeQueryDataprime{
+				Dataprime: dataprimeQuery,
+			},
+		}, nil
 	default:
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Extract Gauge Query Error", fmt.Sprintf("Unknown gauge query type %#v", gaugeQuery))}
 	}
@@ -1672,6 +1682,28 @@ func expandGaugeQuerySpans(ctx context.Context, gaugeQuerySpans *dashboardwidget
 		SpansAggregation: spansAggregation,
 		Filters:          filters,
 		TimeFrame:        timeFrame,
+	}, nil
+}
+
+func expandGaugeQueryDataPrime(ctx context.Context, dataPrime *dashboardwidgets.DataPrimeModel) (*cxsdk.GaugeDataprimeQuery, diag.Diagnostics) {
+	if dataPrime == nil {
+		return nil, nil
+	}
+	filters, diags := dashboardwidgets.ExpandDashboardFiltersSources(ctx, dataPrime.Filters)
+	if diags.HasError() {
+		return nil, diags
+	}
+	timeFrame, diags := dashboardwidgets.ExpandTimeFrameSelect(ctx, dataPrime.TimeFrame)
+	if diags.HasError() {
+		return nil, diags
+	}
+	dataprimeQuery := &cxsdk.DashboardDataprimeQuery{
+		Text: dataPrime.Query.ValueString(),
+	}
+	return &cxsdk.GaugeDataprimeQuery{
+		DataprimeQuery: dataprimeQuery,
+		Filters:        filters,
+		TimeFrame:      timeFrame,
 	}, nil
 }
 
@@ -4342,6 +4374,8 @@ func flattenGaugeQueries(ctx context.Context, query *cxsdk.GaugeQuery) (*dashboa
 		return flattenGaugeQueryLogs(ctx, query.GetLogs())
 	case *cxsdk.GaugeQuerySpans:
 		return flattenGaugeQuerySpans(ctx, query.GetSpans())
+	case *cxsdk.GaugeQueryDataprime:
+		return flattenGaugeQueryDataPrime(ctx, query.GetDataprime())
 	default:
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error Flatten Gauge Query", fmt.Sprintf("unknown query type %T", query))}
 	}
@@ -4426,6 +4460,31 @@ func flattenGaugeQuerySpans(ctx context.Context, spans *cxsdk.GaugeSpansQuery) (
 			Filters:          filters,
 			SpansAggregation: spansAggregation,
 			TimeFrame:        timeFrame,
+		},
+	}, nil
+}
+
+func flattenGaugeQueryDataPrime(ctx context.Context, dataPrime *cxsdk.GaugeDataprimeQuery) (*dashboardwidgets.GaugeQueryModel, diag.Diagnostics) {
+	if dataPrime == nil {
+		return nil, nil
+	}
+	queryStr := types.StringNull()
+	if dataPrime.GetDataprimeQuery() != nil {
+		queryStr = types.StringValue(dataPrime.GetDataprimeQuery().GetText())
+	}
+	filters, diags := dashboardwidgets.FlattenDashboardFiltersSources(ctx, dataPrime.GetFilters())
+	if diags.HasError() {
+		return nil, diags
+	}
+	timeFrame, diags := dashboardwidgets.FlattenTimeFrameSelect(ctx, dataPrime.GetTimeFrame())
+	if diags.HasError() {
+		return nil, diags
+	}
+	return &dashboardwidgets.GaugeQueryModel{
+		DataPrime: &dashboardwidgets.DataPrimeModel{
+			Query:     queryStr,
+			Filters:   filters,
+			TimeFrame: timeFrame,
 		},
 	}, nil
 }

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -382,7 +382,34 @@ func TestAccCoralogixResourceDashboardGaugeWidgetDataPrime(t *testing.T) {
 		CheckDestroy:             testAccCheckDashboardDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoralogixResourceDashboardGaugeWidgetDataPrimeConfig(),
+				Config: testAccCoralogixResourceDashboardWithWidget(`{
+  title = "gauge_dataprime"
+  definition = {
+    gauge = {
+      query = {
+        data_prime = {
+          query = <<-EOT
+source logs
+| filter 1 == 1
+| aggregate count() as c
+| choose c
+EOT
+        }
+      }
+      min            = 0
+      max            = 100
+      show_inner_arc = true
+      show_outer_arc = true
+      unit           = "percent100"
+      data_mode_type = "archive"
+      threshold_by   = "value"
+      thresholds = [{
+        from  = 0
+        color = "green"
+      }]
+    }
+  }
+}`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.title", "gauge_dataprime"),
@@ -815,54 +842,6 @@ layout = {
 }
 }
 `, widget)
-}
-
-func testAccCoralogixResourceDashboardGaugeWidgetDataPrimeConfig() string {
-	return `resource "coralogix_dashboard" test {
-  name        = "test-gauge-dataprime"
-  description = "Acceptance test for gauge widget with DataPrime query"
-  time_frame = {
-    relative = {
-      duration = "seconds:900"
-    }
-  }
-  layout = {
-    sections = [{
-      rows = [{
-        height = 19
-        widgets = [{
-          title = "gauge_dataprime"
-          definition = {
-            gauge = {
-              query = {
-                data_prime = {
-                  query = <<-EOT
-source logs
-| filter 1 == 1
-| aggregate count() as c
-| choose c
-EOT
-                }
-              }
-              min            = 0
-              max            = 100
-              show_inner_arc = true
-              show_outer_arc = true
-              unit           = "percent100"
-              data_mode_type = "archive"
-              threshold_by   = "value"
-              thresholds = [{
-                from  = 0
-                color = "green"
-              }]
-            }
-          }
-        }]
-      }]
-    }]
-  }
-}
-`
 }
 
 func TestAccCoralogixResourceDashboardLayoutColor(t *testing.T) {

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	terraform2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -508,7 +509,14 @@ func TestAccCoralogixResourceDashboardFromJsonWithVar(t *testing.T) {
 }
 
 func testAccCheckDashboardDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*clientset.ClientSet).Dashboards()
+	// Configure the SDK provider so Meta() is set (ProtoV6 tests don't configure testAccProvider).
+	rc := terraform2.ResourceConfig{}
+	_ = testAccProvider.Configure(context.Background(), &rc)
+	meta := testAccProvider.Meta()
+	if meta == nil {
+		return nil
+	}
+	client := meta.(*clientset.ClientSet).Dashboards()
 
 	ctx := context.TODO()
 

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -374,6 +374,33 @@ func TestAccCoralogixResourceDashboardGaugeWidget(t *testing.T) {
 	})
 }
 
+func TestAccCoralogixResourceDashboardGaugeWidgetDataPrime(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceDashboardGaugeWidgetDataPrimeConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.title", "gauge_dataprime"),
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.query.data_prime.query"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.min", "0"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.max", "100"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.unit", "percent100"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.data_mode_type", "archive"),
+				),
+			},
+			{
+				ResourceName:      dashboardResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCoralogixResourceDashboardDataTableWidget(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -780,6 +807,54 @@ layout = {
 }
 }
 `, widget)
+}
+
+func testAccCoralogixResourceDashboardGaugeWidgetDataPrimeConfig() string {
+	return `resource "coralogix_dashboard" test {
+  name        = "test-gauge-dataprime"
+  description = "Acceptance test for gauge widget with DataPrime query"
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+  layout = {
+    sections = [{
+      rows = [{
+        height = 19
+        widgets = [{
+          title = "gauge_dataprime"
+          definition = {
+            gauge = {
+              query = {
+                data_prime = {
+                  query = <<-EOT
+source logs
+| filter 1 == 1
+| aggregate count() as c
+| choose c
+EOT
+                }
+              }
+              min            = 0
+              max            = 100
+              show_inner_arc = true
+              show_outer_arc = true
+              unit           = "percent100"
+              data_mode_type = "archive"
+              threshold_by   = "value"
+              thresholds = [{
+                from  = 0
+                color = "green"
+              }]
+            }
+          }
+        }]
+      }]
+    }]
+  }
+}
+`
 }
 
 func TestAccCoralogixResourceDashboardLayoutColor(t *testing.T) {


### PR DESCRIPTION
### Description

This will solve CDS-2798 and PIPEV2-3566 by adding an option to include DataPrime queries to `coralogix_dashboard`. Aims to solve this error:

```
Error: Extract Gauge Query Error
│
│ with module.workflow_monitoring["sendgrid.json"].coralogix_dashboard.workflow_monitoring[0],
│ on ../../modules/workflow_monitoring/dashboard.tf line 32, in resource "coralogix_dashboard" "workflow_monitoring":
│ 32: resource "coralogix_dashboard" "workflow_monitoring" {
│
│ Unknown gauge query type &dashboard_widgets.GaugeQueryModel{Logs:(*dashboard_widgets.GaugeQueryLogsModel)(nil),
│ Metrics:(*dashboard_widgets.GaugeQueryMetricsModel)(nil), Spans:(*dashboard_widgets.GaugeQuerySpansModel)(nil),
│ DataPrime:(*dashboard_widgets.DataPrimeModel)(0x14000409180)}
╵
```

Merge only after https://github.com/coralogix/coralogix-management-sdk/pull/611 (SDK part), also re-run the provider build after it gets merged. 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
# old test for widgets in general

TF_ACC=1 go test -v -timeout 120m ./internal/provider/ -run TestAccCoralogixResourceDashboardGaugeWidget
=== RUN   TestAccCoralogixResourceDashboardGaugeWidget
--- PASS: TestAccCoralogixResourceDashboardGaugeWidget (12.24s)
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider 13.097s

# new test for dataprime widgets

TF_ACC=1 go test -v -timeout 120m ./internal/provider/ -run TestAccCoralogixResourceD
ashboardGaugeWidgetDataPrime

=== RUN   TestAccCoralogixResourceDashboardGaugeWidgetDataPrime
--- PASS: TestAccCoralogixResourceDashboardGaugeWidgetDataPrime (12.21s)
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider 13.029s
```

### Release Note


```
Features:

#### resource/coralogix_dashboard

Dashboard – Gauge + DataPrime: Gauge widgets can now use DataPrime queries in the `coralogix_dashboard` layout. Previously only Metrics, Logs, and Spans were supported for gauge queries; you can set `query.data_prime.query` (and optional filters / time_frame) to define a gauge from a DataPrime query.
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment