### PR TITLE
ci: add Unreleased section to CHANGELOG and enforce changelog updates on PRs

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -2,6 +2,7 @@ name: changelog-check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - master
 

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -31,5 +31,5 @@ jobs:
         run: |
           git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -q "^CHANGELOG\.md$" || \
             { echo "ERROR: CHANGELOG.md was not updated in this PR."; \
-              echo "Add your change under the '# Unreleased' section, or add the 'skip changelog' label to bypass."; \
+              echo "Update CHANGELOG.md, or add the 'skip changelog' label to bypass."; \
               exit 1; }

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,32 @@
+name: changelog-check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for skip label
+        id: skip
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | jq -e 'any(. == "skip changelog")' > /dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check CHANGELOG.md was modified
+        if: steps.skip.outputs.skip == 'false'
+        run: |
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -q "^CHANGELOG\.md$" || \
+            { echo "ERROR: CHANGELOG.md was not updated in this PR."; \
+              echo "Add your change under the '# Unreleased' section, or add the 'skip changelog' label to bypass."; \
+              exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Unreleased
+
 # Release 3.4.1
 
 #### resource/coralogix_api_key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,21 @@ Every PR must update `CHANGELOG.md`. The CI `changelog-check` workflow enforces 
 - **Normal PR** — add bullet points under the `# Unreleased` section at the top of the file.
 - **Release PR** (the PR that bumps `internal/clientset/version.go` to a new version) — rename `# Unreleased` to `# Release X.Y.Z` matching the new version, and add a fresh empty `# Unreleased` section above it.
 
-Keep entries concise: one line per change, prefixed with the affected resource/data-source path when relevant (e.g. `#### resource/coralogix_alert`).
+Keep entries concise: one line per change, prefixed with the affected resource/data-source path when relevant. Examples:
+
+```markdown
+# Unreleased
+
+#### resource/coralogix_alert
+- FEAT: Add support for `no_data_policy` condition.
+- FIX: Nil pointer dereference on import when `scheduling` is unset.
+
+#### resource/coralogix_dashboard
+- FIX: Incorrect unit mapping for gauge widgets.
+
+#### provider
+- FEAT: Add support for `AP4` region.
+```
 
 ## Public-repo discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,17 @@ Fields that take expressions — `coralogix_tco_policies_logs.dpxl_expression`, 
 
 A bump usually requires adapting many resource files to the new SDK API surface (renamed types, changed signatures). PR #506 touched 17 resource files alongside `go.mod`. That's expected — bundle the bump and the adaptations in the same PR; they're not separable. After the bump: `go mod tidy && go build ./... && go vet ./...`, then the relevant `make testacc` runs to catch behaviour drift the compiler can't.
 
+## Changelog
+
+Every PR must update `CHANGELOG.md`. The CI `changelog-check` workflow enforces this and will block merges if the file is untouched. Add a `skip changelog` label to the PR to bypass the check (no release will be triggered for that PR).
+
+**Where to add your entry:**
+
+- **Normal PR** — add bullet points under the `# Unreleased` section at the top of the file.
+- **Release PR** (the PR that bumps `internal/clientset/version.go` to a new version) — rename `# Unreleased` to `# Release X.Y.Z` matching the new version, and add a fresh empty `# Unreleased` section above it.
+
+Keep entries concise: one line per change, prefixed with the affected resource/data-source path when relevant (e.g. `#### resource/coralogix_alert`).
+
 ## Public-repo discipline
 
 This is a public repo (`coralogix/terraform-provider-coralogix`). Internal ticket identifiers (`BUGV2-`, `CX-`, etc.) belong in **commit messages, PR descriptions, and branch names** — not in committed code, comments, doc strings, test fixtures, or example HCL. Use descriptive names instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ A bump usually requires adapting many resource files to the new SDK API surface 
 
 ## Changelog
 
-Every PR must update `CHANGELOG.md`. The CI `changelog-check` workflow enforces this and will block merges if the file is untouched. Add a `skip changelog` label to the PR to bypass the check (no release will be triggered for that PR).
+Every PR must update `CHANGELOG.md`. The CI `changelog-check` workflow enforces this and will block merges if the file is untouched. Add a `skip changelog` label to the PR to bypass the check.
 
 **Where to add your entry:**
 


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — prepends a `# Unreleased` section at the top. Contributors add their changes there; when a release is cut the section gets renamed to `# Release X.Y.Z` and a new empty `# Unreleased` is added back.
- **`changelog-check.yml`** — new required PR check: fails if `CHANGELOG.md` wasn't touched. Bypass by adding the `skip changelog` label (no release is triggered for those PRs either).

## After merging

Add `changelog-check / validate` as a **required status check** in the master branch protection settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)