### PR TITLE
 fix(BUGV2-4807): suppress case-only drift on coralogix_user.user_name

### DIFF
--- a/internal/provider/aaa/resource_coralogix_user.go
+++ b/internal/provider/aaa/resource_coralogix_user.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
@@ -81,8 +82,13 @@ func (r *UserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				MarkdownDescription: "User ID.",
 			},
 			"user_name": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "User name.",
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					caseInsensitiveStringPlanModifier{},
+				},
+				MarkdownDescription: "User name (email). Comparison is case-insensitive: SSO " +
+					"login can normalize letter case in the backend, and that normalization " +
+					"will not trigger drift in subsequent plans.",
 			},
 			"name": schema.SingleNestedAttribute{
 				Optional: true,
@@ -314,10 +320,15 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	if plan.UserName.ValueString() != state.UserName.ValueString() {
+	if !strings.EqualFold(plan.UserName.ValueString(), state.UserName.ValueString()) {
 		resp.Diagnostics.AddError(
 			"User name cannot be updated",
-			"User name is immutable and cannot be updated",
+			fmt.Sprintf(
+				"Cannot change user_name from %q to %q. user_name is set at creation and "+
+					"cannot be updated in place. To assign this resource to a different user, "+
+					"recreate it (terraform state rm + apply, or `terraform state mv`).",
+				state.UserName.ValueString(), plan.UserName.ValueString(),
+			),
 		)
 		return
 	}
@@ -500,4 +511,23 @@ func extractUserEmails(ctx context.Context, emails types.Set) ([]cxsdk.SCIMUserE
 	}
 
 	return expandedEmails, diags
+}
+
+type caseInsensitiveStringPlanModifier struct{}
+
+func (caseInsensitiveStringPlanModifier) Description(_ context.Context) string {
+	return "Treats the value as case-insensitive — suppresses diffs that only change letter case."
+}
+
+func (m caseInsensitiveStringPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (caseInsensitiveStringPlanModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.IsNull() || req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+	if strings.EqualFold(req.StateValue.ValueString(), req.PlanValue.ValueString()) {
+		resp.PlanValue = req.StateValue
+	}
 }

--- a/internal/provider/aaa/resource_coralogix_user_test.go
+++ b/internal/provider/aaa/resource_coralogix_user_test.go
@@ -1,0 +1,95 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aaa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestCaseInsensitiveStringPlanModifier(t *testing.T) {
+	cases := []struct {
+		name      string
+		state     types.String
+		plan      types.String
+		wantPlan  types.String
+		wantEqual bool // assert resp.PlanValue == state (i.e. modifier suppressed the diff)
+	}{
+		{
+			name:      "case_only_difference_uses_state",
+			state:     types.StringValue("Alice.Example@example.com"),
+			plan:      types.StringValue("alice.example@example.com"),
+			wantEqual: true,
+		},
+		{
+			name:      "exact_match_uses_state",
+			state:     types.StringValue("alice.example@example.com"),
+			plan:      types.StringValue("alice.example@example.com"),
+			wantEqual: true,
+		},
+		{
+			name:      "different_value_passes_through",
+			state:     types.StringValue("alice.example@example.com"),
+			plan:      types.StringValue("bob.other@example.com"),
+			wantPlan:  types.StringValue("bob.other@example.com"),
+			wantEqual: false,
+		},
+		{
+			name:      "null_state_passes_through",
+			state:     types.StringNull(),
+			plan:      types.StringValue("alice.example@example.com"),
+			wantPlan:  types.StringValue("alice.example@example.com"),
+			wantEqual: false,
+		},
+		{
+			name:      "null_plan_passes_through",
+			state:     types.StringValue("alice.example@example.com"),
+			plan:      types.StringNull(),
+			wantPlan:  types.StringNull(),
+			wantEqual: false,
+		},
+		{
+			name:      "unknown_plan_passes_through",
+			state:     types.StringValue("alice.example@example.com"),
+			plan:      types.StringUnknown(),
+			wantPlan:  types.StringUnknown(),
+			wantEqual: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := planmodifier.StringRequest{
+				StateValue: tc.state,
+				PlanValue:  tc.plan,
+			}
+			resp := &planmodifier.StringResponse{PlanValue: tc.plan}
+			caseInsensitiveStringPlanModifier{}.PlanModifyString(context.Background(), req, resp)
+
+			if tc.wantEqual {
+				if !resp.PlanValue.Equal(tc.state) {
+					t.Fatalf("expected PlanValue to equal state %v, got %v", tc.state, resp.PlanValue)
+				}
+				return
+			}
+			if !resp.PlanValue.Equal(tc.wantPlan) {
+				t.Fatalf("expected PlanValue %v, got %v", tc.wantPlan, resp.PlanValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes [BUGV2-4807](https://coralogix.atlassian.net/browse/BUGV2-4807)
### Description

If a user logs in with an email that has different capitalization than what's in your Terraform config, Coralogix updates the stored email to match — and the provider used to crash on the next plan trying to "fix" it back. Now it just
  ignores the case difference, so your apply doesn't break.
  
  `coralogix_user` crashes when the backend normalizes letter case on `user_name` (typically after a user verifies their email and logs in via SSO with different casing than their config). The next plan shows drift, apply errors:

  ```
  Error: User name cannot be updated
  ```

  The error comes from an exact-string compare in `Update` (`internal/provider/aaa/resource_coralogix_user.go`). Fix is purely client-side:

  1. Add a `caseInsensitiveStringPlanModifier` on `user_name`. When state and config differ only in letter case, the modifier pins the planned value to state — Terraform sees no diff and `Update` is never invoked.
  2. Soften the `Update` error message to include the from→to values and recovery guidance.
  3. Update schema description to document the case-insensitive behavior.

  Backend continues to preserve case in storage and over the wire; the provider doesn't normalize anything, only ignores case in diff calculation. Real email changes (different content) still pass through and trigger the existing
  immutability guard.

  ### Acceptance tests
  - [x] Have you added an acceptance test for the functionality being added?
  - [x] Have you run the acceptance tests on this branch?

  Unit test on the plan modifier (`internal/provider/aaa/resource_coralogix_user_test.go`, 6 cases). No TF acceptance test — the trigger requires a real SSO login that mutates `user_name` server-side, too unstable for CI. Verified
  end-to-end manually by hand-editing `terraform.tfstate` to capitalize `user_name` and running `terraform plan -refresh=false`: drift on `master`, `No changes` on this branch.

  Output from acceptance testing:

  ```
  $ make testacc TESTARGS='-run=TestCaseInsensitiveStringPlanModifier'

  --- PASS: TestCaseInsensitiveStringPlanModifier (0.00s)
  PASS
  ok    github.com/coralogix/terraform-provider-coralogix/internal/provider/aaa
  ```

  ### Release Note

  ```release-note
  fix(coralogix_user): treat user_name as case-insensitive — backend case normalization (e.g. on SSO login) no longer causes spurious drift or apply errors (BUGV2-4807)
  ```

  ### References

  BUGV2-4807

  ### Community Note
  * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
  * If you are interested in working on this issue or have submitted a pull request, please leave a comment

[BUGV2-4807]: https://coralogix.atlassian.net/browse/BUGV2-4807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ