### PR TITLE
fix(user): keep user_name docs concise

### DIFF
--- a/internal/provider/aaa/resource_coralogix_user.go
+++ b/internal/provider/aaa/resource_coralogix_user.go
@@ -86,9 +86,7 @@ func (r *UserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				PlanModifiers: []planmodifier.String{
 					caseInsensitiveStringPlanModifier{},
 				},
-				MarkdownDescription: "User name (email). Comparison is case-insensitive: SSO " +
-					"login can normalize letter case in the backend, and that normalization " +
-					"will not trigger drift in subsequent plans.",
+				MarkdownDescription: "User name.",
 			},
 			"name": schema.SingleNestedAttribute{
 				Optional: true,

--- a/internal/provider/aaa/resource_coralogix_user_test.go
+++ b/internal/provider/aaa/resource_coralogix_user_test.go
@@ -18,9 +18,34 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func TestUserResourceSchemaUserName(t *testing.T) {
+	resp := &resource.SchemaResponse{}
+	NewUserResource().Schema(context.Background(), resource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	userNameAttr, ok := resp.Schema.Attributes["user_name"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected user_name to be schema.StringAttribute, got %T", resp.Schema.Attributes["user_name"])
+	}
+	if userNameAttr.MarkdownDescription != "User name." {
+		t.Fatalf("expected user_name description to stay short, got %q", userNameAttr.MarkdownDescription)
+	}
+
+	for _, modifier := range userNameAttr.PlanModifiers {
+		if _, ok := modifier.(caseInsensitiveStringPlanModifier); ok {
+			return
+		}
+	}
+	t.Fatal("expected user_name to include caseInsensitiveStringPlanModifier")
+}
 
 func TestCaseInsensitiveStringPlanModifier(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary
- keep the `coralogix_user.user_name` schema docs as `User name.` so generated docs do not include the SSO/case-insensitive note
- preserve the case-insensitive plan modifier behavior from #520
- add a schema test that guards both the short description and modifier wiring

## Testing
- `go test ./internal/provider/aaa`

Source PR: #520