### PR TITLE
fix(BUGV2-5288): normalize empty description in parsing_rules block rule

### DIFF
--- a/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
+++ b/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -720,6 +721,8 @@ func commonRulesAttrs() map[string]schema.Attribute {
 		},
 		"description": schema.StringAttribute{
 			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString(""),
 			Description: "The rule description.",
 		},
 		"active": schema.BoolAttribute{

--- a/internal/provider/resource_coralogix_parsing_rules_test.go
+++ b/internal/provider/resource_coralogix_parsing_rules_test.go
@@ -123,6 +123,32 @@ func TestAccCoralogixResourceParsingRules_block(t *testing.T) {
 	})
 }
 
+// TestAccCoralogixResourceParsingRules_block_omitted_description verifies BUGV2-5288:
+// before the fix, omitting the optional `description` field inside a `block` rule caused
+// "Provider produced inconsistent result after apply" because the API echoed back "" while
+// Terraform expected null. The fix adds Computed+Default("") to the `description` field
+// in commonRulesAttrs, so omitted description normalizes to "" before the request is sent.
+func TestAccCoralogixResourceParsingRules_block_omitted_description(t *testing.T) {
+	r := getRandomParsingRule()
+	regEx := `.*`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckParsingRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceParsingRulesBlockOmittedDescription(r, regEx),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.0.block.name", r.parsingRuleParams.name),
+					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.0.block.description", ""),
+					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.0.block.regular_expression", regEx),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCoralogixResourceParsingRules_allow(t *testing.T) {
 	r := getRandomParsingRule()
 
@@ -705,6 +731,25 @@ func testAccCoralogixResourceParsingRulesBlock(r *parsingRuleGroupParams, regEx,
   }]
  }
 `, r.name, r.description, r.creator, r.parsingRuleParams.name, r.parsingRuleParams.description, regEx, keepBlockedLogs)
+}
+
+func testAccCoralogixResourceParsingRulesBlockOmittedDescription(r *parsingRuleGroupParams, regEx string) string {
+	return fmt.Sprintf(`resource "coralogix_parsing_rules" "test" {
+  name        = "%s"
+  description = "%s"
+  creator     = "%s"
+  rule_subgroups = [{
+    rules = [{
+      block = {
+        name               = "%s"
+        source_field       = "text"
+        regular_expression = "%s"
+        keep_blocked_logs  = false
+      }
+    }]
+  }]
+}
+`, r.name, r.description, r.creator, r.parsingRuleParams.name, regEx)
 }
 
 func testAccCoralogixResourceParsingRulesJsonExtract(r *parsingRuleGroupParams, jsonKey, destinationField string) string {


### PR DESCRIPTION

  ## Summary

  Fixes [BUGV2-5288](https://coralogix.atlassian.net/browse/BUGV2-5288): when a `coralogix_parsing_rules` resource is created with an optional `description` field omitted inside an inner
  rule (e.g., `block`, `json_extract`, etc.), Terraform halts with `Provider produced inconsistent result after apply: .rule_subgroups[0].rules[0].block.description: was null, but now
  cty.StringVal("")`.

  ## Root Cause

  In `commonRulesAttrs()` (`internal/provider/parsing_rules/resource_coralogix_parsing_rules.go:711`), the inner `description` field on rule types is declared `Optional` only — no
  `Computed`, no `Default`:

  ```go
  "description": schema.StringAttribute{
      Optional:    true,
      Description: "The rule description.",
  },
  ```

  The flow that produces the error:
  1. User omits `description` → Terraform plans the value as `null`.
  2. Provider sends the request; API stores the rule and echoes back `description = ""` in the response.
  3. Provider flattens the response via `types.StringPointerValue(rule.Description)`, which produces `types.StringValue("")` for an empty string.
  4. State has `""`, plan had `null`. For a non-`Computed` attribute, Terraform treats this divergence as a provider bug and rejects the apply.

  `commonRulesAttrs()` is shared across all 9 rule types (`block`, `json_extract`, `replace`, `parse`, `extract_timestamp`, `remove_fields`, `json_stringify`, `extract`,
  `parse_json_field`). The bug surfaces on whichever type the user happens to use; `block` was just the customer's case.

  ## Why was it introduced

  The `description` field has been declared `Optional` only since the resource was first written; this is a structural mismatch between the schema and the API's normalization of empty
  strings, not a regression introduced by a specific commit. A close cousin was fixed in PR #486 ([commit
  `a8ce174`](https://github.com/coralogix/terraform-provider-coralogix/commit/a8ce174), CDS-2792) for the `lucene_query` field on alerts using exactly this pattern. The reporter's ticket
  explicitly cites #486 as the precedent. Mikhail (PR #486 author) noted at the time that he wasn't sure his fix would generalize and suggested raising adjacent cases as separate bugs —
  this is one of those cases.

  ## Is this a breaking change?

  **No.**

  - Users who explicitly set `description = "some value"`: behaviour unchanged.
  - Users who explicitly set `description = ""`: behaviour unchanged.
  - Users who omitted `description`: previously the apply *failed* with the inconsistent-result error; now it succeeds. The state for that field is `""` instead of `null` — a cosmetic
  shift, no semantic change.
  - No schema version bump needed: changing `Optional` → `Optional+Computed+Default("")` does not change the stored state representation.

  ## Risks

  - **Pre-existing test-infra panic** in `testAccCheckParsingRuleDestroy`: when run in isolation (`-run=…`), plugin-framework-only tests panic in the destroy verification because
  `testAccProvider.Meta()` is nil unless an SDKv2 resource was used in the same `go test` invocation. This affects the new test the same way it affects existing parsing_rules tests; full
  CI runs will not surface it (some SDKv2 resource is exercised first). Out of scope for this PR.
  - **Cosmetic drift on import**: importing a parsing rule whose API state has `description = ""` will show `description = ""` in state vs `null` if the user omitted it from config. Same
  behaviour as PR #486 introduced for `lucene_query`.

  ## Changes

  | File | Change |
  |---|---|
  | `internal/provider/parsing_rules/resource_coralogix_parsing_rules.go` | Add `Computed: true` and `Default: stringdefault.StaticString("")` to the `description` attribute in
  `commonRulesAttrs()`. Add `stringdefault` import. The change applies to all 9 rule types since they share `commonRulesAttrs()`. |
  | `internal/provider/resource_coralogix_parsing_rules_test.go` | Add `TestAccCoralogixResourceParsingRules_block_omitted_description` exercising a `block` rule with `description`
  omitted (the exact ticket scenario). |

  ## Test plan

  - [x] Manual reproduction on EU2 against current master: `terraform apply` fails with the exact `Provider produced inconsistent result` error from the ticket.
  - [x] After applying the schema fix: `terraform apply` succeeds; subsequent `terraform plan` is idempotent (no changes); `terraform destroy` cleans up.
  - [x] New acceptance test verified both ways: fails on master with the exact ticket error; passes with the schema fix in place. The test step itself fails/passes correctly even though
  the post-step `testAccCheckParsingRuleDestroy` helper panics on isolated runs (pre-existing test-infra issue, see Risks).
  - [ ] `TestAccCoralogixResourceParsingRules_block_omitted_description` — new test exercising the bug scenario.
  - [ ] `TestAccCoralogixResourceParsingRules_block` — existing literal-path test continues to pass.
  - [ ] All existing parsing_rules acceptance tests pass.

  ### Acceptance tests
  - [x] Have you added an acceptance test for the functionality being added?
  - [ ] Have you run the acceptance tests on this branch?

  Output from acceptance testing:

  ```
  $ make testacc TESTARGS='-run=TestAccCoralogixResourceParsingRules'

  (to be populated after CI run)
  ```

  ### Release Note

  ```release-note
  fix: prevent "Provider produced inconsistent result after apply" error in `coralogix_parsing_rules` when the optional `description` field is omitted in an inner rule (BUGV2-5288)
  ```

  ### References

  - [BUGV2-5288](https://coralogix.atlassian.net/browse/BUGV2-5288) — original bug report with full error trace and customer config.
  - [PR #486](https://github.com/coralogix/terraform-provider-coralogix/pull/486) (CDS-2792) — same pattern applied to `lucene_query`. The reporter explicitly flagged this as the
  precedent and suggested raising the parsing_rules case as a separate bug.

  ### Community Note
  * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community
   and maintainers prioritize this request
  * If you are interested in working on this issue or have submitted a pull request, please leave a comment

  Per the create-pr skill: this is a preview — paste it into the GitHub PR body when you're satisfied. Tweak any wording before submitting if you'd like (the "Risks" section's
  pre-existing-test-infra note in particular is something royfur or another reviewer might want phrased differently).


[BUGV2-5288]: https://coralogix.atlassian.net/browse/BUGV2-5288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUGV2-5288]: https://coralogix.atlassian.net/browse/BUGV2-5288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ