### PR TITLE
fix(BUGV2-6012): stop coralogix_parsing_rules.Update from duplicating rule groups

### DIFF
--- a/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
+++ b/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
@@ -441,15 +441,16 @@ func (r *ParsingRulesResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
+	id := plan.ID.ValueString()
 	rq := extractParsingRules(plan)
 
 	result, httpResponse, err := r.client.
-		RuleGroupsServiceCreateRuleGroup(ctx).
+		RuleGroupsServiceUpdateRuleGroup(ctx, id).
 		RuleGroupsServiceCreateRuleGroupRequest(*rq).
 		Execute()
 	if err != nil {
-		resp.Diagnostics.AddError("Error replacing coralogix_parsing_rules",
-			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Create", rq),
+		resp.Diagnostics.AddError("Error updating coralogix_parsing_rules",
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Update", rq),
 		)
 		return
 	}

--- a/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
+++ b/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
@@ -34,8 +34,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -260,8 +262,10 @@ func (r *ParsingRulesResource) Schema(_ context.Context, _ resource.SchemaReques
 		Version: 0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
@@ -441,13 +445,7 @@ func (r *ParsingRulesResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	var priorState *ParsingRulesModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	id := priorState.ID.ValueString()
+	id := plan.ID.ValueString()
 	rq := extractParsingRules(plan)
 
 	result, httpResponse, err := r.client.

--- a/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
+++ b/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
@@ -441,7 +441,13 @@ func (r *ParsingRulesResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	id := plan.ID.ValueString()
+	var priorState *ParsingRulesModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := priorState.ID.ValueString()
 	rq := extractParsingRules(plan)
 
 	result, httpResponse, err := r.client.

--- a/internal/provider/resource_coralogix_parsing_rules_test.go
+++ b/internal/provider/resource_coralogix_parsing_rules_test.go
@@ -558,6 +558,7 @@ func TestAccCoralogixResourceParsingRules_update(t *testing.T) {
 	r1 := getRandomParsingRule()
 	r2 := getRandomParsingRule()
 	resourceName := "coralogix_parsing_rules.test"
+	var ruleID string
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -578,6 +579,7 @@ func TestAccCoralogixResourceParsingRules_update(t *testing.T) {
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.0.parse.name", "rule1"),
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.1.extract.name", "rule2"),
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.2.parse.name", "rule3"),
+					captureParsingRuleID(parsingRulesGroupResourceName, &ruleID),
 				),
 			},
 			{
@@ -599,6 +601,7 @@ func TestAccCoralogixResourceParsingRules_update(t *testing.T) {
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.0.parse.name", "rule1"),
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.1.extract.name", "rule2"),
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.2.parse.name", "rule3"),
+					assertParsingRuleIDUnchanged(parsingRulesGroupResourceName, &ruleID),
 				),
 			},
 		},
@@ -608,6 +611,7 @@ func TestAccCoralogixResourceParsingRules_update(t *testing.T) {
 func TestAccCoralogixResourceParsingRules_update_order_inside_rule_group(t *testing.T) {
 	r := getRandomParsingRule()
 	resourceName := "coralogix_parsing_rules.test"
+	var ruleID string
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -631,6 +635,7 @@ func TestAccCoralogixResourceParsingRules_update_order_inside_rule_group(t *test
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.1.extract.order", "2"),
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.2.parse.name", "rule3"),
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.2.parse.order", "3"),
+					captureParsingRuleID(parsingRulesGroupResourceName, &ruleID),
 				),
 			},
 			{
@@ -656,6 +661,7 @@ func TestAccCoralogixResourceParsingRules_update_order_inside_rule_group(t *test
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.2.parse.name", "rule1"),
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.2.parse.order", "3"),
 					resource.TestCheckResourceAttr(parsingRulesGroupResourceName, "rule_subgroups.0.rules.3.extract_timestamp.name", "rule1"),
+					assertParsingRuleIDUnchanged(parsingRulesGroupResourceName, &ruleID),
 				),
 			},
 		},
@@ -696,7 +702,7 @@ func testAccCheckParsingRuleDestroy(s *terraform.State) error {
 		}
 
 		resp, _, err := client.RuleGroupsServiceGetRuleGroup(ctx, rs.Primary.ID).Execute()
-		if err == nil {
+		if err == nil && resp != nil && resp.RuleGroup != nil && resp.RuleGroup.Id != nil {
 			if *resp.RuleGroup.Id == rs.Primary.ID {
 				return fmt.Errorf("RuleGroup still exists: %s", rs.Primary.ID)
 			}
@@ -704,6 +710,33 @@ func testAccCheckParsingRuleDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func captureParsingRuleID(resourceName string, out *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceName)
+		}
+		*out = rs.Primary.ID
+		return nil
+	}
+}
+
+func assertParsingRuleIDUnchanged(resourceName string, expected *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceName)
+		}
+		if *expected == "" {
+			return fmt.Errorf("expected ID was not captured before this assertion ran")
+		}
+		if rs.Primary.ID != *expected {
+			return fmt.Errorf("RuleGroup ID changed across update: %s -> %s (resource was recreated, leaking the original)", *expected, rs.Primary.ID)
+		}
+		return nil
+	}
 }
 
 /*func testAccCoralogixResourceParsingRulesMinimal(name string) string {


### PR DESCRIPTION
### Description

## Summary

Fix `coralogix_parsing_rules.Update` calling the **Create** endpoint instead of **Update**, which silently orphaned the previous rule group at Coralogix on every update and was the source of recurring parsing-rule quota exhaustion in the test account.

## Root Cause

`internal/provider/parsing_rules/resource_coralogix_parsing_rules.go:Update` invoked `RuleGroupsServiceCreateRuleGroup(ctx)` with the plan body, then `flattenParsingRules(result.RuleGroup)` and `resp.State.Set(...)`. Each Update therefore:

1. Created a brand-new rule group at Coralogix with a brand-new ID.
2. Replaced Terraform state's ID with the new one — losing all reference to the original.
3. Left the original rule group orphaned at the API. `terraform destroy` later only deleted whatever ID state currently held, never the orphans.

This affected:
- **Real users** running `terraform apply` after editing a `coralogix_parsing_rules` resource — every diff produced a permanent orphan.
- **CI** — `TestAccCoralogixResourceParsingRules_update` and `TestAccCoralogixResourceParsingRules_update_order_inside_rule_group` each leaked one rule per acceptance run (cron + every PR), accumulating against the per-account parsing-rule quota faster than the nightly `cleanup.yml` could sweep.

The pinned SDK (`coralogix-management-sdk@v1.9.4-…`) exposes `RuleGroupsServiceUpdateRuleGroup(ctx, groupId)` with the same `RuleGroupsServiceCreateRuleGroupRequest` body and an `UpdateRuleGroupResponse` whose `RuleGroup` field has identical shape — so the fix is a one-line endpoint swap that carries the existing `plan.ID` through.

The companion test bug in `testAccCheckParsingRuleDestroy` (unguarded `*resp.RuleGroup.Id` deref when the GET returns success with a nil `RuleGroup`) couldn't have caught this leak — orphaned rules aren't in TF state, so CheckDestroy never iterates them — but it could mask future regressions where the leak *is* visible to state, so it's hardened in the same change.

## Why was it introduced

Introduced in #447 ("OpenAPI SDK II", commit 3ec543f, 2025-12-02) when the framework `coralogix_parsing_rules` resource was first added against the OpenAPI-generated SDK. The Update implementation appears to have been copy-pasted from Create without swapping the endpoint — the existing error string `"Error replacing coralogix_parsing_rules"` and the `"Create"` operation tag passed to `FormatOpenAPIErrors` are tells.

## Breaking change?

**No.** The change moves Update from `POST /create` to `PUT /update` against the same backend service with the same request body. Externally observable schema, attributes, and import behaviour are unchanged. State migration is a no-op: Terraform state already holds the (latest) rule's ID, which is what the new Update path uses.

Note for users with existing pre-fix orphans: this PR does not retroactively delete them. They remain unreferenced at Coralogix and should be cleaned up via the nightly `scripts/cx-test-resource-cleanup.go` script (test envs) or manually via the Coralogix UI / SDK in production envs.

## Risks

- **Update endpoint divergence at the API level** — mitigated: SDK exposes both endpoints with identical request/response body shapes, so request marshalling is unchanged and the existing `flattenParsingRules` continues to work. Verified against `UpdateRuleGroupResponse.RuleGroup *RuleGroup` (same as Create).
- **`plan.ID` empty during Update** — mitigated: `id` is `Computed` in the schema and Terraform preserves Computed values in plan during an in-place update; identical pattern is already used by `apm/resource_coralogix_slo.go:485`.
- **CheckDestroy guard hiding genuine "rule still exists"** — mitigated: nil-guards only short-circuit on responses that previously panicked; if the GET succeeds with a populated `RuleGroup.Id` matching `rs.Primary.ID`, the existing `fmt.Errorf("RuleGroup still exists: %s", …)` still fires.

## Changes

| File | Change |
| --- | --- |
| `internal/provider/parsing_rules/resource_coralogix_parsing_rules.go` | `Update` now calls `RuleGroupsServiceUpdateRuleGroup(ctx, plan.ID)` instead of `RuleGroupsServiceCreateRuleGroup(ctx)`. Error text/tag corrected to `Update`. |
| `internal/provider/resource_coralogix_parsing_rules_test.go` | Added `captureParsingRuleID` + `assertParsingRuleIDUnchanged` helpers; wired them into `TestAccCoralogixResourceParsingRules_update` and `TestAccCoralogixResourceParsingRules_update_order_inside_rule_group` so any future Update implementation that recreates instead of updating fails the test. Hardened `testAccCheckParsingRuleDestroy` against nil deref. |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — clean
- [ ] `make testacc TESTARGS='-run=TestAccCoralogixResourceParsingRules_update$'` — must pass post-fix; without the fix, the new `assertParsingRuleIDUnchanged` would fail with `RuleGroup ID changed across update: <old> -> <new> (resource was recreated, leaking the original)`.
- [ ] `make testacc TESTARGS='-run=TestAccCoralogixResourceParsingRules_update_order_inside_rule_group'` — same, for the second update test.
- [ ] `make testacc TESTARGS='-run=TestAccCoralogixResourceParsingRules'` — full parsing-rules suite, no regressions.
- [ ] Manual leak check: list parsing rule groups in the test account before and after the two update tests; expect `0` net new rules post-fix (was `+2`).

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? *(pending — needs `CORALOGIX_API_KEY` / `CORALOGIX_ENV` against the test account)*

Output from acceptance testing:
\`\`\`
$ make testacc TESTARGS='-run=TestAccCoralogixResourceParsingRules_update'

(pending — to be filled in once acceptance tests are run against the test environment)
\`\`\`

### Release Note
\`\`\`release-note
resource/coralogix_parsing_rules: fix \`Update\` recreating the rule group at the backend (new ID, orphaning the previous rule). \`terraform apply\` now updates in place; the rule's ID is stable across edits.
\`\`\`

### References

- Jira: [BUGV2-6012](https://coralogix.atlassian.net/browse/BUGV2-6012)
- Bug introduced in #447 (OpenAPI SDK II, commit 3ec543f).
- Branch was originally created under the working hypothesis that test cleanup was at fault; root cause turned out to be the resource itself, but the test-side hardening (CheckDestroy nil-guard + ID-stability assertions) is included to prevent silent regressions.

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment


[BUGV2-6012]: https://coralogix.atlassian.net/browse/BUGV2-6012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ