### PR TITLE
Fix coralogix_integration import parameters

### DIFF
--- a/.claude/skills/framework-import-dynamic-attributes/SKILL.md
+++ b/.claude/skills/framework-import-dynamic-attributes/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: framework-import-dynamic-attributes
+description: "Use when a Terraform Plugin Framework resource import reads required DynamicAttribute values. Handle imported partial state before converting dynamic values."
+---
+
+# Framework Import Dynamic Attributes
+
+**Trigger:** A framework resource uses `ImportStatePassthroughID` and a required `schema.DynamicAttribute`.
+
+**Fix:** In `Read`, treat null, unknown, or zero-value dynamic attributes as absent imported state, fetch backend values, and only overwrite fetched state with prior dynamic state when the prior value is known.
+
+**Why:** Terraform import initially supplies only the imported ID, so converting a missing dynamic value as if it came from config can fail before the backend read populates state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+#### resource/coralogix_integration
+
+- FIX: Support importing integrations when Terraform has not populated dynamic `parameters` state yet.
+
 # Release 3.4.1
 
 #### resource/coralogix_api_key

--- a/internal/provider/integrations/data_source_coralogix_integration.go
+++ b/internal/provider/integrations/data_source_coralogix_integration.go
@@ -103,10 +103,12 @@ func (d *IntegrationDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 	state, e := integrationDetail(result, keys)
-	state.Parameters = data.Parameters
 	if e.HasError() {
 		resp.Diagnostics.Append(e...)
 		return
+	}
+	if hasKnownParameters(data.Parameters) {
+		state.Parameters = data.Parameters
 	}
 
 	diags = resp.State.Set(ctx, state)

--- a/internal/provider/integrations/resource_coralogix_integration.go
+++ b/internal/provider/integrations/resource_coralogix_integration.go
@@ -170,17 +170,24 @@ func (r *IntegrationResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	state, e := integrationDetail(readResult, keys)
-	state.Parameters = plan.Parameters
 	if e.HasError() {
 		resp.Diagnostics.Append(e...)
 		return
 	}
+	state.Parameters = plan.Parameters
 
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 }
 
 func KeysFromPlan(ctx context.Context, plan *IntegrationResourceModel) ([]string, diag.Diagnostics) {
+	if plan == nil {
+		return nil, nil
+	}
+	if !hasKnownParameters(plan.Parameters) {
+		return nil, nil
+	}
+
 	// extract keys first to filter the returned parameters later
 	parameters, diags := dynamicToParameters(plan.Parameters)
 	keys := make([]string, len(parameters))
@@ -287,6 +294,13 @@ func dynamicToParameters(planParameters types.Dynamic) ([]integrations.Parameter
 	return parameters, diag.Diagnostics{}
 }
 
+func hasKnownParameters(parameters types.Dynamic) bool {
+	if parameters.IsNull() || parameters.IsUnknown() || parameters.UnderlyingValue() == nil {
+		return false
+	}
+	return !parameters.IsUnderlyingValueNull() && !parameters.IsUnderlyingValueUnknown()
+}
+
 func collectionToParameters(elements []attr.Value) (*integrations.ParameterStringList, diag.Diagnostics) {
 	strings := make([]string, len(elements))
 	for i, value := range elements {
@@ -327,7 +341,7 @@ func parametersToDynamic(parameters []integrations.Parameter, keys []string) (ty
 	t := make(map[string]attr.Type, len(parameters))
 	for _, parameter := range parameters {
 
-		if parameter.ParameterStringList != nil && slices.Contains(keys, *parameter.ParameterStringList.Key) {
+		if parameter.ParameterStringList != nil && includeParameter(keys, parameter.ParameterStringList.Key) {
 			v := parameter.ParameterStringList
 			values := make([]attr.Value, len(v.StringList.Values))
 			assignedTypes := make([]attr.Type, len(v.StringList.Values))
@@ -342,23 +356,23 @@ func parametersToDynamic(parameters []integrations.Parameter, keys []string) (ty
 			obj[*parameter.ParameterStringList.Key] = parameters
 			t[*parameter.ParameterStringList.Key] = types.TupleType{ElemTypes: assignedTypes}
 
-		} else if parameter.ParameterBooleanValue != nil && slices.Contains(keys, *parameter.ParameterBooleanValue.Key) {
+		} else if parameter.ParameterBooleanValue != nil && includeParameter(keys, parameter.ParameterBooleanValue.Key) {
 			obj[*parameter.ParameterBooleanValue.Key] = types.BoolValue(parameter.ParameterBooleanValue.BooleanValue)
 			t[*parameter.ParameterBooleanValue.Key] = types.BoolType
 
-		} else if parameter.ParameterStringValue != nil && slices.Contains(keys, *parameter.ParameterStringValue.Key) {
+		} else if parameter.ParameterStringValue != nil && includeParameter(keys, parameter.ParameterStringValue.Key) {
 			obj[*parameter.ParameterStringValue.Key] = types.StringValue(parameter.ParameterStringValue.StringValue)
 			t[*parameter.ParameterStringValue.Key] = types.StringType
 
-		} else if parameter.ParameterNumericValue != nil && slices.Contains(keys, *parameter.ParameterNumericValue.Key) {
+		} else if parameter.ParameterNumericValue != nil && includeParameter(keys, parameter.ParameterNumericValue.Key) {
 			obj[*parameter.ParameterNumericValue.Key] = types.NumberValue(big.NewFloat(parameter.ParameterNumericValue.NumericValue))
 			t[*parameter.ParameterNumericValue.Key] = types.NumberType
 
-		} else if parameter.ParameterApiKey != nil && slices.Contains(keys, *parameter.ParameterApiKey.Key) {
+		} else if parameter.ParameterApiKey != nil && includeParameter(keys, parameter.ParameterApiKey.Key) {
 			obj[*parameter.ParameterApiKey.Key] = types.StringPointerValue(parameter.ParameterApiKey.ApiKey.Value)
 			t[*parameter.ParameterApiKey.Key] = types.StringType
 
-		} else if parameter.ParameterSensitiveData != nil && slices.Contains(keys, *parameter.ParameterSensitiveData.Key) {
+		} else if parameter.ParameterSensitiveData != nil && includeParameter(keys, parameter.ParameterSensitiveData.Key) {
 			obj[*parameter.ParameterSensitiveData.Key] = types.StringValue("<redacted>")
 			t[*parameter.ParameterSensitiveData.Key] = types.StringType
 		} else {
@@ -367,6 +381,10 @@ func parametersToDynamic(parameters []integrations.Parameter, keys []string) (ty
 	}
 	val, e := types.ObjectValue(t, obj)
 	return types.DynamicValue(val), e
+}
+
+func includeParameter(keys []string, key *string) bool {
+	return key != nil && (keys == nil || slices.Contains(keys, *key))
 }
 
 func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -402,10 +420,12 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 	state, e := integrationDetail(result, keys)
-	state.Parameters = plan.Parameters
 	if e.HasError() {
 		resp.Diagnostics.Append(e...)
 		return
+	}
+	if hasKnownParameters(plan.Parameters) {
+		state.Parameters = plan.Parameters
 	}
 
 	diags = resp.State.Set(ctx, state)
@@ -470,11 +490,11 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	state, e := integrationDetail(readResult, keys)
-	state.Parameters = plan.Parameters
 	if e.HasError() {
 		resp.Diagnostics.Append(e...)
 		return
 	}
+	state.Parameters = plan.Parameters
 
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/integrations/resource_coralogix_integration_test.go
+++ b/internal/provider/integrations/resource_coralogix_integration_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrations
+
+import (
+	"context"
+	"testing"
+
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/integration_service"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestKeysFromPlanAllowsImportedStateWithoutParameters(t *testing.T) {
+	model := &IntegrationResourceModel{}
+
+	keys, diags := KeysFromPlan(context.Background(), model)
+	if diags.HasError() {
+		t.Fatalf("expected imported state without parameters to be accepted, got diagnostics: %v", diags)
+	}
+	if keys != nil {
+		t.Fatalf("expected nil keys for imported state without parameters, got %v", keys)
+	}
+}
+
+func TestIntegrationDetailWithNilKeysIncludesBackendParameters(t *testing.T) {
+	id := "integration-id"
+	definitionKey := "slack-central"
+	definitionVersion := "1.0.0"
+	applicationNameKey := "ApplicationName"
+	enabledKey := "Enabled"
+
+	state, diags := integrationDetail(&cxsdk.GetDeployedIntegrationResponse{
+		Integration: &cxsdk.DeployedIntegrationInformation{
+			Id:                &id,
+			DefinitionKey:     &definitionKey,
+			DefinitionVersion: &definitionVersion,
+			Parameters: []cxsdk.Parameter{
+				{
+					ParameterStringValue: &cxsdk.ParameterStringValue{
+						Key:         &applicationNameKey,
+						StringValue: "svc-as-code",
+					},
+				},
+				{
+					ParameterBooleanValue: &cxsdk.ParameterBooleanValue{
+						Key:          &enabledKey,
+						BooleanValue: true,
+					},
+				},
+			},
+		},
+	}, nil)
+
+	if diags.HasError() {
+		t.Fatalf("expected integration detail to include all backend parameters, got diagnostics: %v", diags)
+	}
+
+	parameters, ok := state.Parameters.UnderlyingValue().(types.Object)
+	if !ok {
+		t.Fatalf("expected parameters to be an object, got %T", state.Parameters.UnderlyingValue())
+	}
+
+	attributes := parameters.Attributes()
+	if got := attributes[applicationNameKey].(types.String).ValueString(); got != "svc-as-code" {
+		t.Fatalf("expected %s parameter to be %q, got %q", applicationNameKey, "svc-as-code", got)
+	}
+	if got := attributes[enabledKey].(types.Bool).ValueBool(); !got {
+		t.Fatalf("expected %s parameter to be true", enabledKey)
+	}
+}


### PR DESCRIPTION
Jira: https://coralogix.atlassian.net/browse/CX-41068

## Problem
Importing an existing integration failed before Terraform could run `plan`:

```bash
terraform import coralogix_integration.generated 123456
```

During import Terraform initially gives the provider only the imported `id`. The `coralogix_integration` read path then tried to convert dynamic `parameters` from state before the backend read had populated them, so the provider returned `Parameters have to be an object` / `Invalid parameters: <nil>`.

## What changed
- Treat missing/null/unknown dynamic `parameters` as imported partial state instead of invalid config.
- Fetch the live integration first and hydrate `parameters` from the backend when no prior parameter state is known.
- Preserve user-provided dynamic `parameters` for normal create/update/read paths where state is already known.
- Add regression tests for the imported-state path and backend parameter hydration.
- Add a short repo skill documenting this Terraform Plugin Framework import pitfall.

## Testing
- `go test ./internal/provider/integrations -count=1`
- `make test`