### PR TITLE
fix(BUGV2-1291): accept observation_field in logs aggregation validator

### DIFF
--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -850,10 +850,19 @@ func (l logsAggregationValidator) ValidateObject(ctx context.Context, req valida
 	}
 
 	aggregationType := aggregation.Type.ValueString()
-	if aggregationType == "count" && !aggregation.Field.IsNull() {
-		resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", "when type is `count`, `field` cannot be set"))
-	} else if aggregationType != "count" && aggregation.Field.IsNull() {
-		resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", fmt.Sprintf("when type is `%s`, `field` must be set", aggregationType)))
+	fieldSet := !aggregation.Field.IsNull()
+	observationFieldSet := !aggregation.ObservationField.IsNull()
+
+	if aggregationType == "count" {
+		if fieldSet || observationFieldSet {
+			resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", "when type is `count`, neither `field` nor `observation_field` can be set"))
+		}
+	} else {
+		if !fieldSet && !observationFieldSet {
+			resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", fmt.Sprintf("when type is `%s`, either `field` or `observation_field` must be set", aggregationType)))
+		} else if fieldSet && observationFieldSet {
+			resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", fmt.Sprintf("when type is `%s`, `field` and `observation_field` are mutually exclusive — set exactly one", aggregationType)))
+		}
 	}
 
 	if aggregationType == "percentile" && aggregation.Percent.IsNull() {

--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -849,25 +849,34 @@ func (l logsAggregationValidator) ValidateObject(ctx context.Context, req valida
 		return
 	}
 
+	if aggregation.Type.IsNull() || aggregation.Type.IsUnknown() {
+		return
+	}
+
 	aggregationType := aggregation.Type.ValueString()
-	fieldSet := !aggregation.Field.IsNull()
-	observationFieldSet := !aggregation.ObservationField.IsNull()
+	fieldKnownSet := !aggregation.Field.IsNull() && !aggregation.Field.IsUnknown()
+	fieldKnownUnset := aggregation.Field.IsNull()
+	obsKnownSet := !aggregation.ObservationField.IsNull() && !aggregation.ObservationField.IsUnknown()
+	obsKnownUnset := aggregation.ObservationField.IsNull()
 
 	if aggregationType == "count" {
-		if fieldSet || observationFieldSet {
+		if fieldKnownSet || obsKnownSet {
 			resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", "when type is `count`, neither `field` nor `observation_field` can be set"))
 		}
 	} else {
-		if !fieldSet && !observationFieldSet {
+		if fieldKnownUnset && obsKnownUnset {
 			resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", fmt.Sprintf("when type is `%s`, either `field` or `observation_field` must be set", aggregationType)))
-		} else if fieldSet && observationFieldSet {
+		} else if fieldKnownSet && obsKnownSet {
 			resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", fmt.Sprintf("when type is `%s`, `field` and `observation_field` are mutually exclusive — set exactly one", aggregationType)))
 		}
 	}
 
-	if aggregationType == "percentile" && aggregation.Percent.IsNull() {
+	percentKnownSet := !aggregation.Percent.IsNull() && !aggregation.Percent.IsUnknown()
+	percentKnownUnset := aggregation.Percent.IsNull()
+
+	if aggregationType == "percentile" && percentKnownUnset {
 		resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", "when type is `percentile`, `percent` must be set"))
-	} else if aggregationType != "percentile" && !aggregation.Percent.IsNull() {
+	} else if aggregationType != "percentile" && percentKnownSet {
 		resp.Diagnostics.Append(diag.NewErrorDiagnostic("logs aggregation validation failed", fmt.Sprintf("when type is `%s`, `percent` cannot be set", aggregationType)))
 	}
 }

--- a/internal/provider/dashboards/dashboard_widgets/common_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/common_test.go
@@ -54,6 +54,15 @@ func TestLogsAggregationValidator(t *testing.T) {
 		{name: "percentile_field_and_percent", aggType: "percentile", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Value(95)},
 		{name: "percentile_missing_percent", aggType: "percentile", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Null(), wantErr: "`percent` must be set"},
 		{name: "avg_with_percent", aggType: "avg", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Value(50), wantErr: "`percent` cannot be set"},
+
+		// Unknown values must not trigger false positives — they may resolve to either set or null.
+		{name: "avg_unknown_field_null_obs", aggType: "avg", field: types.StringUnknown(), observationField: nullObservationField, percent: types.Float64Null()},
+		{name: "avg_null_field_unknown_obs", aggType: "avg", field: types.StringNull(), observationField: types.ObjectUnknown(ObservationFieldAttr()), percent: types.Float64Null()},
+		{name: "avg_known_field_unknown_obs", aggType: "avg", field: types.StringValue("foo"), observationField: types.ObjectUnknown(ObservationFieldAttr()), percent: types.Float64Null()},
+		{name: "count_unknown_field", aggType: "count", field: types.StringUnknown(), observationField: nullObservationField, percent: types.Float64Null()},
+		{name: "count_unknown_obs", aggType: "count", field: types.StringNull(), observationField: types.ObjectUnknown(ObservationFieldAttr()), percent: types.Float64Null()},
+		{name: "percentile_unknown_percent", aggType: "percentile", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Unknown()},
+		{name: "avg_unknown_percent", aggType: "avg", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Unknown()},
 	}
 
 	for _, tc := range cases {

--- a/internal/provider/dashboards/dashboard_widgets/common_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/common_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_widgets
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestLogsAggregationValidator(t *testing.T) {
+	someObservationField := types.ObjectValueMust(ObservationFieldAttr(), map[string]attr.Value{
+		"keypath": types.ListValueMust(types.StringType, []attr.Value{types.StringValue("meta"), types.StringValue("responseTime")}),
+		"scope":   types.StringValue("user_data"),
+	})
+	nullObservationField := types.ObjectNull(ObservationFieldAttr())
+
+	cases := []struct {
+		name             string
+		aggType          string
+		field            types.String
+		observationField types.Object
+		percent          types.Float64
+		wantErr          string // empty = expect no error; otherwise must be substring of diagnostic
+	}{
+		{name: "count_no_field", aggType: "count", field: types.StringNull(), observationField: nullObservationField, percent: types.Float64Null()},
+		{name: "count_with_field", aggType: "count", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Null(), wantErr: "neither `field` nor `observation_field`"},
+		{name: "count_with_observation_field", aggType: "count", field: types.StringNull(), observationField: someObservationField, percent: types.Float64Null(), wantErr: "neither `field` nor `observation_field`"},
+
+		{name: "avg_neither", aggType: "avg", field: types.StringNull(), observationField: nullObservationField, percent: types.Float64Null(), wantErr: "either `field` or `observation_field` must be set"},
+		{name: "avg_field_only", aggType: "avg", field: types.StringValue("meta.responseTime.numeric"), observationField: nullObservationField, percent: types.Float64Null()},
+		{name: "avg_observation_field_only", aggType: "avg", field: types.StringNull(), observationField: someObservationField, percent: types.Float64Null()},
+		{name: "avg_both_set", aggType: "avg", field: types.StringValue("foo"), observationField: someObservationField, percent: types.Float64Null(), wantErr: "mutually exclusive"},
+
+		{name: "sum_observation_field_only", aggType: "sum", field: types.StringNull(), observationField: someObservationField, percent: types.Float64Null()},
+		{name: "count_distinct_field_only", aggType: "count_distinct", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Null()},
+
+		{name: "percentile_field_and_percent", aggType: "percentile", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Value(95)},
+		{name: "percentile_missing_percent", aggType: "percentile", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Null(), wantErr: "`percent` must be set"},
+		{name: "avg_with_percent", aggType: "avg", field: types.StringValue("foo"), observationField: nullObservationField, percent: types.Float64Value(50), wantErr: "`percent` cannot be set"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := types.ObjectValueMust(AggregationModelAttr(), map[string]attr.Value{
+				"type":              types.StringValue(tc.aggType),
+				"field":             tc.field,
+				"percent":           tc.percent,
+				"observation_field": tc.observationField,
+			})
+
+			req := validator.ObjectRequest{ConfigValue: cfg}
+			resp := &validator.ObjectResponse{}
+			logsAggregationValidator{}.ValidateObject(context.Background(), req, resp)
+
+			if tc.wantErr == "" {
+				if resp.Diagnostics.HasError() {
+					t.Fatalf("expected no error, got: %s", resp.Diagnostics.Errors())
+				}
+				return
+			}
+
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("expected error containing %q, got none", tc.wantErr)
+			}
+			joined := ""
+			for _, d := range resp.Diagnostics.Errors() {
+				joined += d.Summary() + ": " + d.Detail() + "\n"
+			}
+			if !strings.Contains(joined, tc.wantErr) {
+				t.Fatalf("expected error containing %q, got:\n%s", tc.wantErr, joined)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
### Description

`logsAggregationValidator` rejects any logs-aggregation block that uses `observation_field` instead of `field`, even though the schema declares both as `Optional` and `ExpandLogsAggregation` already passes either to the SDK. Configurations like

```hcl
aggregation = {
  type = "avg"
  observation_field = {
    keypath = ["meta", "responseTime"]
    scope   = "user_data"
  }
}
```

fail at plan time with `logs aggregation validation failed: when type is 'avg', 'field' must be set`. That's a self-inconsistency — the validator forbids what the rest of the provider accepts.

The behaviour change in `logsAggregationValidator.ValidateObject`:

| `type` | Before | After |
|---|---|---|
| `count` | error if `field` is set | error if `field` *or* `observation_field` is set |
| non-count | error if `field` is null | error only if **both** `field` and `observation_field` are null |
| any non-count | (no check) | error if both are set (mutually exclusive) |
| `percentile` | unchanged | unchanged |

Error messages now name `observation_field` so users see the alternative.

### Customer context
The customer in BUGV2-1291 hit drift where the API echoed `field = "meta.responseTime.numeric"` back as `observation_field = {keypath = ["meta", "responseTime"], scope = "user_data"}` (segment dropped). They tried to fix the drift by switching their config to `observation_field`, but the validator blocked the attempt.

This PR is intentionally scoped to the validator. The drift root cause is server-side (dashboards-api dropping the `.numeric` segment) and is being followed up with that team separately.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
  - Added a unit test for the validator (`internal/provider/dashboards/dashboard_widgets/common_test.go`, 12 cases). A full acceptance test is intentionally not added — it would entangle with the server-side round-trip drift this PR does not fix and would flake when the backend is corrected.
- [x] Have you run the acceptance tests on this branch?
  - Unit tests pass:
    ```
    $ go test ./internal/provider/dashboards/dashboard_widgets/ -run TestLogsAggregationValidator -v
    ...
    --- PASS: TestLogsAggregationValidator (0.00s)
    ```
  - Local `terraform plan` against EU2 with `observation_field` for an `avg` aggregation succeeds where it previously errored.

### Release Note
```release-note
fix(dashboards): allow `observation_field` as an alternative to `field` in logs aggregations (BUGV2-1291)
```