### PR TITLE
feat: improve 2 skill definitions (create-pr, manual-validation-harness)

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: PR description structure for non-trivial bug fixes in this repo. Follows the .github/PULL_REQUEST_TEMPLATE.md skeleton but expands the Description body with deeper sections. Trigger phrases: "create a PR", "open a PR", "draft the PR description".
+description: "Use when creating a PR for a non-trivial bug fix in this repo. Assembles a structured PR description following .github/PULL_REQUEST_TEMPLATE.md with expanded sections for root cause, risks, and test plan. Do NOT use for trivial one-liner fixes."
 ---
 
 # Create PR

--- a/.claude/skills/manual-validation-harness/SKILL.md
+++ b/.claude/skills/manual-validation-harness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manual-validation-harness
-description: When validating a coralogix terraform-provider bug fix end-to-end against a real Coralogix env. Triggers on "test the fix locally", "reproduce the bug", "validate before merge".
+description: "Use when validating a Coralogix terraform-provider bug fix end-to-end against a real Coralogix environment. Builds the provider locally, runs multi-step Terraform apply/plan scenarios to verify idempotency, and catches perpetual-diff regressions before merge."
 ---
 
 # Manual end-to-end validation


### PR DESCRIPTION
Hey @coralogix 👋

I ran your skills through `tessl skill review` at work and found targeted improvements in your skills. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| create-pr | 10% | 100% | +90% |
| manual-validation-harness | 73% | 94% | +21% |

These were easy changes to bring the skill's structure and activation in line with what performs well against Anthropic's best practices.

<details>
<summary>What changed in create-pr</summary>

The description contained unquoted colons that broke YAML parsing, causing the 10% score. Rewrote as a properly quoted string with a "Use when" clause. All skill body content preserved.

</details>

<details>
<summary>What changed in manual-validation-harness</summary>

Rewrote the description with a "Use when" clause and concrete capabilities (builds provider locally, runs multi-step Terraform apply/plan scenarios, catches perpetual-diff regressions). All procedure steps and gotchas preserved.

</details>

In addition, I stress-tested your [`manual-validation-harness` skill against a few real-world scenarios](https://tessl.io/registry/skills/github/coralogix/terraform-provider-coralogix/manual-validation-harness/evals), and it held up really well. This means that your skill meaningfully improves agent steering and contributes to stronger output quality. Kudos for that!

Honest disclosure, I work at @tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

If you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@rohan-tessl](https://github.com/rohan-tessl), if you hit any snags.
