### PR TITLE
feat: add DPXL and quota-based routing to coralogix_tco_policies_logs (CX-40070)

### DIFF
--- a/docs/data-sources/tco_policies_logs.md
+++ b/docs/data-sources/tco_policies_logs.md
@@ -34,11 +34,13 @@ Read-Only:
 - `applications` (Attributes) The applications to apply the policy on. Applies the policy on all the applications by default. (see [below for nested schema](#nestedatt--policies--applications))
 - `archive_retention_id` (String) Allowing logs with a specific retention to be tagged.
 - `description` (String) The policy description
+- `dpxl_expression` (String) DataPrime expression to match logs for this policy. Mutually exclusive with `severities` — set exactly one. The expression must include a version prefix, e.g. `<v1> $d.severity == 'INFO'`.
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
 - `id` (String) tco-policy ID.
 - `name` (String) tco-policy name.
 - `order` (Number) The policy's order between the other policies.
 - `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"].
+- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
 
@@ -49,6 +51,23 @@ Read-Only:
 
 - `names` (Set of String)
 - `rule_type` (String) The rule type. Can be one of ["includes" "is" "is_not" "starts_with" "unspecified"].
+
+
+<a id="nestedatt--policies--quota_based_priority_override"></a>
+### Nested Schema for `policies.quota_based_priority_override`
+
+Read-Only:
+
+- `usage_tiers` (Attributes List) Ordered list of quota-consumption tiers; the policy's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override--usage_tiers))
+
+<a id="nestedatt--policies--quota_based_priority_override--usage_tiers"></a>
+### Nested Schema for `policies.quota_based_priority_override.usage_tiers`
+
+Read-Only:
+
+- `daily_quota_percentage` (Number) Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.
+- `priority` (String) The priority to apply when this tier is active. Can be one of ["block" "high" "low" "medium"].
+
 
 
 <a id="nestedatt--policies--subsystems"></a>

--- a/docs/resources/tco_policies_logs.md
+++ b/docs/resources/tco_policies_logs.md
@@ -83,6 +83,28 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
         rule_type = "is"
         names     = ["mobile", "web"]
       }
+    },
+    # DPXL-expression-based matcher. Mutually exclusive with `severities` — set
+    # exactly one. The expression must include a version prefix, e.g. `<v1>`.
+    {
+      name            = "Example tco_policy with DPXL expression"
+      description     = "Match logs via DataPrime expression instead of severities"
+      priority        = "high"
+      dpxl_expression = "<v1> $d.severity == 'INFO'"
+    },
+    # Quota-based priority override: dynamically reassign the policy's priority
+    # based on daily quota consumption tiers.
+    {
+      name        = "Example tco_policy with quota-based override"
+      description = "Drop priority as daily quota is consumed"
+      priority    = "high"
+      severities  = ["info", "warning"]
+      quota_based_priority_override = {
+        usage_tiers = [
+          { daily_quota_percentage = 50, priority = "medium" },
+          { daily_quota_percentage = 80, priority = "low" },
+        ]
+      }
     }
   ]
 }
@@ -112,7 +134,9 @@ Optional:
 - `applications` (Attributes) The applications to apply the policy on. Applies the policy on all the applications by default. (see [below for nested schema](#nestedatt--policies--applications))
 - `archive_retention_id` (String) Allowing logs with a specific retention to be tagged.
 - `description` (String) The policy description
+- `dpxl_expression` (String) DataPrime expression to match logs for this policy. Mutually exclusive with `severities` — set exactly one. The expression must include a version prefix, e.g. `<v1> $d.severity == 'INFO'`.
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
+- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
 
@@ -131,6 +155,23 @@ Required:
 Optional:
 
 - `rule_type` (String) The rule type. Can be one of ["includes" "is" "is_not" "starts_with" "unspecified"].
+
+
+<a id="nestedatt--policies--quota_based_priority_override"></a>
+### Nested Schema for `policies.quota_based_priority_override`
+
+Required:
+
+- `usage_tiers` (Attributes List) Ordered list of quota-consumption tiers; the policy's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override--usage_tiers))
+
+<a id="nestedatt--policies--quota_based_priority_override--usage_tiers"></a>
+### Nested Schema for `policies.quota_based_priority_override.usage_tiers`
+
+Required:
+
+- `daily_quota_percentage` (Number) Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.
+- `priority` (String) The priority to apply when this tier is active. Can be one of ["block" "high" "low" "medium"].
+
 
 
 <a id="nestedatt--policies--subsystems"></a>

--- a/examples/resources/coralogix_tco_policies_logs/resource.tf
+++ b/examples/resources/coralogix_tco_policies_logs/resource.tf
@@ -68,6 +68,28 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
         rule_type = "is"
         names     = ["mobile", "web"]
       }
+    },
+    # DPXL-expression-based matcher. Mutually exclusive with `severities` — set
+    # exactly one. The expression must include a version prefix, e.g. `<v1>`.
+    {
+      name            = "Example tco_policy with DPXL expression"
+      description     = "Match logs via DataPrime expression instead of severities"
+      priority        = "high"
+      dpxl_expression = "<v1> $d.severity == 'INFO'"
+    },
+    # Quota-based priority override: dynamically reassign the policy's priority
+    # based on daily quota consumption tiers.
+    {
+      name        = "Example tco_policy with quota-based override"
+      description = "Drop priority as daily quota is consumed"
+      priority    = "high"
+      severities  = ["info", "warning"]
+      quota_based_priority_override = {
+        usage_tiers = [
+          { daily_quota_percentage = 50, priority = "medium" },
+          { daily_quota_percentage = 80, priority = "low" },
+        ]
+      }
     }
   ]
 }

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -29,6 +29,8 @@ import (
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 	tcoPolicys "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/policies_service"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -96,21 +98,32 @@ type TCOPoliciesListModel struct {
 }
 
 type TCOPolicyLogsModel struct {
-	ID                 types.String `tfsdk:"id"`
-	Name               types.String `tfsdk:"name"`
-	Description        types.String `tfsdk:"description"`
-	Enabled            types.Bool   `tfsdk:"enabled"`
-	Order              types.Int64  `tfsdk:"order"`
-	Priority           types.String `tfsdk:"priority"`
-	Applications       types.Object `tfsdk:"applications"`
-	Subsystems         types.Object `tfsdk:"subsystems"`
-	Severities         types.Set    `tfsdk:"severities"`
-	ArchiveRetentionID types.String `tfsdk:"archive_retention_id"`
+	ID                         types.String `tfsdk:"id"`
+	Name                       types.String `tfsdk:"name"`
+	Description                types.String `tfsdk:"description"`
+	Enabled                    types.Bool   `tfsdk:"enabled"`
+	Order                      types.Int64  `tfsdk:"order"`
+	Priority                   types.String `tfsdk:"priority"`
+	Applications               types.Object `tfsdk:"applications"`
+	Subsystems                 types.Object `tfsdk:"subsystems"`
+	Severities                 types.Set    `tfsdk:"severities"`
+	ArchiveRetentionID         types.String `tfsdk:"archive_retention_id"`
+	DpxlExpression             types.String `tfsdk:"dpxl_expression"`
+	QuotaBasedPriorityOverride types.Object `tfsdk:"quota_based_priority_override"` // QuotaBasedPriorityOverrideModel
 }
 
 type TCORuleModel struct {
 	RuleType types.String `tfsdk:"rule_type"`
 	Names    types.Set    `tfsdk:"names"`
+}
+
+type QuotaBasedPriorityOverrideModel struct {
+	UsageTiers types.List `tfsdk:"usage_tiers"` // []UsageTierModel
+}
+
+type UsageTierModel struct {
+	DailyQuotaPercentage types.Float64 `tfsdk:"daily_quota_percentage"`
+	Priority             types.String  `tfsdk:"priority"`
 }
 
 func (r *TCOPoliciesLogsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -241,6 +254,45 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 								},
 							},
 							MarkdownDescription: "The subsystems to apply the policy on. Applies the policy on all the subsystems by default.",
+						},
+						"dpxl_expression": schema.StringAttribute{
+							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("severities")),
+							},
+							MarkdownDescription: "DataPrime expression to match logs for this policy. Mutually exclusive with `severities` — set exactly one. The expression must include a version prefix, e.g. `<v1> $d.severity == 'INFO'`.",
+						},
+						"quota_based_priority_override": schema.SingleNestedAttribute{
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"usage_tiers": schema.ListNestedAttribute{
+									Required: true,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(1),
+									},
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"daily_quota_percentage": schema.Float64Attribute{
+												Required: true,
+												Validators: []validator.Float64{
+													float64validator.Between(0, 100),
+												},
+												MarkdownDescription: "Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.",
+											},
+											"priority": schema.StringAttribute{
+												Required: true,
+												Validators: []validator.String{
+													stringvalidator.OneOf(tcoPoliciesValidPriorities...),
+												},
+												MarkdownDescription: fmt.Sprintf("The priority to apply when this tier is active. Can be one of %q.", tcoPoliciesValidPriorities),
+											},
+										},
+									},
+									MarkdownDescription: "Ordered list of quota-consumption tiers; the policy's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached.",
+								},
+							},
+							MarkdownDescription: "Dynamically reassign the policy's priority based on daily quota consumption tiers.",
 						},
 					},
 				},
@@ -488,33 +540,80 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 	if diags.HasError() {
 		return nil, diags
 	}
+	quotaBased, diags := flattenQuotaBasedPriorityOverride(ctx, logsPolicy.PriorityOverride)
+	if diags.HasError() {
+		return nil, diags
+	}
 
 	return &TCOPolicyLogsModel{
-		ID:                 types.StringValue(logsPolicy.GetId()),
-		Name:               types.StringValue(logsPolicy.GetName()),
-		Description:        types.StringValue(logsPolicy.GetDescription()),
-		Enabled:            types.BoolValue(logsPolicy.GetEnabled()),
-		Order:              types.Int64Value(int64(logsPolicy.GetOrder())),
-		Priority:           types.StringValue(tcoPoliciesPriorityApiToSchema[logsPolicy.GetPriority()]),
-		Applications:       applications,
-		Subsystems:         subsystems,
-		ArchiveRetentionID: flattenArchiveRetention(logsPolicy.ArchiveRetention),
-		Severities:         flattenTCOPolicySeverities(logRules.GetSeverities()),
+		ID:                         types.StringValue(logsPolicy.GetId()),
+		Name:                       types.StringValue(logsPolicy.GetName()),
+		Description:                types.StringValue(logsPolicy.GetDescription()),
+		Enabled:                    types.BoolValue(logsPolicy.GetEnabled()),
+		Order:                      types.Int64Value(int64(logsPolicy.GetOrder())),
+		Priority:                   types.StringValue(tcoPoliciesPriorityApiToSchema[logsPolicy.GetPriority()]),
+		Applications:               applications,
+		Subsystems:                 subsystems,
+		ArchiveRetentionID:         flattenArchiveRetention(logsPolicy.ArchiveRetention),
+		Severities:                 flattenTCOPolicySeverities(logRules.GetSeverities()),
+		DpxlExpression:             types.StringPointerValue(logRules.DpxlExpression),
+		QuotaBasedPriorityOverride: quotaBased,
 	}, nil
+}
+
+func flattenQuotaBasedPriorityOverride(ctx context.Context, po *tcoPolicys.PriorityOverride) (types.Object, diag.Diagnostics) {
+	if po == nil || po.QuotaBased == nil {
+		return types.ObjectNull(quotaBasedPriorityOverrideAttributes()), nil
+	}
+
+	tiers := po.QuotaBased.UsageTiers
+	tierObjects := make([]UsageTierModel, 0, len(tiers))
+	for _, t := range tiers {
+		var priority string
+		if t.Priority != nil {
+			priority = tcoPoliciesPriorityApiToSchema[*t.Priority]
+		}
+		tierObjects = append(tierObjects, UsageTierModel{
+			DailyQuotaPercentage: types.Float64PointerValue(t.DailyQuotaPercentage),
+			Priority:             types.StringValue(priority),
+		})
+	}
+	tiersList, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: usageTierAttributes()}, tierObjects)
+	if diags.HasError() {
+		return types.ObjectNull(quotaBasedPriorityOverrideAttributes()), diags
+	}
+	return types.ObjectValueFrom(ctx, quotaBasedPriorityOverrideAttributes(), &QuotaBasedPriorityOverrideModel{
+		UsageTiers: tiersList,
+	})
 }
 
 func policiesLogsAttr() map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":                   types.StringType,
-		"name":                 types.StringType,
-		"description":          types.StringType,
-		"enabled":              types.BoolType,
-		"order":                types.Int64Type,
-		"priority":             types.StringType,
-		"applications":         types.ObjectType{AttrTypes: tcoPolicyRuleAttributes()},
-		"subsystems":           types.ObjectType{AttrTypes: tcoPolicyRuleAttributes()},
-		"severities":           types.SetType{ElemType: types.StringType},
-		"archive_retention_id": types.StringType,
+		"id":                            types.StringType,
+		"name":                          types.StringType,
+		"description":                   types.StringType,
+		"enabled":                       types.BoolType,
+		"order":                         types.Int64Type,
+		"priority":                      types.StringType,
+		"applications":                  types.ObjectType{AttrTypes: tcoPolicyRuleAttributes()},
+		"subsystems":                    types.ObjectType{AttrTypes: tcoPolicyRuleAttributes()},
+		"severities":                    types.SetType{ElemType: types.StringType},
+		"archive_retention_id":          types.StringType,
+		"dpxl_expression":               types.StringType,
+		"quota_based_priority_override": types.ObjectType{AttrTypes: quotaBasedPriorityOverrideAttributes()},
+	}
+}
+
+func quotaBasedPriorityOverrideAttributes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"usage_tiers": types.ListType{ElemType: types.ObjectType{AttrTypes: usageTierAttributes()}},
+	}
+}
+
+func usageTierAttributes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"daily_quota_percentage": types.Float64Type,
+		"priority":               types.StringType,
 	}
 }
 
@@ -577,6 +676,10 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 	if diags.HasError() {
 		return nil, diags
 	}
+	priorityOverride, diags := expandQuotaBasedPriorityOverride(ctx, plan.QuotaBasedPriorityOverride)
+	if diags.HasError() {
+		return nil, diags
+	}
 	enabled := !plan.Enabled.ValueBool()
 
 	return &tcoPolicys.CreateLogPolicyRequest{
@@ -588,9 +691,49 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 			SubsystemRule:    subsystemRule,
 			ArchiveRetention: archiveRetention,
 			Disabled:         &enabled,
+			PriorityOverride: priorityOverride,
 		},
 		LogRules: tcoPolicys.LogRules{
-			Severities: severities,
+			Severities:     severities,
+			DpxlExpression: plan.DpxlExpression.ValueStringPointer(),
+		},
+	}, nil
+}
+
+func expandQuotaBasedPriorityOverride(ctx context.Context, override types.Object) (*tcoPolicys.PriorityOverride, diag.Diagnostics) {
+	if override.IsNull() || override.IsUnknown() {
+		return nil, nil
+	}
+
+	var model QuotaBasedPriorityOverrideModel
+	if diags := override.As(ctx, &model, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return nil, diags
+	}
+
+	var tierObjects []types.Object
+	if diags := model.UsageTiers.ElementsAs(ctx, &tierObjects, true); diags.HasError() {
+		return nil, diags
+	}
+
+	tiers := make([]tcoPolicys.UsageTier, 0, len(tierObjects))
+	for _, to := range tierObjects {
+		var tm UsageTierModel
+		if diags := to.As(ctx, &tm, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return nil, diags
+		}
+		tier := tcoPolicys.UsageTier{
+			DailyQuotaPercentage: tm.DailyQuotaPercentage.ValueFloat64Pointer(),
+		}
+		if !tm.Priority.IsNull() && !tm.Priority.IsUnknown() {
+			p := tcoPoliciesPrioritySchemaToApi[tm.Priority.ValueString()]
+			tier.Priority = &p
+		}
+		tiers = append(tiers, tier)
+	}
+
+	return &tcoPolicys.PriorityOverride{
+		QuotaBased: &tcoPolicys.QuotaBased{
+			UsageTiers: tiers,
 		},
 	}, nil
 }

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -682,6 +682,13 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 	}
 	enabled := !plan.Enabled.ValueBool()
 
+	logRules := tcoPolicys.LogRules{}
+	if !plan.DpxlExpression.IsNull() && !plan.DpxlExpression.IsUnknown() {
+		logRules.DpxlExpression = plan.DpxlExpression.ValueStringPointer()
+	} else {
+		logRules.Severities = severities
+	}
+
 	return &tcoPolicys.CreateLogPolicyRequest{
 		Policy: tcoPolicys.CreateGenericPolicyRequest{
 			Name:             plan.Name.ValueString(),
@@ -693,10 +700,7 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 			Disabled:         &enabled,
 			PriorityOverride: priorityOverride,
 		},
-		LogRules: tcoPolicys.LogRules{
-			Severities:     severities,
-			DpxlExpression: plan.DpxlExpression.ValueStringPointer(),
-		},
+		LogRules: logRules,
 	}, nil
 }
 

--- a/internal/provider/resource_coralogix_tco_policies_logs_test.go
+++ b/internal/provider/resource_coralogix_tco_policies_logs_test.go
@@ -208,7 +208,7 @@ func TestAccCoralogixResourceTCOPoliciesLogs_dpxl_replaces_severities(t *testing
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.severities.#", "1"),
 					resource.TestCheckTypeSetElemAttr(tcoPoliciesResourceName, "policies.0.severities.*", "info"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.dpxl_expression", ""),
+					resource.TestCheckNoResourceAttr(tcoPoliciesResourceName, "policies.0.dpxl_expression"),
 				),
 			},
 			{

--- a/internal/provider/resource_coralogix_tco_policies_logs_test.go
+++ b/internal/provider/resource_coralogix_tco_policies_logs_test.go
@@ -153,3 +153,80 @@ policies = [{
 }
 	`
 }
+
+// TestAccCoralogixResourceTCOPoliciesLogs_dpxl_expression covers a TCO log policy
+// whose matcher is a DataPrime expression instead of severities. The two are
+// mutually exclusive at the API level, so this fixture omits severities entirely.
+func TestAccCoralogixResourceTCOPoliciesLogs_dpxl_expression(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceTCOPoliciesLogsDpxlExpression(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with DPXL expression"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "high"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.dpxl_expression", "<v1> $d.severity == 'INFO'"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.severities.#", "0"),
+				),
+			},
+		},
+	})
+}
+func TestAccCoralogixResourceTCOPoliciesLogs_quota_based_priority_override(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceTCOPoliciesLogsQuotaBasedOverride(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with quota-based override"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "high"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.quota_based_priority_override.usage_tiers.#", "2"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.quota_based_priority_override.usage_tiers.0.daily_quota_percentage", "50"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.quota_based_priority_override.usage_tiers.0.priority", "medium"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.quota_based_priority_override.usage_tiers.1.daily_quota_percentage", "80"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.quota_based_priority_override.usage_tiers.1.priority", "low"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsDpxlExpression() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name            = "Example tco_policy with DPXL expression"
+      description     = "DPXL-based matcher for the TCO policy"
+      priority        = "high"
+      dpxl_expression = "<v1> $d.severity == 'INFO'"
+    },
+  ]
+}
+`
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsQuotaBasedOverride() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name        = "Example tco_policy with quota-based override"
+      description = "Dynamic priority reassignment based on daily quota tiers"
+      priority    = "high"
+      severities  = ["info", "warning"]
+      quota_based_priority_override = {
+        usage_tiers = [
+          { daily_quota_percentage = 50, priority = "medium" },
+          { daily_quota_percentage = 80, priority = "low" },
+        ]
+      }
+    },
+  ]
+}
+`
+}

--- a/internal/provider/resource_coralogix_tco_policies_logs_test.go
+++ b/internal/provider/resource_coralogix_tco_policies_logs_test.go
@@ -197,6 +197,57 @@ func TestAccCoralogixResourceTCOPoliciesLogs_quota_based_priority_override(t *te
 	})
 }
 
+func TestAccCoralogixResourceTCOPoliciesLogs_dpxl_replaces_severities(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceTCOPoliciesLogsSeveritiesOnly(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.severities.#", "1"),
+					resource.TestCheckTypeSetElemAttr(tcoPoliciesResourceName, "policies.0.severities.*", "info"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.dpxl_expression", ""),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceTCOPoliciesLogsDpxlOnly(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.dpxl_expression", "<v1> $d.severity == 'INFO'"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.severities.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsSeveritiesOnly() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name        = "Example tco_policy migration"
+      priority    = "high"
+      severities  = ["info"]
+    },
+  ]
+}
+`
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsDpxlOnly() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name            = "Example tco_policy migration"
+      priority        = "high"
+      dpxl_expression = "<v1> $d.severity == 'INFO'"
+    },
+  ]
+}
+`
+}
+
 func testAccCoralogixResourceTCOPoliciesLogsDpxlExpression() string {
 	return `resource "coralogix_tco_policies_logs" "test" {
   policies = [


### PR DESCRIPTION
## Summary

  Adds two new fields to `coralogix_tco_policies_logs` to support advanced routing capabilities introduced upstream ([CX-40070](https://coralogix.atlassian.net/browse/CX-40070)):

  - **`dpxl_expression`** — a DataPrime expression that can match logs for the policy as an *alternative* to `severities`. Mutually exclusive with `severities` (the API enforces; the provider mirrors via a `ConflictsWith` validator).
  - **`quota_based_priority_override`** — dynamically reassign the policy's priority based on daily quota consumption tiers. Each tier specifies a `daily_quota_percentage` (0–100, API-enforced) and a `priority`.

  The data source `coralogix_tco_policies_logs` inherits both fields automatically through its existing schema delegation.

  ## Use case

  DPXL gives users a more expressive matcher than the fixed severity enum. Quota-based override lets users keep traffic flowing under a lower priority bucket once a daily quota is exceeded, rather than dropping logs on the floor.

  ## Design notes

  - **DPXL ↔ severities mutual exclusion** is enforced at plan time via `stringvalidator.ConflictsWith`. This was *not* derivable from the proto: the proto allows both fields independently, and `openapiv3_schema.required:["severities"]`
   is a JSON-schema doc hint, not a runtime constraint. The actual rule was discovered by probing the API. (Would be cleaner long-term if the proto encoded this — separate thread with the backend team to discuss `oneof` or
  `buf.validate`.)
  - **`daily_quota_percentage` bound** is `[0, 100]`, enforced server-side (`each usageTier.dailyQuotaPercentage must be between 0 and 100`). Mirrored as `float64validator.Between(0, 100)`.
  - **`priority_override` is a proto `oneof`** with only `quota_based` defined today. The schema flattens past the wrapper for now; if the API adds another variant, a sibling attribute alongside `quota_based_priority_override` keeps the
   door open without restructuring this one. A code comment notes this.
  - **DPXL expressions need a version prefix** (e.g. `<v1> ...`); bare expressions are rejected at API compile time. The schema description calls this out so users don't trip the same way I did.

  ## Empirical validation

  Probed every combination against EU2 before encoding the validators:

  | Scenario | Outcome | Encoded as |
  |---|---|---|
  | severities + dpxl_expression | API rejects (`Cannot provide both`) | `ConflictsWith` |
  | dpxl_expression only (`<v1>` prefix) | API accepts | (no extra constraint) |
  | severities + quota_based_priority_override | API accepts | (structural correctness confirmed) |
  | daily_quota_percentage = 150 | API rejects (`must be between 0 and 100`) | `Float64Validator.Between(0, 100)` |

  ## Is this a breaking change?

  **No.** Both fields are optional and additive. Existing configs using `severities` keep working unchanged. The `ConflictsWith` only fires when a user explicitly sets both DPXL and severities, which is a configuration that previously
  failed at apply-time anyway — now it fails earlier with a clearer message.

  ## Changes

  | File | Change |
  |---|---|
  | `internal/provider/dataplans/resource_coralogix_tco_policies_logs.go` | Add `dpxl_expression` and `quota_based_priority_override` to schema and `TCOPolicyLogsModel`. New model structs `QuotaBasedPriorityOverrideModel`,
  `UsageTierModel`. New helpers `expandQuotaBasedPriorityOverride`, `flattenQuotaBasedPriorityOverride`, `quotaBasedPriorityOverrideAttributes`, `usageTierAttributes`. Extractor and flatten updated to round-trip both fields. Imports
  `float64validator` and `listvalidator`. |
  | `internal/provider/resource_coralogix_tco_policies_logs_test.go` | Add `TestAccCoralogixResourceTCOPoliciesLogs_dpxl_expression` and `TestAccCoralogixResourceTCOPoliciesLogs_quota_based_priority_override`. |
  | `examples/resources/coralogix_tco_policies_logs/resource.tf` | Append two example policies showing DPXL and quota-based override. |
  | `docs/resources/tco_policies_logs.md` | Auto-regenerated by `make generate`. |
  | `docs/data-sources/tco_policies_logs.md` | Auto-regenerated. |

  ## Test plan

  - [x] Manually validated all four scenarios above against EU2 before encoding validators.
  - [x] `go build ./...` clean.
  - [x] `go vet ./internal/provider/...` clean.
  - [x] `make generate` produced clean docs reflecting both fields with full descriptions.
  - [ ] `TestAccCoralogixResourceTCOPoliciesLogs_dpxl_expression` — new acceptance test, exercises DPXL-only path.
  - [ ] `TestAccCoralogixResourceTCOPoliciesLogs_quota_based_priority_override` — new acceptance test, exercises the nested usage_tiers structure.
  - [ ] Existing `TestAccCoralogixResourceTCOPoliciesLogsCreate` continues to pass (no schema regressions for severity-based policies).

  ### Acceptance tests
  - [x] Have you added an acceptance test for the functionality being added?
  - [ ] Have you run the acceptance tests on this branch?

  Output from acceptance testing:

  ```
  $ make testacc TESTARGS='-run=TestAccCoralogixResourceTCOPoliciesLogs'

  (populated after CI run)
  ```

  ### Release Note

  ```release-note
  features:

  #### resource/coralogix_tco_policies_logs

  * `dpxl_expression`: route logs via a DataPrime expression instead of severities (mutually exclusive with `severities`; expressions need a `<v1>` version prefix).
  * `quota_based_priority_override`: dynamically reassign the policy's priority based on daily quota consumption tiers (`daily_quota_percentage` between 0 and 100, plus a `priority`).
  ```

  ### References

  - Parent epic: CX-40069 (Terraform provider support for DPXL and quota-based routing).
  - Upstream protos:
    - `cx-management-apis/proto/com/coralogix/quota/v1/log_rules.proto`
    - `cx-management-apis/proto/com/coralogix/quota/v1/priority_override.proto`
  - Related backend thread (separately raised): the proto does not encode the DPXL/severities mutual exclusion — discussing whether to add a `oneof` or `buf.validate` rule upstream so all SDKs see the constraint.

  ### Community Note
  * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
  * If you are interested in working on this issue or have submitted a pull request, please leave a comment

[CX-40070]: https://coralogix.atlassian.net/browse/CX-40070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ