### PR TITLE
docs(alerts_scheduler): clarify what_expression field usage

### DIFF
--- a/docs/data-sources/alerts_scheduler.md
+++ b/docs/data-sources/alerts_scheduler.md
@@ -35,7 +35,7 @@ Read-Only:
 
 - `alerts_unique_ids` (Set of String)
 - `meta_labels` (Attributes Set) (see [below for nested schema](#nestedatt--filter--meta_labels))
-- `what_expression` (String) DataPrime query expression. - [DataPrime query language](https://coralogix.com/docs/dataprime-query-language/).
+- `what_expression` (String) A [DataPrime](https://coralogix.com/docs/dataprime-query-language/) expression that filters which **group-by values** to suppress within the selected alerts. The expression must start with `source logs | filter` (this syntax is required even for metric or tracing alerts - the filtering works on group-by values regardless of alert type). Use `"source logs | filter true"` to suppress all alert activity without filtering specific values. Use `"source logs | filter $d.fieldName == 'value'"` to suppress only when specific group-by values match. This field controls **what triggered values** to suppress, while `alerts_unique_ids` or `meta_labels` control **which alerts** the rule applies to.
 
 <a id="nestedatt--filter--meta_labels"></a>
 ### Nested Schema for `filter.meta_labels`

--- a/docs/resources/alerts_scheduler.md
+++ b/docs/resources/alerts_scheduler.md
@@ -27,56 +27,102 @@ provider "coralogix" {
   #env = "<add the environment you want to work at or add env variable CORALOGIX_ENV>"
 }
 
-resource "coralogix_alerts_scheduler" "example" {
-  name        = "example"
-  description = "example"
+# Example 1: Suppress ALL alert activity for specific alerts (no group-by filtering)
+# Use "source logs | filter true" to suppress all triggered values
+resource "coralogix_alerts_scheduler" "suppress_all" {
+  name        = "Maintenance Window - Suppress All"
+  description = "Suppress all alert activity during maintenance window"
   filter = {
-    what_expression   = "source logs | filter $d.cpodId:string == '122'"
+    what_expression   = "source logs | filter true"
     alerts_unique_ids = ["ed6f3713-d827-49a2-9bb6-a8dba8b8c580"]
   }
   schedule = {
     operation = "mute"
     one_time = {
       time_frame = {
-        start_time = "2021-01-04T00:00:00.000"
-        end_time   = "2025-01-01T00:00:50.000"
+        start_time = "2025-01-04T00:00:00.000"
+        end_time   = "2025-01-04T06:00:00.000"
         time_zone  = "UTC+2"
       }
     }
   }
 }
 
-resource "coralogix_alerts_scheduler" "example_2" {
-  name        = "example"
-  description = "example"
+# Example 2: Suppress only specific group-by values
+# The what_expression filters which triggered values to suppress
+# Note: "source logs" syntax works for ALL alert types (logs, metrics, tracing)
+resource "coralogix_alerts_scheduler" "suppress_specific_values" {
+  name        = "Suppress Test Environment Alerts"
+  description = "Suppress alerts only when environment=test"
   filter = {
-    what_expression = "source logs | filter $d.cpodId:string == '122'"
+    what_expression   = "source logs | filter $d.environment == 'test'"
+    alerts_unique_ids = ["ed6f3713-d827-49a2-9bb6-a8dba8b8c580"]
+  }
+  schedule = {
+    operation = "mute"
+    one_time = {
+      time_frame = {
+        start_time = "2025-01-04T00:00:00.000"
+        end_time   = "2025-01-05T00:00:00.000"
+        time_zone  = "UTC+2"
+      }
+    }
+  }
+}
+
+# Example 3: Suppress with multiple conditions
+# Works with any alert group-by keys including metric labels
+resource "coralogix_alerts_scheduler" "suppress_multiple_conditions" {
+  name        = "Suppress Staging Cluster Alerts"
+  description = "Suppress alerts for staging cluster in us-east region"
+  filter = {
+    what_expression   = "source logs | filter $d.cluster == 'staging' && $d.region == 'us-east-1'"
+    alerts_unique_ids = ["ed6f3713-d827-49a2-9bb6-a8dba8b8c580"]
+  }
+  schedule = {
+    operation = "mute"
+    one_time = {
+      time_frame = {
+        start_time = "2025-01-04T00:00:00.000"
+        end_time   = "2025-01-05T00:00:00.000"
+        time_zone  = "UTC+2"
+      }
+    }
+  }
+}
+
+# Example 4: Recurring suppression with meta_labels selector
+resource "coralogix_alerts_scheduler" "recurring_suppression" {
+  name        = "Weekly Maintenance Window"
+  description = "Suppress alerts every Sunday for maintenance"
+  filter = {
+    what_expression = "source logs | filter true"
     meta_labels = [
       {
-        key   = "key"
-        value = "value"
+        key   = "team"
+        value = "platform"
       }
     ]
   }
   schedule = {
-    operation = "active"
+    operation = "mute"
     recurring = {
       dynamic = {
-        repeat_every = 2
+        repeat_every = 1
         frequency = {
           weekly = {
             days = ["Sunday"]
           }
         }
         time_frame = {
-          start_time = "2021-01-04T00:00:00.000"
+          start_time = "2025-01-05T02:00:00.000"
           duration = {
-            for_over  = 2
+            for_over  = 4
             frequency = "hours"
           }
-          time_zone = "UTC+2"
+          time_zone = "UTC+0"
         }
-        termination_date = "2025-01-01T00:00:00.000"
+        termination_date = "2026-01-01T00:00:00.000"
       }
     }
   }
@@ -107,7 +153,7 @@ resource "coralogix_alerts_scheduler" "example_2" {
 
 Required:
 
-- `what_expression` (String) DataPrime query expression. - [DataPrime query language](https://coralogix.com/docs/dataprime-query-language/).
+- `what_expression` (String) A [DataPrime](https://coralogix.com/docs/dataprime-query-language/) expression that filters which **group-by values** to suppress within the selected alerts. The expression must start with `source logs | filter` (this syntax is required even for metric or tracing alerts - the filtering works on group-by values regardless of alert type). Use `"source logs | filter true"` to suppress all alert activity without filtering specific values. Use `"source logs | filter $d.fieldName == 'value'"` to suppress only when specific group-by values match. This field controls **what triggered values** to suppress, while `alerts_unique_ids` or `meta_labels` control **which alerts** the rule applies to.
 
 Optional:
 

--- a/examples/resources/coralogix_alerts_scheduler/resource.tf
+++ b/examples/resources/coralogix_alerts_scheduler/resource.tf
@@ -12,56 +12,102 @@ provider "coralogix" {
   #env = "<add the environment you want to work at or add env variable CORALOGIX_ENV>"
 }
 
-resource "coralogix_alerts_scheduler" "example" {
-  name        = "example"
-  description = "example"
+# Example 1: Suppress ALL alert activity for specific alerts (no group-by filtering)
+# Use "source logs | filter true" to suppress all triggered values
+resource "coralogix_alerts_scheduler" "suppress_all" {
+  name        = "Maintenance Window - Suppress All"
+  description = "Suppress all alert activity during maintenance window"
   filter = {
-    what_expression   = "source logs | filter $d.cpodId:string == '122'"
+    what_expression   = "source logs | filter true"
     alerts_unique_ids = ["ed6f3713-d827-49a2-9bb6-a8dba8b8c580"]
   }
   schedule = {
     operation = "mute"
     one_time = {
       time_frame = {
-        start_time = "2021-01-04T00:00:00.000"
-        end_time   = "2025-01-01T00:00:50.000"
+        start_time = "2025-01-04T00:00:00.000"
+        end_time   = "2025-01-04T06:00:00.000"
         time_zone  = "UTC+2"
       }
     }
   }
 }
 
-resource "coralogix_alerts_scheduler" "example_2" {
-  name        = "example"
-  description = "example"
+# Example 2: Suppress only specific group-by values
+# The what_expression filters which triggered values to suppress
+# Note: "source logs" syntax works for ALL alert types (logs, metrics, tracing)
+resource "coralogix_alerts_scheduler" "suppress_specific_values" {
+  name        = "Suppress Test Environment Alerts"
+  description = "Suppress alerts only when environment=test"
   filter = {
-    what_expression = "source logs | filter $d.cpodId:string == '122'"
+    what_expression   = "source logs | filter $d.environment == 'test'"
+    alerts_unique_ids = ["ed6f3713-d827-49a2-9bb6-a8dba8b8c580"]
+  }
+  schedule = {
+    operation = "mute"
+    one_time = {
+      time_frame = {
+        start_time = "2025-01-04T00:00:00.000"
+        end_time   = "2025-01-05T00:00:00.000"
+        time_zone  = "UTC+2"
+      }
+    }
+  }
+}
+
+# Example 3: Suppress with multiple conditions
+# Works with any alert group-by keys including metric labels
+resource "coralogix_alerts_scheduler" "suppress_multiple_conditions" {
+  name        = "Suppress Staging Cluster Alerts"
+  description = "Suppress alerts for staging cluster in us-east region"
+  filter = {
+    what_expression   = "source logs | filter $d.cluster == 'staging' && $d.region == 'us-east-1'"
+    alerts_unique_ids = ["ed6f3713-d827-49a2-9bb6-a8dba8b8c580"]
+  }
+  schedule = {
+    operation = "mute"
+    one_time = {
+      time_frame = {
+        start_time = "2025-01-04T00:00:00.000"
+        end_time   = "2025-01-05T00:00:00.000"
+        time_zone  = "UTC+2"
+      }
+    }
+  }
+}
+
+# Example 4: Recurring suppression with meta_labels selector
+resource "coralogix_alerts_scheduler" "recurring_suppression" {
+  name        = "Weekly Maintenance Window"
+  description = "Suppress alerts every Sunday for maintenance"
+  filter = {
+    what_expression = "source logs | filter true"
     meta_labels = [
       {
-        key   = "key"
-        value = "value"
+        key   = "team"
+        value = "platform"
       }
     ]
   }
   schedule = {
-    operation = "active"
+    operation = "mute"
     recurring = {
       dynamic = {
-        repeat_every = 2
+        repeat_every = 1
         frequency = {
           weekly = {
             days = ["Sunday"]
           }
         }
         time_frame = {
-          start_time = "2021-01-04T00:00:00.000"
+          start_time = "2025-01-05T02:00:00.000"
           duration = {
-            for_over  = 2
+            for_over  = 4
             frequency = "hours"
           }
-          time_zone = "UTC+2"
+          time_zone = "UTC+0"
         }
-        termination_date = "2025-01-01T00:00:00.000"
+        termination_date = "2026-01-01T00:00:00.000"
       }
     }
   }

--- a/internal/provider/alerts/resource_coralogix_alerts_scheduler.go
+++ b/internal/provider/alerts/resource_coralogix_alerts_scheduler.go
@@ -201,7 +201,7 @@ func (r *AlertsSchedulerResource) Schema(_ context.Context, _ resource.SchemaReq
 				Attributes: map[string]schema.Attribute{
 					"what_expression": schema.StringAttribute{
 						Required:            true,
-						MarkdownDescription: "DataPrime query expression. - [DataPrime query language](https://coralogix.com/docs/dataprime-query-language/).",
+						MarkdownDescription: "A [DataPrime](https://coralogix.com/docs/dataprime-query-language/) expression that filters which **group-by values** to suppress within the selected alerts. The expression must start with `source logs | filter` (this syntax is required even for metric or tracing alerts - the filtering works on group-by values regardless of alert type). Use `\"source logs | filter true\"` to suppress all alert activity without filtering specific values. Use `\"source logs | filter $d.fieldName == 'value'\"` to suppress only when specific group-by values match. This field controls **what triggered values** to suppress, while `alerts_unique_ids` or `meta_labels` control **which alerts** the rule applies to.",
 					},
 					"meta_labels": schema.SetNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
### Description

Improves documentation for the `what_expression` field in `coralogix_alerts_scheduler` resource.

**Problem:** Customers were confused about:
- What `what_expression` actually filters (group-by values, not alerts)
- How to use it for metric/tracing alerts (not just logs)
- That `"source logs | filter ..."` syntax works for ALL alert types

**Solution:** Updated schema description and added comprehensive examples showing:
- `"source logs | filter true"` - suppress all alert activity
- `"source logs | filter $d.fieldName == 'value'"` - filter specific group-by values
- Multiple conditions with `&&` and `||` operators

**Verified:** Tested against Coralogix account - both syntax patterns work correctly.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
  - N/A - Documentation only change, no logic changes
- [x] Have you run the acceptance tests on this branch?
  - Existing tests will run via CI

Output from acceptance testing:


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

N/A - Documentation only change. Manually verified by creating suppression rules
with both "source logs | filter true" and "source logs | filter $d.environment == 'test'"
against EU2 account.

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
docs(alerts_scheduler): Clarified what_expression field usage - explains that the field filters group-by values (not alerts), that source logs | filter syntax works for all alert types (logs, metrics, tracing), and added examples for common use cases.
...
```

### References
[CDS-2830](https://coralogix.atlassian.net/browse/CDS-2830)
<!---

--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

[CDS-2830]: https://coralogix.atlassian.net/browse/CDS-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ