### PR TITLE
chore: add CLAUDE.md / AGENTS.md guidance and project skills

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,22 @@
+# Project skills
+
+Project-specific skills for the Coralogix Terraform provider. See the **Skill maintenance** section in `../../CLAUDE.md` for when to add or update skills.
+
+Each skill is a directory containing a `SKILL.md` file:
+
+```
+.claude/skills/
+  <skill-name>/
+    SKILL.md
+```
+
+`SKILL.md` frontmatter:
+
+```markdown
+---
+name: <kebab-case-name>
+description: <one sentence — concrete triggers Claude matches against>
+---
+```
+
+This directory is intentionally tracked in git so the knowledge base travels with the repo.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: create-pr
+description: Structure for a non-trivial bug-fix PR description in this repo (compounding issues, schema-level changes, framework-internals fixes). Replaces the default PR template body, which is minimal scaffolding. Trigger phrases include "create a PR", "open a PR", "draft the PR description". For feature PRs, fall back to the team's standard process.
+---
+
+# Create PR — bug-fix description structure
+
+**Trigger:** opening a PR for a non-trivial bug fix. Trivial one-liners can keep the default template.
+
+**Sections (use as `##` headers in order, replacing the default template body):**
+
+1. **Summary** — one sentence: what bug is fixed and the link to the ticket if any.
+2. **Root Cause** — the *mechanism*, not the symptom. If multiple compounding bugs, split into "Issue 1 / Issue 2 / …" with `file:function` refs and explain how each contributes.
+3. **Why was it introduced** — run `git log --follow <file>` and `git blame` the offending lines. Cite the introducing commit + the original intent. If you can't find a clear answer, say so — don't speculate from commit-message phrasing.
+4. **Breaking change?** — explicit yes/no. If no, list edge cases where behaviour shifts (e.g., post-import re-plan). If yes, describe the migration path.
+5. **Risks** — bullet list. For each, how the fix mitigates it (or why it's acceptable).
+6. **Changes** — `| File | Change |` table. One row per touched file.
+7. **Test plan** — checklist with specific test function names that exercise the fix; flag existing tests being strengthened.
+
+**Before creating the PR:** show the full assembled description to the user and wait for explicit approval. PR creation is a visible-to-others action — never `gh pr create` without confirmation, even after the description is "done". The user may want to tweak wording, drop a section, or hold the PR.
+
+**Why:** reviewers shouldn't redo the archaeology you already did. This structure makes review fast and leaves a forensic trail for future regression triage. Symptom-and-fix descriptions push the work back onto the reviewer.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,22 +1,25 @@
 ---
 name: create-pr
-description: Structure for a non-trivial bug-fix PR description in this repo (compounding issues, schema-level changes, framework-internals fixes). Replaces the default PR template body, which is minimal scaffolding. Trigger phrases include "create a PR", "open a PR", "draft the PR description". For feature PRs, fall back to the team's standard process.
+description: PR description structure for non-trivial bug fixes in this repo. Follows the .github/PULL_REQUEST_TEMPLATE.md skeleton but expands the Description body with deeper sections. Trigger phrases: "create a PR", "open a PR", "draft the PR description".
 ---
 
-# Create PR — bug-fix description structure
+# Create PR
 
-**Trigger:** opening a PR for a non-trivial bug fix. Trivial one-liners can keep the default template.
+**Trigger:** opening a PR for a non-trivial bug fix. Trivial one-liners can keep the default template body as-is.
 
-**Sections (use as `##` headers in order, replacing the default template body):**
+**Use `.github/PULL_REQUEST_TEMPLATE.md` as the skeleton** — keep every section (Description, Acceptance tests, Release Note, References, Community Note). Don't drop the Community Note or other boilerplate.
 
-1. **Summary** — one sentence: what bug is fixed and the link to the ticket if any.
-2. **Root Cause** — the *mechanism*, not the symptom. If multiple compounding bugs, split into "Issue 1 / Issue 2 / …" with `file:function` refs and explain how each contributes.
-3. **Why was it introduced** — run `git log --follow <file>` and `git blame` the offending lines. Cite the introducing commit + the original intent. If you can't find a clear answer, say so — don't speculate from commit-message phrasing.
-4. **Breaking change?** — explicit yes/no. If no, list edge cases where behaviour shifts (e.g., post-import re-plan). If yes, describe the migration path.
-5. **Risks** — bullet list. For each, how the fix mitigates it (or why it's acceptable).
-6. **Changes** — `| File | Change |` table. One row per touched file.
-7. **Test plan** — checklist with specific test function names that exercise the fix; flag existing tests being strengthened.
+**Inside the Description section,** use these `##` headers in order:
+1. **Summary** — one sentence: what bug is fixed; link the ticket if any.
+2. **Root Cause** — the *mechanism*, not the symptom. Split into "Issue 1 / Issue 2 …" with `file:function` refs if compounding.
+3. **Why was it introduced** — cite the introducing commit via `git log --follow` / `git blame`. If unclear, say so; don't speculate from commit-message phrasing.
+4. **Breaking change?** — explicit yes/no, with edge cases or migration path.
+5. **Risks** — bullets, with mitigation per item.
+6. **Changes** — `| File | Change |` table.
+7. **Test plan** — checklist with specific test function names.
 
-**Before creating the PR:** show the full assembled description to the user and wait for explicit approval. PR creation is a visible-to-others action — never `gh pr create` without confirmation, even after the description is "done". The user may want to tweak wording, drop a section, or hold the PR.
+**Fill the rest of the template:** answer the Acceptance tests checkboxes, paste relevant `make testacc TESTARGS='-run=...'` output, write a meaningful Release Note (`NONE` for chore/internal), link related PRs/issues in References, keep Community Note verbatim.
 
-**Why:** reviewers shouldn't redo the archaeology you already did. This structure makes review fast and leaves a forensic trail for future regression triage. Symptom-and-fix descriptions push the work back onto the reviewer.
+**Before `gh pr create`:** show the assembled description and wait for explicit approval. PR creation is visible-to-others.
+
+**Why:** reviewers shouldn't redo the archaeology you did. Symptom-and-fix descriptions push the work back onto them.

--- a/.claude/skills/framework-null-vs-unknown-in-extractors/SKILL.md
+++ b/.claude/skills/framework-null-vs-unknown-in-extractors/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: framework-null-vs-unknown-in-extractors
+description: In `extract*` helpers under `internal/provider/**/resource_*.go` that feed `Replace*`/`Update*` SDK calls, never collapse `IsNull()` and `IsUnknown()` into one branch. Null = clear; unknown = omit.
+---
+
+# Null vs Unknown in extractor helpers
+
+**Trigger:** an extractor turns a `types.Set/List/Map/Object` into an SDK request body, and you see `if x.IsNull() || x.IsUnknown()` returning the same value.
+
+**Fix:**
+
+```go
+if x.IsUnknown() {
+    return nil, nil               // omit key → server keeps existing value
+}
+if x.IsNull() {
+    return []sdk.Foo{}, nil       // explicit empty → server clears on Replace
+}
+```
+
+**Why:** the SDK's `ToMap()` uses `IsNil()` to decide whether to emit a JSON key. Collapsing both states either silently preserves removed values (both → nil) or silently destroys values still being resolved (both → empty slice).

--- a/.claude/skills/manual-validation-harness/SKILL.md
+++ b/.claude/skills/manual-validation-harness/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: manual-validation-harness
+description: When validating a coralogix terraform-provider bug fix end-to-end against a real Coralogix env. Triggers on "test the fix locally", "reproduce the bug", "validate before merge".
+---
+
+# Manual end-to-end validation
+
+**Trigger:** user wants to exercise a provider bug fix against a real env, post-build pre-merge.
+
+**Procedure:**
+
+1. `make install` from the PR branch (builds + installs to `~/.terraform.d/plugins/locally/debug/coralogix/1.5/<arch>`).
+2. Isolated workdir: `mkdir /tmp/<ticket>-test && cd $_`.
+3. Project-local `terraformrc` with `dev_overrides` for `coralogix/coralogix` pointing at the install dir above. `export TF_CLI_CONFIG_FILE=$PWD/terraformrc`.
+4. Multi-step scenarios: keep step files in `./steps/`, `cp steps/stepN.tf main.tf` between runs. (Terraform reads every `.tf` in cwd → loose step files cause duplicate-resource errors.)
+5. Each step: `terraform apply -auto-approve`, verify in UI, then `terraform plan` → expect `No changes.` (idempotency catches perpetual-diff regressions).
+6. Cleanup: `terraform destroy -auto-approve && rm -rf /tmp/<ticket>-test`.
+
+**Gotchas:**
+
+- 403 from API = key/env mismatch, not a provider bug.
+- "Provider development overrides are in effect" warning is expected.
+- Don't write `.tf` files via heredoc in chat — paste indentation breaks them. Use an editor or have Claude Write them.
+
+**Why:** unit + acceptance tests catch regressions; manual validation gives the reviewer end-to-end confidence and exposes UI-layer behaviour the test suite can't observe.

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ terraform.rc
 terraform
 
 dist/
+
+# Claude Code per-user settings (allow-lists, model overrides, etc.)
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Project guidance for AI coding agents (Claude Code, Codex, Cursor, etc.) working in this repository. `AGENTS.md` is a symlink to this file so vendor-neutral discovery works alongside Claude Code's documented entry point.
 
 ## Common commands
 
@@ -51,7 +51,9 @@ Both implementations live in `internal/provider/provider.go`. To add a new resou
 
 ## Skill maintenance (dynamic)
 
-Project skills live at `.claude/skills/<skill-name>/SKILL.md`. Treat the skills directory as a living knowledge base — when a bug fix or issue reveals non-obvious, repeat-able knowledge, capture it as a skill so future sessions inherit it. Don't capture things already derivable from the code, git history, or CLAUDE.md.
+Project skills live at `.claude/skills/<skill-name>/SKILL.md`. The directory is symlinked from `.cursor/skills` so Cursor users discover the same files; if a future tool needs them, add a similar symlink for that tool's convention rather than duplicating files.
+
+Treat the skills directory as a living knowledge base — when a bug fix or issue reveals non-obvious, repeat-able knowledge, capture it as a skill so future sessions inherit it. Don't capture things already derivable from the code, git history, or this file.
 
 **When to create a new skill** (after finishing the actual fix):
 - A bug fix uncovered a footgun that's likely to bite again (e.g., a Plan-Modifier that *must* be set to avoid spurious diffs on a specific attribute type, an SDKv2-vs-framework gotcha, a gRPC enum mapping that breaks silently).
@@ -64,7 +66,7 @@ Project skills live at `.claude/skills/<skill-name>/SKILL.md`. Treat the skills 
 
 **When NOT to create a skill:**
 - One-off fixes with no generalizable lesson.
-- Anything covered by Go/Terraform docs or already in CLAUDE.md.
+- Anything covered by Go/Terraform docs or already in this file.
 - Vague "be careful with X" advice without a concrete trigger and action.
 
 **Keep skills short** — ~20 lines, index-entry sized. A fresh Claude should read it in 30 seconds and know what to do. If it needs >30 lines, it's probably two skills. Don't include current-state inventories ("attribute X still has the bug") — those rot fast and belong in PR descriptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common commands
+
+```bash
+make build       # Compile the provider binary
+make install     # Build and install into ~/.terraform.d/plugins/locally/debug/coralogix/1.5/<os_arch>
+make test        # Unit tests (parallel, 30s timeout)
+make testacc     # Acceptance tests (TF_ACC=1, 120m timeout) — hits real Coralogix APIs
+make generate    # Regenerate docs/ via terraform-plugin-docs (note: `git checkout -- docs/guides` runs after)
+```
+
+Run a single test:
+```bash
+go test ./internal/provider/... -run TestAccCoralogixResourceAlert -v -timeout 30m
+TF_ACC=1 go test ./internal/provider/alerts/... -run TestAccAlert -v
+```
+
+Local end-to-end smoke against examples: `./exec_examples_locally.sh` (rewrites every `examples/resources/*.tf` to point at `locally/debug/coralogix` v1.5, runs `terraform plan`, then reverts).
+
+The Makefile's `OS_ARCH=darwin_arm64` may need editing for non-Apple-Silicon dev machines. Pair `make install` with a `~/.terraformrc` dev-overrides block pointing at `~/.terraform.d/plugins/locally/debug/coralogix`.
+
+## Required environment for running the provider
+
+- `CORALOGIX_API_KEY` — required.
+- Either `CORALOGIX_ENV` (e.g. `EU1`, `US1`, `AP3`, etc.) **or** `CORALOGIX_DOMAIN` (e.g. `coralogix.com`) — exactly one. Setting both is a configuration error. The full env→gRPC URL map lives in `internal/provider/provider.go`.
+
+## Architecture
+
+**Mux server (terraform-plugin-mux).** `main.go` combines two provider implementations behind one binary:
+- `provider.OldProvider()` — legacy `terraform-plugin-sdk/v2` provider, upgraded via `tf5to6server`. Hosts the older resources still on SDKv2 (`coralogix_rules_group`, `coralogix_enrichment`, `coralogix_data_set`, `coralogix_hosted_dashboard`, `coralogix_grafana_folder`).
+- `provider.NewCoralogixProvider()` — `terraform-plugin-framework` provider. Hosts everything else and is where new resources should be added.
+
+Both implementations live in `internal/provider/provider.go`. To add a new resource/data source on the framework path, register it in the `Resources()` / `DataSources()` slices there.
+
+**Resource packages.** Each Coralogix domain lives in its own subpackage under `internal/provider/<domain>/`, with `resource_*.go`, `data_source_*.go`, and `*_test.go` files. The cross-cutting `*_test.go` files at `internal/provider/` root are the acceptance-test entry points that import resource-specific fixtures from `examples/`.
+
+**Client layer.** `internal/clientset/` is the single factory for backend clients. `clientset.NewClientSet(env, apiKey, grpcURL)` returns a struct holding ~30 typed clients (alerts, dashboards, SLOs, TCO, AAA, notifications, …). Most are gRPC clients from `coralogix-management-sdk`; a few use REST (`rest/client.go`, `grafana-client.go`, `groups-client.go`). `callPropertiesCreator.go` builds the auth/metadata for outgoing gRPC calls. The clientset is what `Configure` hands to every resource as `ResourceData`/`DataSourceData`.
+
+**Shared helpers.** `internal/utils/` has constants and generic helpers (map/slice utilities, schema helpers) used across all resource packages.
+
+**Docs are generated.** `docs/` is produced by `tfplugindocs` (`make generate`) from schema descriptions and `examples/`. Don't hand-edit files under `docs/resources/` or `docs/data-sources/` — edit the schema and example, then regenerate. `docs/guides/` is hand-written and explicitly preserved by the Makefile's `git checkout -- docs/guides`.
+
+**Examples are public contract.** `examples/resources/coralogix_<name>/resource.tf` and `examples/data-sources/coralogix_<name>/data-source.tf` are pulled into generated docs and are smoke-tested by `exec_examples_locally.sh`. Keep them runnable.
+
+## Pre-commit
+
+`.pre-commit-config.yaml` runs `gofmt`, `goimports`, `go vet`, `golangci-lint`, `go-cyclo` (limit 15), `go-mod-tidy`, `go-build`, and `go-unit-tests` on every commit.
+
+## Skill maintenance (dynamic)
+
+Project skills live at `.claude/skills/<skill-name>/SKILL.md`. Treat the skills directory as a living knowledge base — when a bug fix or issue reveals non-obvious, repeat-able knowledge, capture it as a skill so future sessions inherit it. Don't capture things already derivable from the code, git history, or CLAUDE.md.
+
+**When to create a new skill** (after finishing the actual fix):
+- A bug fix uncovered a footgun that's likely to bite again (e.g., a Plan-Modifier that *must* be set to avoid spurious diffs on a specific attribute type, an SDKv2-vs-framework gotcha, a gRPC enum mapping that breaks silently).
+- A repeatable diagnostic procedure emerged (e.g., "to debug a `coralogix_dashboard` import panic, check X, then Y").
+- A migration recipe applies to >1 resource (e.g., porting a resource from SDKv2 to plugin-framework).
+
+**When to update an existing skill** instead of creating a new one:
+- The fix is a new edge case of an already-documented pattern → append to the existing SKILL.md.
+- A documented assumption is now wrong → correct it in place; don't leave stale guidance.
+
+**When NOT to create a skill:**
+- One-off fixes with no generalizable lesson.
+- Anything covered by Go/Terraform docs or already in CLAUDE.md.
+- Vague "be careful with X" advice without a concrete trigger and action.
+
+**Keep skills short** — ~20 lines, index-entry sized. A fresh Claude should read it in 30 seconds and know what to do. If it needs >30 lines, it's probably two skills. Don't include current-state inventories ("attribute X still has the bug") — those rot fast and belong in PR descriptions.
+
+**Skill file layout:**
+
+```markdown
+---
+name: <kebab-case-name>
+description: <one sentence — concrete triggers Claude matches against (resource names, error strings, file paths)>
+---
+
+# <Title>
+
+**Trigger:** <when this applies, in one line>
+
+**Fix:** <what to do — code snippet if useful>
+
+**Why:** <one sentence — the underlying reason, so future-you can judge edge cases>
+```
+
+**Naming:** kebab-case, scoped to the problem, not the resource (e.g., `framework-plan-modifier-for-set-of-objects`, not `fix-alert-bug-2026-04`). A good name reads like an index entry.
+
+**Workflow at end of a bug-fix session:**
+1. Ask: "did I just learn something a fresh Claude wouldn't?"
+2. If yes, check `.claude/skills/` — is there an existing skill to extend?
+3. Otherwise, create a new skill. Keep it tight; one specific lesson per skill beats a sprawling catch-all.
+4. Commit the skill alongside the fix so reviewers can sanity-check the captured lesson.


### PR DESCRIPTION
Adds cross-tool AI agent guidance and project-level skills so contributors using Claude Code, Codex, Cursor, or similar inherit shared conventions instead of re-deriving them per session.

  **Files added:**
  - **`CLAUDE.md`** — canonical project guidance: architecture (mux server, clientset, package layout), common commands, env vars, pre-commit toolchain, skill-maintenance workflow.
  - **`AGENTS.md`** → symlink to `CLAUDE.md` (Codex's documented discovery filename; vendor-neutral entry point with no content duplication).
  - **`.claude/skills/`** — three project-level skills, ~20 lines each:
    - `framework-null-vs-unknown-in-extractors` — review trigger for `IsNull() || IsUnknown()` collapsed in extractor helpers feeding `Replace*`/`Update*` SDK calls.
    - `manual-validation-harness` — end-to-end validation procedure for bug fixes (build, dev_overrides, isolated workdir, idempotency check) with documented gotchas.
    - `create-pr` — structure for non-trivial bug-fix PR descriptions with a "show description, wait for approval" gate before `gh pr create`.
  - **`.cursor/skills`** → symlink to `.claude/skills/` (Cursor users discover the same files; single source of truth, no parallel format).
  - **`.gitignore`** — excludes `.claude/settings.local.json` (per-user permission allow-lists).