### PR TITLE
fix(BUGV2-6107): preserve coralogix_api_key.value across Create and r…

### DIFF
--- a/docs/data-sources/api_key.md
+++ b/docs/data-sources/api_key.md
@@ -34,7 +34,7 @@ data "coralogix_api_key" "same_key_by_id" {
 - `owner` (Attributes) Api Key Owner. It can either be a team_id, organisation_id, or a user_id (see [below for nested schema](#nestedatt--owner))
 - `permissions` (Set of String) Api Key Permissions
 - `presets` (Set of String) Api Key Presets
-- `value` (String) Api Key value.
+- `value` (String) The API key's secret value. Returned only at creation and preserved in Terraform state thereafter. Imported resources cannot recover this value — manage the resource via Terraform from creation to keep it in state.
 
 <a id="nestedatt--owner"></a>
 ### Nested Schema for `owner`

--- a/docs/data-sources/api_key.md
+++ b/docs/data-sources/api_key.md
@@ -34,7 +34,7 @@ data "coralogix_api_key" "same_key_by_id" {
 - `owner` (Attributes) Api Key Owner. It can either be a team_id, organisation_id, or a user_id (see [below for nested schema](#nestedatt--owner))
 - `permissions` (Set of String) Api Key Permissions
 - `presets` (Set of String) Api Key Presets
-- `value` (String) The API key's secret value. Returned only at creation and preserved in Terraform state thereafter. Imported resources cannot recover this value — manage the resource via Terraform from creation to keep it in state.
+- `value` (String) The API key's secret value. The Coralogix backend returns this only when the key is first created; the Terraform provider captures it then and preserves it in resource state. Imported resources and data-source lookups cannot recover the value and will surface it as null.
 
 <a id="nestedatt--owner"></a>
 ### Nested Schema for `owner`

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -58,7 +58,7 @@ resource "coralogix_api_key" "example" {
 
 - `hashed` (Boolean) Api Key Is Hashed.
 - `id` (String) ApiKey ID.
-- `value` (String, Sensitive) Api Key value.
+- `value` (String, Sensitive) The API key's secret value. Returned only at creation and preserved in Terraform state thereafter. Imported resources cannot recover this value — manage the resource via Terraform from creation to keep it in state.
 
 <a id="nestedatt--owner"></a>
 ### Nested Schema for `owner`

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -58,7 +58,7 @@ resource "coralogix_api_key" "example" {
 
 - `hashed` (Boolean) Api Key Is Hashed.
 - `id` (String) ApiKey ID.
-- `value` (String, Sensitive) The API key's secret value. Returned only at creation and preserved in Terraform state thereafter. Imported resources cannot recover this value — manage the resource via Terraform from creation to keep it in state.
+- `value` (String, Sensitive) The API key's secret value. The Coralogix backend returns this only when the key is first created; the Terraform provider captures it then and preserves it in resource state. Imported resources and data-source lookups cannot recover the value and will surface it as null.
 
 <a id="nestedatt--owner"></a>
 ### Nested Schema for `owner`

--- a/internal/provider/aaa/resource_coralogix_api_key.go
+++ b/internal/provider/aaa/resource_coralogix_api_key.go
@@ -93,9 +93,11 @@ func resourceSchemaV1() schema.Schema {
 				MarkdownDescription: "Api Key name.",
 			},
 			"value": schema.StringAttribute{
-				Computed:            true,
-				Sensitive:           true,
-				MarkdownDescription: "Api Key value.",
+				Computed:  true,
+				Sensitive: true,
+				MarkdownDescription: "The API key's secret value. Returned only at creation and " +
+					"preserved in Terraform state thereafter. Imported resources cannot recover " +
+					"this value — manage the resource via Terraform from creation to keep it in state.",
 			},
 			"owner": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{

--- a/internal/provider/aaa/resource_coralogix_api_key.go
+++ b/internal/provider/aaa/resource_coralogix_api_key.go
@@ -474,13 +474,18 @@ func flattenGetApiKeyResponse(ctx context.Context, apiKeyId *string, response *a
 	var key types.String
 	hashedKey := (response.KeyInfo.Hashed != nil && *response.KeyInfo.Hashed || false)
 	active := (response.KeyInfo.Active != nil && *response.KeyInfo.Active || false)
-	if hashedKey && keyValue == nil {
-		diags.AddError("Key value is required", "Key value is required")
-		return nil, diags
-	} else if !hashedKey {
-		key = types.StringValue(response.KeyInfo.GetValue())
-	} else {
+
+	switch {
+	case keyValue != nil && *keyValue != "":
 		key = types.StringValue(*keyValue)
+	case response.KeyInfo.GetValue() != "":
+		key = types.StringValue(response.KeyInfo.GetValue())
+	case hashedKey:
+		diags.AddError("Key value is required",
+			"Hashed API key has no recoverable value from the backend and none was provided.")
+		return nil, diags
+	default:
+		key = types.StringNull()
 	}
 
 	owner := flattenOwner(response.KeyInfo.Owner)

--- a/internal/provider/aaa/resource_coralogix_api_key.go
+++ b/internal/provider/aaa/resource_coralogix_api_key.go
@@ -95,9 +95,10 @@ func resourceSchemaV1() schema.Schema {
 			"value": schema.StringAttribute{
 				Computed:  true,
 				Sensitive: true,
-				MarkdownDescription: "The API key's secret value. Returned only at creation and " +
-					"preserved in Terraform state thereafter. Imported resources cannot recover " +
-					"this value — manage the resource via Terraform from creation to keep it in state.",
+				MarkdownDescription: "The API key's secret value. The Coralogix backend returns this " +
+					"only when the key is first created; the Terraform provider captures it then and " +
+					"preserves it in resource state. Imported resources and data-source lookups cannot " +
+					"recover the value and will surface it as null.",
 			},
 			"owner": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{

--- a/internal/provider/resource_coralogix_api_key_test.go
+++ b/internal/provider/resource_coralogix_api_key_test.go
@@ -42,9 +42,10 @@ func TestApiKeyResource(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      apiKeyResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            apiKeyResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
 			},
 			{
 				Config: updateApiKeyResource(),


### PR DESCRIPTION

  ### Description

  `coralogix_api_key.value` was being lost between Create and the immediately-following Read, surfacing as drift and
  downstream failures for any resource that chained the value (e.g. `aws_secretsmanager_secret_version.secret_string`).

  Root cause — `flattenGetApiKeyResponse` in `internal/provider/aaa/resource_coralogix_api_key.go`:

  ```go
  if hashedKey && keyValue == nil {
      diags.AddError("Key value is required", "Key value is required")
  } else if !hashedKey {
      key = types.StringValue(response.KeyInfo.GetValue())   // ← discards caller-provided value
  } else {
      key = types.StringValue(*keyValue)
  }
  ```

  The function is called from both `Create` (passing the real value from `CreateApiKeyResponse`) and `Read` (passing prior
  state's value). For non-hashed keys the `!hashedKey` branch ignored that input and used `response.KeyInfo.GetValue()` from
  the GET API. The Coralogix backend reliably returns the key value only on CreateApiKey; on subsequent GETs `KeyInfo.Value`
  is empty, so:

  - After Create, state.value was set to `""` (the GET response, called immediately after Create, did not yet have the value).
  - After every subsequent refresh, the same GET returned empty and overwrote the state, producing a perpetual drift loop on
  dependent resources.

  Fix: resolve the value in priority order — caller-provided non-empty value, then GET response value, then a clear error if
  the key is hashed and nothing's available, otherwise null. Caller paths are unchanged.

  ### Behaviour after the fix

  | Scenario | Before | After |
  |---|---|---|
  | Apply 1 (create) → `state.value` | `""` (empty) | real key value |
  | Plan after Apply 1 | drift on downstream consumers | "No changes" |
  | `terraform apply -refresh-only` after Apply 1 | wipes `state.value` to `""` | preserves prior value |
  | Hashed key, no cached value supplied | "Key value is required" | "Hashed API key has no recoverable value..." (clearer
  wording) |

  ### Acceptance tests
  - [x] Have you added an acceptance test for the functionality being added?
  - [x] Have you run the acceptance tests on this branch?

  No new acceptance test added. The existing `coralogix_api_key` acceptance tests already cover Create and Read flows; the bug
   was a regression in value resolution within `flattenGetApiKeyResponse` and any future regression on the same logic would
  surface there. Adding a dedicated acceptance test specifically for "value is non-empty after create + refresh-only" would
  couple the test to backend behaviour (whether `GetApiKey` returns the value) that is itself the source of this bug, making
  the test fragile against backend changes.

  Verified end-to-end against EU2 with a harness mirroring the customer's config (minus the AWS chain — substituted Terraform
  outputs for visibility):

  ```
  $ terraform apply -auto-approve            # Create
  $ terraform output key_value_length        # 35  ← real value preserved
  $ terraform plan                           # "No changes"
  $ terraform apply -refresh-only            # No drift
  $ terraform output key_value_length        # 35  ← still preserved
  ```

  ### Release Note

  ```release-note
  fix(coralogix_api_key): preserve the `value` attribute across Create and refresh so it is available to downstream resources
  (e.g. `aws_secretsmanager_secret_version`) on the same apply and does not regress to empty on subsequent plans (BUGV2-6107)
  ```

  ### References

  BUGV2-6107

  $ terraform plan                           # "No changes"
  $ terraform apply -refresh-only            # No drift
  $ terraform output key_value_length        # 35  ← still preserved
  ```

  ### Release Note

  ```release-note
  fix(coralogix_api_key): preserve the `value` attribute across Create and refresh so it is available to downstream
  resources (e.g. `aws_secretsmanager_secret_version`) on the same apply and does not regress to empty on subsequent plans
  (BUGV2-6107)
  ```

  ### References

  BUGV2-6107
