### PR TITLE
 chore(skills): tighten conventions and exempt docs from heavy CI

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: PR description structure for non-trivial bug fixes in this repo. Follows the .github/PULL_REQUEST_TEMPLATE.md skeleton but expands the Description body with deeper sections. Trigger phrases: "create a PR", "open a PR", "draft the PR description".
+description: "Use when creating a PR for a non-trivial bug fix in this repo. Assembles a structured PR description following .github/PULL_REQUEST_TEMPLATE.md with expanded sections for root cause, risks, and test plan. Do NOT use for trivial one-liner fixes."
 ---
 
 # Create PR

--- a/.claude/skills/manual-validation-harness/SKILL.md
+++ b/.claude/skills/manual-validation-harness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manual-validation-harness
-description: When validating a coralogix terraform-provider bug fix end-to-end against a real Coralogix env. Triggers on "test the fix locally", "reproduce the bug", "validate before merge".
+description: "Use when validating a Coralogix terraform-provider bug fix end-to-end against a real Coralogix environment. Builds the provider locally, runs multi-step Terraform apply/plan scenarios to verify idempotency, and catches perpetual-diff regressions before merge."
 ---
 
 # Manual end-to-end validation

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '.claude/**'
+      - '.cursor/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '**/*.md'
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@
 name: release
 on:
   pull_request:
+    paths-ignore:
+      - '.claude/**'
+      - '.cursor/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '**/*.md'
   workflow_dispatch:
   workflow_run:
     workflows: ["semantic-release"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,44 @@ Both implementations live in `internal/provider/provider.go`. To add a new resou
 
 `.pre-commit-config.yaml` runs `gofmt`, `goimports`, `go vet`, `golangci-lint`, `go-cyclo` (limit 15), `go-mod-tidy`, `go-build`, and `go-unit-tests` on every commit.
 
+## Adding API support / SDK considerations
+
+The provider depends on the public Go SDK at [`coralogix/coralogix-management-sdk`](https://github.com/coralogix/coralogix-management-sdk). That SDK is the authoritative surface for "is this API field available to me?".
+
+**To check whether a field exists in the pinned SDK:**
+
+```bash
+grep coralogix-management-sdk go.mod                       # find pinned version
+grep -rn "FieldName" ~/go/pkg/mod/github.com/coralogix/coralogix-management-sdk@<version>/go/openapi/gen/<service>/
+```
+
+If the SDK's generated Go types don't include the field, an SDK release has to land first. If they do, wire the schema, model, extractor, and flatten in the relevant `internal/provider/<domain>/` package.
+
+When the resource has a paired data source (`data_source_*.go`), check whether it delegates to the resource's `Schema()` method — many in this repo do, which means new attributes flow through automatically. Quick check: `grep "var r.*Resource" internal/provider/<domain>/data_source_*.go`.
+
+**Verify empirically.** API behaviour can diverge from what the SDK's generated Go types suggest — runtime business rules (mutual exclusion, value bounds, defaults) often aren't expressed in the types. Always test against a real environment before encoding constraints in the schema. Wrong validators that block valid configs are harder to undo than missing ones. Examples that surfaced in this codebase:
+
+- `LogRules.dpxl_expression` and `LogRules.severities` are mutually exclusive at the API even though the Go types don't enforce it.
+- `UsageTier.daily_quota_percentage` is bounded to `0–100` even though the Go type is plain `float64`.
+
+### Coralogix expression languages use a `<v1>` version prefix
+
+Fields that take expressions — `coralogix_tco_policies_logs.dpxl_expression`, `coralogix_scope.default_expression`, `coralogix_scope.filters[*].expression` — require a version tag at the start of the string (e.g. `<v1> $d.severity == 'INFO'`, `<v1>true`). Bare expressions are rejected at API compile time. When adding a new expression-typed field, mention the prefix in `MarkdownDescription` and include it in test fixtures.
+
+### Bumping the SDK in `go.mod`
+
+A bump usually requires adapting many resource files to the new SDK API surface (renamed types, changed signatures). PR #506 touched 17 resource files alongside `go.mod`. That's expected — bundle the bump and the adaptations in the same PR; they're not separable. After the bump: `go mod tidy && go build ./... && go vet ./...`, then the relevant `make testacc` runs to catch behaviour drift the compiler can't.
+
+## Public-repo discipline
+
+This is a public repo (`coralogix/terraform-provider-coralogix`). Internal ticket identifiers (`BUGV2-`, `CX-`, etc.) belong in **commit messages, PR descriptions, and branch names** — not in committed code, comments, doc strings, test fixtures, or example HCL. Use descriptive names instead.
+
+A simple grep before committing catches leakage:
+
+```bash
+git diff master.. -- internal docs examples | grep -iE "BUGV2-|CX-[0-9]" || echo "✓ none"
+```
+
 ## Skill maintenance (dynamic)
 
 Project skills live at `.claude/skills/<skill-name>/SKILL.md`. The directory is symlinked from `.cursor/skills` so Cursor users discover the same files; if a future tool needs them, add a similar symlink for that tool's convention rather than duplicating files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Treat the skills directory as a living knowledge base — when a bug fix or issu
 ```markdown
 ---
 name: <kebab-case-name>
-description: <one sentence — concrete triggers Claude matches against (resource names, error strings, file paths)>
+description: "Use when <concrete trigger — resource names, error strings, file paths, scenarios>. <One short clause on what it does.> Do NOT use for <obvious anti-pattern, when relevant>."
 ---
 
 # <Title>
@@ -88,7 +88,14 @@ description: <one sentence — concrete triggers Claude matches against (resourc
 **Why:** <one sentence — the underlying reason, so future-you can judge edge cases>
 ```
 
+**Description format** (frontmatter):
+- Always quote the value (single line, in `"…"`). Strict YAML parsers choke on unquoted descriptions that contain colons, parentheses, or other punctuation.
+- Start with `Use when …` so it matches the documented Anthropic Skills convention and other agents (Cursor, Codex) discover it consistently.
+- Keep under ~200 characters. The description is what tools match against to decide relevance — be specific and concrete, avoid filler.
+
 **Naming:** kebab-case, scoped to the problem, not the resource (e.g., `framework-plan-modifier-for-set-of-objects`, not `fix-alert-bug-2026-04`). A good name reads like an index entry.
+
+**Public surface:** `.claude/skills/` is checked into a public repo and indexed by external tooling. No customer names, no internal-only ticket bodies, no non-public URLs. Treat skills like docs you'd be comfortable showing to anyone who reads the repo.
 
 **Workflow at end of a bug-fix session:**
 1. Ask: "did I just learn something a fresh Claude wouldn't?"


### PR DESCRIPTION

  ### Description

  Bundles three small skill-maintenance improvements:

  1. **Skill frontmatter cleanup** — adopt the documented `"Use when …"` Anthropic Skills convention and quote descriptions to keep strict YAML parsers happy. Reapplies the change @rohan-tessl proposed in #519 (couldn't merge directly —
  branch protection requires verified signatures and fork PRs aren't signed). Skill bodies unchanged.
  2. **CLAUDE.md skill conventions** — document the frontmatter format (quoted, `"Use when …"` prefix, ≤200 chars) and add a "public surface" note so future contributors know `.claude/skills/` is publicly indexed (no customer names, no
  internal URLs).
  3. **Workflow `paths-ignore`** — skip Acceptance Tests and Release workflows on PRs that only touch docs / agent metadata. Fixes the false-positive failures #519 hit.

  ### Acceptance tests
  - [ ] Have you added an acceptance test for the functionality being added?
  - [ ] Have you run the acceptance tests on this branch?

  Skill / docs / CI-config only — no provider behavior change. The `paths-ignore` filters mean those workflows now intentionally don't run on this PR.

  ### Release Note

  ```release-note
  NONE

  References

  Closes #519 (re-applied with signed commit).