### PR TITLE
CX-40825 add more tests to alert_scheduler

### DIFF
--- a/docs/resources/alerts_scheduler.md
+++ b/docs/resources/alerts_scheduler.md
@@ -48,7 +48,27 @@ resource "coralogix_alerts_scheduler" "suppress_all" {
   }
 }
 
-# Example 2: Suppress only specific group-by values
+# Example 2: Suppress all alert activity for every alert
+# Omit both selector fields (alerts_unique_ids and meta_labels) to target all alerts
+resource "coralogix_alerts_scheduler" "suppress_every_alert" {
+  name        = "Maintenance Window - Every Alert"
+  description = "Suppress every alert during maintenance window"
+  filter = {
+    what_expression = "source logs | filter true"
+  }
+  schedule = {
+    operation = "mute"
+    one_time = {
+      time_frame = {
+        start_time = "2025-01-04T00:00:00.000"
+        end_time   = "2025-01-04T06:00:00.000"
+        time_zone  = "UTC+2"
+      }
+    }
+  }
+}
+
+# Example 3: Suppress only specific group-by values
 # The what_expression filters which triggered values to suppress
 # Note: "source logs" syntax works for ALL alert types (logs, metrics, tracing)
 resource "coralogix_alerts_scheduler" "suppress_specific_values" {
@@ -70,7 +90,7 @@ resource "coralogix_alerts_scheduler" "suppress_specific_values" {
   }
 }
 
-# Example 3: Suppress with multiple conditions
+# Example 4: Suppress with multiple conditions
 # Works with any alert group-by keys including metric labels
 resource "coralogix_alerts_scheduler" "suppress_multiple_conditions" {
   name        = "Suppress Staging Cluster Alerts"
@@ -91,7 +111,7 @@ resource "coralogix_alerts_scheduler" "suppress_multiple_conditions" {
   }
 }
 
-# Example 4: Recurring suppression with meta_labels selector
+# Example 5: Recurring suppression with meta_labels selector
 resource "coralogix_alerts_scheduler" "recurring_suppression" {
   name        = "Weekly Maintenance Window"
   description = "Suppress alerts every Sunday for maintenance"
@@ -128,7 +148,7 @@ resource "coralogix_alerts_scheduler" "recurring_suppression" {
   }
 }
 
-# Example 5: Permanent (always active) suppression rule
+# Example 6: Permanent (always active) suppression rule
 resource "coralogix_alerts_scheduler" "permanent_suppression" {
   name        = "Permanent Suppression - Test Environment"
   description = "Permanently suppress alerts for test environment"
@@ -149,7 +169,7 @@ resource "coralogix_alerts_scheduler" "permanent_suppression" {
   }
 }
 
-# Example 6: Permanent suppression for specific alerts
+# Example 7: Permanent suppression for specific alerts
 resource "coralogix_alerts_scheduler" "permanent_alert_suppression" {
   name        = "Permanent Alert Mute"
   description = "Permanently mute specific alerts"

--- a/examples/resources/coralogix_alerts_scheduler/resource.tf
+++ b/examples/resources/coralogix_alerts_scheduler/resource.tf
@@ -33,7 +33,27 @@ resource "coralogix_alerts_scheduler" "suppress_all" {
   }
 }
 
-# Example 2: Suppress only specific group-by values
+# Example 2: Suppress all alert activity for every alert
+# Omit both selector fields (alerts_unique_ids and meta_labels) to target all alerts
+resource "coralogix_alerts_scheduler" "suppress_every_alert" {
+  name        = "Maintenance Window - Every Alert"
+  description = "Suppress every alert during maintenance window"
+  filter = {
+    what_expression = "source logs | filter true"
+  }
+  schedule = {
+    operation = "mute"
+    one_time = {
+      time_frame = {
+        start_time = "2025-01-04T00:00:00.000"
+        end_time   = "2025-01-04T06:00:00.000"
+        time_zone  = "UTC+2"
+      }
+    }
+  }
+}
+
+# Example 3: Suppress only specific group-by values
 # The what_expression filters which triggered values to suppress
 # Note: "source logs" syntax works for ALL alert types (logs, metrics, tracing)
 resource "coralogix_alerts_scheduler" "suppress_specific_values" {
@@ -55,7 +75,7 @@ resource "coralogix_alerts_scheduler" "suppress_specific_values" {
   }
 }
 
-# Example 3: Suppress with multiple conditions
+# Example 4: Suppress with multiple conditions
 # Works with any alert group-by keys including metric labels
 resource "coralogix_alerts_scheduler" "suppress_multiple_conditions" {
   name        = "Suppress Staging Cluster Alerts"
@@ -76,7 +96,7 @@ resource "coralogix_alerts_scheduler" "suppress_multiple_conditions" {
   }
 }
 
-# Example 4: Recurring suppression with meta_labels selector
+# Example 5: Recurring suppression with meta_labels selector
 resource "coralogix_alerts_scheduler" "recurring_suppression" {
   name        = "Weekly Maintenance Window"
   description = "Suppress alerts every Sunday for maintenance"
@@ -113,7 +133,7 @@ resource "coralogix_alerts_scheduler" "recurring_suppression" {
   }
 }
 
-# Example 5: Permanent (always active) suppression rule
+# Example 6: Permanent (always active) suppression rule
 resource "coralogix_alerts_scheduler" "permanent_suppression" {
   name        = "Permanent Suppression - Test Environment"
   description = "Permanently suppress alerts for test environment"
@@ -134,7 +154,7 @@ resource "coralogix_alerts_scheduler" "permanent_suppression" {
   }
 }
 
-# Example 6: Permanent suppression for specific alerts
+# Example 7: Permanent suppression for specific alerts
 resource "coralogix_alerts_scheduler" "permanent_alert_suppression" {
   name        = "Permanent Alert Mute"
   description = "Permanently mute specific alerts"

--- a/internal/provider/alerts/resource_coralogix_alerts_scheduler_test.go
+++ b/internal/provider/alerts/resource_coralogix_alerts_scheduler_test.go
@@ -15,8 +15,15 @@
 package alerts
 
 import (
+	"context"
+	"slices"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	alertscheduler "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/alert_scheduler_rule_service"
 )
 
 func TestNormalizeStartTimeFromAPI(t *testing.T) {
@@ -115,5 +122,99 @@ func TestStartTimeSemanticallyEqual(t *testing.T) {
 				t.Errorf("startTimeSemanticallyEqual(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFlattenFilterTreatsNilOrEmptyAlertIDsAsAllAlerts(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		ids  []string
+	}{
+		{name: "nil ids", ids: nil},
+		{name: "empty ids", ids: []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
+				AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
+					WhatExpression: alertscheduler.PtrString("source logs | filter true"),
+					AlertUniqueIds: alertscheduler.AlertUniqueIds{Value: tt.ids},
+				},
+			}
+
+			got, diags := flattenFilter(ctx, filter)
+			if diags.HasError() {
+				t.Fatalf("flattenFilter returned diagnostics: %v", diags)
+			}
+
+			var model FilterModel
+			if diags := got.As(ctx, &model, basetypes.ObjectAsOptions{}); diags.HasError() {
+				t.Fatalf("converting flattened filter returned diagnostics: %v", diags)
+			}
+
+			if got := model.WhatExpression.ValueString(); got != "source logs | filter true" {
+				t.Fatalf("what_expression = %q, want source logs | filter true", got)
+			}
+			if !model.AlertsUniqueIDs.IsNull() {
+				t.Fatalf("alerts_unique_ids should be null for all-alert backend filter, got %#v", model.AlertsUniqueIDs)
+			}
+			if !model.MetaLabels.IsNull() {
+				t.Fatalf("meta_labels should be null for all-alert backend filter, got %#v", model.MetaLabels)
+			}
+		})
+	}
+}
+
+func TestFlattenFilterPreservesDirectAlertIDs(t *testing.T) {
+	ctx := context.Background()
+	filter := &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
+		AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
+			WhatExpression: alertscheduler.PtrString("source logs | filter true"),
+			AlertUniqueIds: alertscheduler.AlertUniqueIds{Value: []string{"alert-id-1", "alert-id-2"}},
+		},
+	}
+
+	got, diags := flattenFilter(ctx, filter)
+	if diags.HasError() {
+		t.Fatalf("flattenFilter returned diagnostics: %v", diags)
+	}
+
+	var model FilterModel
+	if diags := got.As(ctx, &model, basetypes.ObjectAsOptions{}); diags.HasError() {
+		t.Fatalf("converting flattened filter returned diagnostics: %v", diags)
+	}
+
+	var ids []string
+	if diags := model.AlertsUniqueIDs.ElementsAs(ctx, &ids, false); diags.HasError() {
+		t.Fatalf("converting alert IDs returned diagnostics: %v", diags)
+	}
+	slices.Sort(ids)
+	if len(ids) != 2 || ids[0] != "alert-id-1" || ids[1] != "alert-id-2" {
+		t.Fatalf("alerts_unique_ids = %#v, want [alert-id-1 alert-id-2]", ids)
+	}
+}
+
+func TestExtractFilterOmitsAlertIDsForAllAlerts(t *testing.T) {
+	ctx := context.Background()
+	filter, diags := types.ObjectValueFrom(ctx, filterModelAttr(), FilterModel{
+		WhatExpression:  types.StringValue("source logs | filter true"),
+		MetaLabels:      types.SetNull(types.ObjectType{AttrTypes: labelModelAttr()}),
+		AlertsUniqueIDs: types.SetNull(types.StringType),
+	})
+	if diags.HasError() {
+		t.Fatalf("creating filter object returned diagnostics: %v", diags)
+	}
+
+	got, diags := extractFilter(ctx, filter)
+	if diags.HasError() {
+		t.Fatalf("extractFilter returned diagnostics: %v", diags)
+	}
+	if got.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds == nil {
+		t.Fatal("extractFilter did not produce alert unique IDs filter for all-alert config")
+	}
+	if ids := got.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds.AlertUniqueIds.Value; ids != nil {
+		t.Fatalf("all-alert config should extract nil alert IDs, got %#v", ids)
 	}
 }

--- a/internal/provider/resource_coralogix_alerts_scheduler_test.go
+++ b/internal/provider/resource_coralogix_alerts_scheduler_test.go
@@ -20,14 +20,18 @@ import (
 	"testing"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
+	"github.com/google/uuid"
 
+	alertscheduler "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/alert_scheduler_rule_service"
 	terraform2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var (
-	alertsSchedulerResourceName = "coralogix_alerts_scheduler.test"
+	alertsSchedulerResourceName         = "coralogix_alerts_scheduler.test"
+	importedAlertsSchedulerResourceName = "coralogix_alerts_scheduler.imported"
+	alertsSchedulerTargetAlertName      = "coralogix_alert.scheduler_target"
 )
 
 func TestAccCoralogixResourceResourceAlertsScheduler(t *testing.T) {
@@ -96,6 +100,109 @@ func TestAccCoralogixResourceResourceAlertsSchedulerAllAlerts(t *testing.T) {
 	})
 }
 
+func TestAccCoralogixResourceAlertsSchedulerImportAllAlertsNoDrift(t *testing.T) {
+	name := fmt.Sprintf("alerts-scheduler-all-alerts-%s", uuid.NewString())
+	config := testAccCoralogixResourceAlertsSchedulerImportedAllAlerts(name)
+	var schedulerID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckAlertsSchedulerDestroy,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					schedulerID = testAccCreateAlertsScheduler(t, testAccBackendAlertsSchedulerAllAlerts(name))
+				},
+				Config:             config,
+				ResourceName:       importedAlertsSchedulerResourceName,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc: func(*terraform.State) (string, error) {
+					if schedulerID == "" {
+						return "", fmt.Errorf("missing imported alert scheduler ID")
+					}
+					return schedulerID, nil
+				},
+				ImportStateCheck: testAccCheckImportedAlertsScheduler(map[string]string{
+					"name":                             name,
+					"filter.what_expression":           "source logs | filter true",
+					"schedule.operation":               "mute",
+					"schedule.recurring.always_active": "true",
+				}, []string{
+					"filter.alerts_unique_ids.#",
+					"filter.meta_labels.#",
+				}),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceAlertsSchedulerImportDirectAlertIDNoDrift(t *testing.T) {
+	alertName := fmt.Sprintf("alerts-scheduler-target-%s", uuid.NewString())
+	schedulerName := fmt.Sprintf("alerts-scheduler-direct-id-%s", uuid.NewString())
+	config := testAccCoralogixResourceAlertsSchedulerImportedDirectAlertID(alertName, schedulerName)
+	var alertID string
+	var schedulerID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckAlertAndAlertsSchedulerDestroy,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixAlertsSchedulerTargetAlert(alertName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(alertsSchedulerTargetAlertName, "name", alertName),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[alertsSchedulerTargetAlertName]
+						if !ok {
+							return fmt.Errorf("missing target alert resource")
+						}
+						alertID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					if alertID == "" {
+						t.Fatal("missing target alert ID")
+					}
+					schedulerID = testAccCreateAlertsScheduler(t, testAccBackendAlertsSchedulerDirectAlertID(schedulerName, alertID))
+				},
+				Config:             config,
+				ResourceName:       importedAlertsSchedulerResourceName,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc: func(*terraform.State) (string, error) {
+					if schedulerID == "" {
+						return "", fmt.Errorf("missing imported alert scheduler ID")
+					}
+					return schedulerID, nil
+				},
+				ImportStateCheck: testAccCheckImportedAlertsScheduler(map[string]string{
+					"name":                             schedulerName,
+					"filter.what_expression":           "source logs | filter true",
+					"filter.alerts_unique_ids.#":       "1",
+					"schedule.operation":               "mute",
+					"schedule.recurring.always_active": "true",
+				}, []string{
+					"filter.meta_labels.#",
+				}),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAlertsSchedulerDestroy(s *terraform.State) error {
 	testAccProvider = OldProvider()
 	rc := terraform2.ResourceConfig{}
@@ -119,6 +226,106 @@ func testAccCheckAlertsSchedulerDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckAlertAndAlertsSchedulerDestroy(s *terraform.State) error {
+	if err := testAccCheckAlertsSchedulerDestroy(s); err != nil {
+		return err
+	}
+	return testAccCheckAlertDestroy(s)
+}
+
+func testAccCreateAlertsScheduler(t *testing.T, scheduler alertscheduler.AlertSchedulerRule) string {
+	t.Helper()
+
+	client := testAccAlertsSchedulerClient(t)
+	createRequest := alertscheduler.CreateAlertSchedulerRuleRequestDataStructure{
+		AlertSchedulerRule: scheduler,
+	}
+	createResp, _, err := client.
+		AlertSchedulerRuleServiceCreateAlertSchedulerRule(context.Background()).
+		CreateAlertSchedulerRuleRequestDataStructure(createRequest).
+		Execute()
+	if err != nil {
+		t.Fatalf("creating out-of-band alert scheduler: %s", err)
+	}
+
+	schedulerID := createResp.AlertSchedulerRule.GetUniqueIdentifier()
+	t.Cleanup(func() {
+		_, _, _ = client.AlertSchedulerRuleServiceDeleteAlertSchedulerRule(context.Background(), schedulerID).Execute()
+	})
+	return schedulerID
+}
+
+func testAccAlertsSchedulerClient(t *testing.T) *alertscheduler.AlertSchedulerRuleServiceAPIService {
+	t.Helper()
+
+	testAccProvider = OldProvider()
+	rc := terraform2.ResourceConfig{}
+	if diags := testAccProvider.Configure(context.Background(), &rc); diags.HasError() {
+		t.Fatalf("configuring provider for alert scheduler client: %v", diags)
+	}
+	return testAccProvider.Meta().(*clientset.ClientSet).AlertSchedulers()
+}
+
+func testAccBackendAlertsSchedulerAllAlerts(name string) alertscheduler.AlertSchedulerRule {
+	return testAccBackendAlertsScheduler(name, nil)
+}
+
+func testAccBackendAlertsSchedulerDirectAlertID(name string, alertID string) alertscheduler.AlertSchedulerRule {
+	return testAccBackendAlertsScheduler(name, []string{alertID})
+}
+
+func testAccBackendAlertsScheduler(name string, alertIDs []string) alertscheduler.AlertSchedulerRule {
+	operation := alertscheduler.SCHEDULEOPERATION_SCHEDULE_OPERATION_MUTE
+	return alertscheduler.AlertSchedulerRule{
+		Name:        alertscheduler.PtrString(name),
+		Description: alertscheduler.PtrString("Imported parity scheduler"),
+		Enabled:     alertscheduler.PtrBool(true),
+		Filter: &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
+			AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
+				WhatExpression: alertscheduler.PtrString("source logs | filter true"),
+				AlertUniqueIds: alertscheduler.AlertUniqueIds{Value: alertIDs},
+			},
+		},
+		Schedule: &alertscheduler.Schedule{
+			ScheduleRecurring: &alertscheduler.ScheduleRecurring{
+				ScheduleOperation: &operation,
+				Recurring: alertscheduler.Recurring{
+					RecurringAlwaysActive: &alertscheduler.RecurringAlwaysActive{
+						AlwaysActive: map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testAccCheckImportedAlertsScheduler(expected map[string]string, absent []string) resource.ImportStateCheckFunc {
+	return func(states []*terraform.InstanceState) error {
+		var schedulerState *terraform.InstanceState
+		for _, state := range states {
+			if _, ok := state.Attributes["filter.what_expression"]; ok {
+				schedulerState = state
+				break
+			}
+		}
+		if schedulerState == nil {
+			return fmt.Errorf("expected imported alert scheduler state, got %d state entries", len(states))
+		}
+		attrs := schedulerState.Attributes
+		for key, want := range expected {
+			if got := attrs[key]; got != want {
+				return fmt.Errorf("imported %s = %q, want %q", key, got, want)
+			}
+		}
+		for _, key := range absent {
+			if got, ok := attrs[key]; ok && got != "" && got != "0" {
+				return fmt.Errorf("imported %s = %q, want absent or empty", key, got)
+			}
+		}
+		return nil
+	}
 }
 
 func testAccCoralogixResourceAlertsScheduler() string {
@@ -191,6 +398,85 @@ func testAccCoralogixResourceAlertsSchedulerAllAlerts() string {
   }
 }
 `
+}
+
+func testAccCoralogixResourceAlertsSchedulerImportedAllAlerts(name string) string {
+	return fmt.Sprintf(`resource "coralogix_alerts_scheduler" "imported" {
+  name        = %[1]q
+  description = "Imported parity scheduler"
+  enabled     = true
+  filter = {
+    what_expression = "source logs | filter true"
+  }
+  schedule = {
+    operation = "mute"
+    recurring = {
+      always_active = true
+    }
+  }
+}
+`, name)
+}
+
+func testAccCoralogixResourceAlertsSchedulerImportedDirectAlertID(alertName string, schedulerName string) string {
+	return testAccCoralogixAlertsSchedulerTargetAlert(alertName) + fmt.Sprintf(`
+resource "coralogix_alerts_scheduler" "imported" {
+  name        = %[1]q
+  description = "Imported parity scheduler"
+  enabled     = true
+  filter = {
+    what_expression   = "source logs | filter true"
+    alerts_unique_ids = [coralogix_alert.scheduler_target.id]
+  }
+  schedule = {
+    operation = "mute"
+    recurring = {
+      always_active = true
+    }
+  }
+}
+`, schedulerName)
+}
+
+func testAccCoralogixAlertsSchedulerTargetAlert(name string) string {
+	return fmt.Sprintf(`resource "coralogix_alert" "scheduler_target" {
+  name         = %[1]q
+  description  = "Alert scheduler parity target"
+  priority     = "P2"
+  phantom_mode = true
+
+  labels = {
+    alert_type        = "security"
+    security_severity = "high"
+  }
+
+  incidents_settings = {
+    notify_on = "Triggered and Resolved"
+    retriggering_period = {
+      minutes = 10
+    }
+  }
+
+  schedule = {
+    active_on = {
+      days_of_week = ["Wednesday", "Thursday"]
+      start_time   = "08:30"
+      end_time     = "20:30"
+      utc_offset   = "+0300"
+    }
+  }
+
+  type_definition = {
+    logs_immediate = {
+      logs_filter = {
+        simple_filter = {
+          lucene_query = "message:\"error\""
+        }
+      }
+    }
+  }
+}
+`, name)
 }
 
 func TestAccCoralogixResourceResourceAlertsSchedulerAlwaysActive(t *testing.T) {


### PR DESCRIPTION
## Summary
- Re-applies the alerts scheduler parity changes from #525
- Adds all-alerts and direct alert ID import/no-drift coverage
- Updates alerts scheduler examples/docs for all-alert suppression
- Omits the user_name documentation wording change from #525 as requested

## Tests
- go test ./internal/provider/alerts
- go test ./internal/provider -run '^$'