### PR TITLE
[CDS-2851] Fix OpenAPI domain base URL and add CX510, CX520 regions

### DIFF
--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -214,7 +214,11 @@ func NewClientSet(region string, apiKey string, targetUrl string) *ClientSet {
 
 	_, found := cxsdkOpenapi.URLFromRegion(strings.ToLower(region))
 	if !found {
-		url := cxsdkOpenapi.URLFromDomain(region)
+		openapiDomain := region
+		if !strings.HasPrefix(openapiDomain, "api.") {
+			openapiDomain = "api." + openapiDomain
+		}
+		url := cxsdkOpenapi.URLFromDomain(openapiDomain)
 		confBuilder.WithURL(url)
 	} else {
 		confBuilder.WithRegion(strings.ToLower(region))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -72,6 +72,8 @@ var (
 		"US1":     "ng-api-grpc.coralogix.us:443",
 		"USA2":    "ng-api-grpc.cx498.coralogix.com:443",
 		"US2":     "ng-api-grpc.cx498.coralogix.com:443",
+		"CX510":   "ng-api-grpc.cx510.coralogix.com:443",
+		"CX520":   "ng-api-grpc.cx520.coralogix.com:443",
 	}
 	validEnvironmentAliases                   = utils.GetKeys(terraformEnvironmentAliasToGrpcUrl)
 	terraformEnvironmentAliasToSdkEnvironment = map[string]string{
@@ -89,6 +91,8 @@ var (
 		"US1":     "US1",
 		"USA2":    "US2",
 		"US2":     "US2",
+		"CX510":   "cx510.coralogix.com",
+		"CX520":   "cx520.coralogix.com",
 	}
 )
 


### PR DESCRIPTION
Fixes an issue where custom domains without the api. prefix would fail to connect to OpenAPI endpoints (such as TCO policies and Scopes). Also adds support for the CX510 and CX520 regions.