### PR TITLE
fix: dial gRPC on api.private.* hosts for AWS PrivateLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### provider
 
 - FIX: When `domain` is an AWS PrivateLink management host (`api.private.<region>.coralogix.com`), dial gRPC on that host instead of `ng-api-grpc.<domain>` so dashboards and other gRPC resources work over PrivateLink.
+- FIX: Route SCIM users and groups REST clients to the PrivateLink management host (`https://api.private.<region>.coralogix.com/scim/...`) instead of `ng-api-http.api.private...`.
 
 #### resource/coralogix_integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+#### provider
+
+- FIX: When `domain` is an AWS PrivateLink management host (`api.private.<region>.coralogix.com`), dial gRPC on that host instead of `ng-api-grpc.<domain>` so dashboards and other gRPC resources work over PrivateLink.
+
 #### resource/coralogix_integration
 
 - FIX: Support importing integrations when Terraform has not populated dynamic `parameters` state yet.

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -205,8 +205,16 @@ func (c *ClientSet) DataEnrichments() (*ess.EnrichmentsServiceAPIService, *cess.
 }
 
 func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
-	apiKeySdk := newTerraformSDKCallPropertiesCreator(apiKey, TF_PROVIDER_VERSION, grpcTarget)
+	grpcCreator := newTerraformSDKCallPropertiesCreator(apiKey, TF_PROVIDER_VERSION, grpcTarget)
 	apikeyCPC := NewCallPropertiesCreator(grpcTarget, apiKey)
+
+	// UsersClient uses REST SCIM and type-asserts *cxsdk.SDKCallPropertiesCreator; a custom
+	// CallPropertiesCreator makes NewUsersClient return nil (see users-client.go).
+	sdkCreator := cxsdk.NewSDKCallPropertiesCreatorTerraform(
+		strings.ToLower(region),
+		cxsdk.NewAuthContext(apiKey, apiKey),
+		TF_PROVIDER_VERSION,
+	)
 
 	confBuilder := cxsdkOpenapi.NewConfigBuilder().
 		WithTerraformVersion(TF_PROVIDER_VERSION).
@@ -231,18 +239,18 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 
 	return &ClientSet{
 		// deprecated
-		dataSet:     cxsdk.NewDataSetClient(apiKeySdk),
-		enrichments: cxsdk.NewEnrichmentClient(apiKeySdk),
-		legacySlos:  cxsdk.NewLegacySLOsClient(apiKeySdk),
-		ruleGroups:  cxsdk.NewRuleGroupsClient(apiKeySdk),
-		teams:       cxsdk.NewTeamsClient(apiKeySdk),
+		dataSet:     cxsdk.NewDataSetClient(grpcCreator),
+		enrichments: cxsdk.NewEnrichmentClient(grpcCreator),
+		legacySlos:  cxsdk.NewLegacySLOsClient(grpcCreator),
+		ruleGroups:  cxsdk.NewRuleGroupsClient(grpcCreator),
+		teams:       cxsdk.NewTeamsClient(grpcCreator),
 
-		users: cxsdk.NewUsersClient(apiKeySdk),
+		users: cxsdk.NewUsersClient(sdkCreator),
 
 		// TODO
-		dashboards:     cxsdk.NewDashboardsClient(apiKeySdk),
-		events2Metrics: cxsdk.NewEvents2MetricsClient(apiKeySdk),
-		groupGrpc:      cxsdk.NewGroupsClient(apiKeySdk),
+		dashboards:     cxsdk.NewDashboardsClient(grpcCreator),
+		events2Metrics: cxsdk.NewEvents2MetricsClient(grpcCreator),
+		groupGrpc:      cxsdk.NewGroupsClient(grpcCreator),
 
 		dahboardsFolders:      cs.DashboardFolders(),
 		parsingRuleGroups:     cs.RuleGroups(),

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -53,7 +53,7 @@ type ClientSet struct {
 	legacySlos     *cxsdk.LegacySLOsClient
 	dashboards     *cxsdk.DashboardsClient
 	ruleGroups     *cxsdk.RuleGroupsClient
-	users          *cxsdk.UsersClient
+	users          *UsersClient
 	events2Metrics *cxsdk.Events2MetricsClient
 	groupGrpc      *cxsdk.GroupsClient
 	teams          *cxsdk.TeamsClient
@@ -167,7 +167,7 @@ func (c *ClientSet) Groups() *GroupsClient {
 	return c.groups
 }
 
-func (c *ClientSet) Users() *cxsdk.UsersClient {
+func (c *ClientSet) Users() *UsersClient {
 	return c.users
 }
 
@@ -208,14 +208,6 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 	grpcCreator := newTerraformSDKCallPropertiesCreator(apiKey, TF_PROVIDER_VERSION, grpcTarget)
 	apikeyCPC := NewCallPropertiesCreator(grpcTarget, apiKey)
 
-	// UsersClient uses REST SCIM and type-asserts *cxsdk.SDKCallPropertiesCreator; a custom
-	// CallPropertiesCreator makes NewUsersClient return nil (see users-client.go).
-	sdkCreator := cxsdk.NewSDKCallPropertiesCreatorTerraform(
-		strings.ToLower(region),
-		cxsdk.NewAuthContext(apiKey, apiKey),
-		TF_PROVIDER_VERSION,
-	)
-
 	confBuilder := cxsdkOpenapi.NewConfigBuilder().
 		WithTerraformVersion(TF_PROVIDER_VERSION).
 		WithAPIKey(apiKey)
@@ -245,7 +237,7 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 		ruleGroups:  cxsdk.NewRuleGroupsClient(grpcCreator),
 		teams:       cxsdk.NewTeamsClient(grpcCreator),
 
-		users: cxsdk.NewUsersClient(sdkCreator),
+		users: NewUsersClient(region, apiKey),
 
 		// TODO
 		dashboards:     cxsdk.NewDashboardsClient(grpcCreator),
@@ -275,6 +267,6 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 		customDataEnrichments: cs.CustomEnrichments(),
 		alertScheduler:        cs.AlertScheduler(),
 		grafana:               NewGrafanaClient(apikeyCPC),
-		groups:                NewGroupsClient(apikeyCPC),
+		groups:                NewGroupsClient(region, apiKey),
 	}
 }

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -204,9 +204,9 @@ func (c *ClientSet) DataEnrichments() (*ess.EnrichmentsServiceAPIService, *cess.
 	return c.dataEnrichments, c.customDataEnrichments
 }
 
-func NewClientSet(region string, apiKey string, targetUrl string) *ClientSet {
-	apiKeySdk := cxsdk.NewSDKCallPropertiesCreatorTerraform(strings.ToLower(region), cxsdk.NewAuthContext(apiKey, apiKey), TF_PROVIDER_VERSION)
-	apikeyCPC := NewCallPropertiesCreator(targetUrl, apiKey)
+func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
+	apiKeySdk := newTerraformSDKCallPropertiesCreator(apiKey, TF_PROVIDER_VERSION, grpcTarget)
+	apikeyCPC := NewCallPropertiesCreator(grpcTarget, apiKey)
 
 	confBuilder := cxsdkOpenapi.NewConfigBuilder().
 		WithTerraformVersion(TF_PROVIDER_VERSION).

--- a/internal/clientset/clientset_test.go
+++ b/internal/clientset/clientset_test.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientset
+
+import "testing"
+
+func TestNewClientSet_UsersClientNotNil(t *testing.T) {
+	t.Parallel()
+
+	cs := NewClientSet("eu2", "dummy-key", GrpcTargetFromDomain("eu2.coralogix.com"))
+	if cs.Users() == nil {
+		t.Fatal("Users() must not be nil; NewUsersClient requires *SDKCallPropertiesCreator")
+	}
+}

--- a/internal/clientset/clientset_test.go
+++ b/internal/clientset/clientset_test.go
@@ -21,6 +21,17 @@ func TestNewClientSet_UsersClientNotNil(t *testing.T) {
 
 	cs := NewClientSet("eu2", "dummy-key", GrpcTargetFromDomain("eu2.coralogix.com"))
 	if cs.Users() == nil {
-		t.Fatal("Users() must not be nil; NewUsersClient requires *SDKCallPropertiesCreator")
+		t.Fatal("Users() must not be nil")
+	}
+	if cs.Users().BaseURL() != "https://ng-api-http.eu2.coralogix.com/scim/Users" {
+		t.Fatalf("Users().BaseURL() = %q", cs.Users().BaseURL())
+	}
+
+	pl := NewClientSet("api.private.eu2.coralogix.com", "dummy-key", GrpcTargetFromDomain("api.private.eu2.coralogix.com"))
+	if pl.Users().BaseURL() != "https://api.private.eu2.coralogix.com/scim/Users" {
+		t.Fatalf("PrivateLink Users().BaseURL() = %q", pl.Users().BaseURL())
+	}
+	if pl.Groups().TargetUrl != "https://api.private.eu2.coralogix.com/scim/Groups" {
+		t.Fatalf("PrivateLink Groups TargetUrl = %q", pl.Groups().TargetUrl)
 	}
 }

--- a/internal/clientset/endpoints.go
+++ b/internal/clientset/endpoints.go
@@ -33,6 +33,37 @@ func GrpcTargetFromDomain(domain string) string {
 	return fmt.Sprintf("ng-api-grpc.%s:443", domain)
 }
 
+// ScimRestBaseURL returns the HTTPS base URL for SCIM REST APIs (users, groups) for the
+// given provider env or domain. PrivateLink management hosts use api.private.* directly;
+// public regions use ng-api-http.* (matching coralogix-management-sdk CoralogixRestEndpointFromRegion).
+func ScimRestBaseURL(regionOrDomain string) string {
+	regionOrDomain = normalizeProviderDomain(regionOrDomain)
+	if strings.HasPrefix(regionOrDomain, "api.private.") {
+		return "https://" + regionOrDomain
+	}
+
+	switch strings.ToLower(regionOrDomain) {
+	case "us1", "usa1":
+		return "https://ng-api-http.coralogix.us"
+	case "us2", "usa2":
+		return "https://ng-api-http.cx498.coralogix.com"
+	case "us3", "usa3":
+		return "https://ng-api-http.us3.coralogix.com"
+	case "eu1", "europe1":
+		return "https://ng-api-http.coralogix.com"
+	case "eu2", "europe2":
+		return "https://ng-api-http.eu2.coralogix.com"
+	case "ap1", "apac1":
+		return "https://ng-api-http.app.coralogix.in"
+	case "ap2", "apac2":
+		return "https://ng-api-http.coralogixsg.com"
+	case "ap3", "apac3":
+		return "https://ng-api-http.ap3.coralogix.com"
+	default:
+		return fmt.Sprintf("https://ng-api-http.%s", regionOrDomain)
+	}
+}
+
 func normalizeProviderDomain(domain string) string {
 	domain = strings.TrimSpace(domain)
 	domain = strings.TrimPrefix(domain, "https://")

--- a/internal/clientset/endpoints.go
+++ b/internal/clientset/endpoints.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientset
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GrpcTargetFromDomain returns the host:port used for gRPC management API calls when the
+// provider is configured with domain (CORALOGIX_DOMAIN).
+//
+// AWS PrivateLink exposes management REST and gRPC on api.private.<region>.coralogix.com
+// (see Coralogix endpoints docs). The public SaaS pattern ng-api-grpc.<domain> does not
+// apply to api.private.* hostnames.
+func GrpcTargetFromDomain(domain string) string {
+	domain = normalizeProviderDomain(domain)
+	if strings.HasPrefix(domain, "api.private.") {
+		return domain + ":443"
+	}
+	return fmt.Sprintf("ng-api-grpc.%s:443", domain)
+}
+
+func normalizeProviderDomain(domain string) string {
+	domain = strings.TrimSpace(domain)
+	domain = strings.TrimPrefix(domain, "https://")
+	domain = strings.TrimPrefix(domain, "http://")
+	return strings.TrimSuffix(domain, "/")
+}

--- a/internal/clientset/endpoints_test.go
+++ b/internal/clientset/endpoints_test.go
@@ -50,3 +50,35 @@ func TestGrpcTargetFromDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestScimRestBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		regionOrDomain string
+		want           string
+	}{
+		{
+			regionOrDomain: "api.private.eu2.coralogix.com",
+			want:           "https://api.private.eu2.coralogix.com",
+		},
+		{
+			regionOrDomain: "EU2",
+			want:           "https://ng-api-http.eu2.coralogix.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.regionOrDomain, func(t *testing.T) {
+			t.Parallel()
+			if got := ScimRestBaseURL(tt.regionOrDomain); got != tt.want {
+				t.Fatalf("ScimRestBaseURL(%q) = %q, want %q", tt.regionOrDomain, got, tt.want)
+			}
+		})
+	}
+
+	// SDK default for unknown domain must not be used for PrivateLink hosts.
+	if got := ScimRestBaseURL("api.private.eu1.coralogix.com"); got == "https://ng-api-http.api.private.eu1.coralogix.com" {
+		t.Fatalf("ScimRestBaseURL must not use ng-api-http prefix for api.private.*, got %q", got)
+	}
+}

--- a/internal/clientset/endpoints_test.go
+++ b/internal/clientset/endpoints_test.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientset
+
+import "testing"
+
+func TestGrpcTargetFromDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		domain string
+		want   string
+	}{
+		{
+			domain: "api.private.eu2.coralogix.com",
+			want:   "api.private.eu2.coralogix.com:443",
+		},
+		{
+			domain: "https://api.private.us1.coralogix.com/",
+			want:   "api.private.us1.coralogix.com:443",
+		},
+		{
+			domain: "custom.example.com",
+			want:   "ng-api-grpc.custom.example.com:443",
+		},
+		{
+			domain: "api.eu2.coralogix.com",
+			want:   "ng-api-grpc.api.eu2.coralogix.com:443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.domain, func(t *testing.T) {
+			t.Parallel()
+			if got := GrpcTargetFromDomain(tt.domain); got != tt.want {
+				t.Fatalf("GrpcTargetFromDomain(%q) = %q, want %q", tt.domain, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/clientset/groups-client.go
+++ b/internal/clientset/groups-client.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset/rest"
 )
@@ -106,8 +105,8 @@ func (c GroupsClient) DeleteGroup(ctx context.Context, groupID string) error {
 	return err
 }
 
-func NewGroupsClient(c *CallPropertiesCreator) *GroupsClient {
-	targetUrl := "https://" + strings.Replace(c.targetUrl, "grpc", "http", 1) + "/scim/Groups"
-	client := rest.NewRestClient(targetUrl, c.apiKey)
+func NewGroupsClient(regionOrDomain, apiKey string) *GroupsClient {
+	targetUrl := ScimRestBaseURL(regionOrDomain) + "/scim/Groups"
+	client := rest.NewRestClient(targetUrl, apiKey)
 	return &GroupsClient{client: client, TargetUrl: targetUrl}
 }

--- a/internal/clientset/terraform_sdk_call_properties.go
+++ b/internal/clientset/terraform_sdk_call_properties.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientset
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"runtime"
+	"time"
+
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	"github.com/google/uuid"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+)
+
+// gRPC metadata header names (must match coralogix-management-sdk/go/constants.go).
+const (
+	sdkVersionHeaderName       = "x-cx-sdk-version"
+	sdkLanguageHeaderName      = "x-cx-sdk-language"
+	sdkGoVersionHeaderName     = "x-cx-go-version"
+	sdkCorrelationIDHeaderName = "x-cx-correlation-id"
+)
+
+// terraformSDKCallPropertiesCreator dials an explicit gRPC target from the provider instead of
+// relying on SDK region→endpoint mapping (which prefixes ng-api-grpc. for custom domains).
+type terraformSDKCallPropertiesCreator struct {
+	grpcTarget       string
+	teamsLevelAPIKey string
+	userLevelAPIKey  string
+	correlationID    string
+	sdkVersion       string
+}
+
+func newTerraformSDKCallPropertiesCreator(apiKey, terraformProviderVersion, grpcTarget string) cxsdk.CallPropertiesCreator {
+	return &terraformSDKCallPropertiesCreator{
+		grpcTarget:       grpcTarget,
+		teamsLevelAPIKey: apiKey,
+		userLevelAPIKey:  apiKey,
+		correlationID:    uuid.NewString(),
+		sdkVersion:       fmt.Sprint("terraform-", terraformProviderVersion),
+	}
+}
+
+func (c *terraformSDKCallPropertiesCreator) GetTeamsLevelCallProperties(ctx context.Context) (*cxsdk.CallProperties, error) {
+	return c.callProperties(ctx, c.teamsLevelAPIKey)
+}
+
+func (c *terraformSDKCallPropertiesCreator) GetUserLevelCallProperties(ctx context.Context) (*cxsdk.CallProperties, error) {
+	return c.callProperties(ctx, c.userLevelAPIKey)
+}
+
+func (c *terraformSDKCallPropertiesCreator) callProperties(ctx context.Context, apiKey string) (*cxsdk.CallProperties, error) {
+	ctx = grpcOutgoingContext(ctx, apiKey, c.correlationID, c.sdkVersion)
+
+	conn, err := grpcSecureConnection(c.grpcTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cxsdk.CallProperties{
+		Ctx:         ctx,
+		Connection:  conn,
+		CallOptions: grpcCallOptions(),
+	}, nil
+}
+
+func grpcOutgoingContext(ctx context.Context, apiKey, correlationID, sdkVersion string) context.Context {
+	md := metadata.New(map[string]string{
+		"Authorization":            fmt.Sprintf("Bearer %s", apiKey),
+		sdkVersionHeaderName:       sdkVersion,
+		sdkLanguageHeaderName:      "go",
+		sdkGoVersionHeaderName:     runtime.Version(),
+		sdkCorrelationIDHeaderName: correlationID,
+	})
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func grpcCallOptions() []grpc.CallOption {
+	var opts []grpc.CallOption
+	opts = append(opts, grpc_retry.WithMax(5))
+	opts = append(opts, grpc_retry.WithBackoff(grpc_retry.BackoffLinear(time.Second)))
+	opts = append(opts, grpc.MaxCallRecvMsgSize(50*1024*1024))
+	opts = append(opts, grpc.MaxCallSendMsgSize(50*1024*1024))
+	return opts
+}
+
+func grpcSecureConnection(targetURL string) (*grpc.ClientConn, error) {
+	// Match coralogix-management-sdk/go/callPropertiesCreator.go (grpc.Dial for proxy compatibility).
+	return grpc.Dial(targetURL,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+}

--- a/internal/clientset/users_client.go
+++ b/internal/clientset/users_client.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientset
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	"github.com/coralogix/terraform-provider-coralogix/internal/clientset/rest"
+)
+
+// UsersClient calls the SCIM Users API with a region/domain-aware management base URL.
+type UsersClient struct {
+	client  *rest.Client
+	baseURL string
+}
+
+// NewUsersClient builds a SCIM users client for provider env or domain configuration.
+func NewUsersClient(regionOrDomain, apiKey string) *UsersClient {
+	baseURL := ScimRestBaseURL(regionOrDomain) + "/scim/Users"
+	return &UsersClient{
+		client:  rest.NewRestClient(baseURL, apiKey),
+		baseURL: baseURL,
+	}
+}
+
+// BaseURL returns the SCIM Users collection URL.
+func (c *UsersClient) BaseURL() string {
+	return c.baseURL
+}
+
+// Create creates a new SCIM user.
+func (c *UsersClient) Create(ctx context.Context, userReq *cxsdk.SCIMUser) (*cxsdk.SCIMUser, error) {
+	body, err := json.Marshal(userReq)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyResp, err := c.client.Post(ctx, "", "application/json", string(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var userResp cxsdk.SCIMUser
+	if err := json.Unmarshal([]byte(bodyResp), &userResp); err != nil {
+		return nil, err
+	}
+
+	return &userResp, nil
+}
+
+// Get retrieves a SCIM user by ID.
+func (c *UsersClient) Get(ctx context.Context, userID string) (*cxsdk.SCIMUser, error) {
+	bodyResp, err := c.client.Get(ctx, fmt.Sprintf("/%s", userID))
+	if err != nil {
+		return nil, err
+	}
+
+	var userResp cxsdk.SCIMUser
+	if err := json.Unmarshal([]byte(bodyResp), &userResp); err != nil {
+		return nil, err
+	}
+
+	return &userResp, nil
+}
+
+// List retrieves all SCIM users.
+func (c *UsersClient) List(ctx context.Context) ([]cxsdk.SCIMUser, error) {
+	bodyResp, err := c.client.Get(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var listResp struct {
+		Resources []cxsdk.SCIMUser `json:"Resources"`
+	}
+	if err := json.Unmarshal([]byte(bodyResp), &listResp); err != nil {
+		return nil, err
+	}
+
+	return listResp.Resources, nil
+}
+
+// Update updates a SCIM user by ID.
+func (c *UsersClient) Update(ctx context.Context, userID string, userReq *cxsdk.SCIMUser) (*cxsdk.SCIMUser, error) {
+	body, err := json.Marshal(userReq)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyResp, err := c.client.Put(ctx, fmt.Sprintf("/%s", userID), "application/json", string(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var userResp cxsdk.SCIMUser
+	if err := json.Unmarshal([]byte(bodyResp), &userResp); err != nil {
+		return nil, err
+	}
+
+	return &userResp, nil
+}
+
+// Delete deletes a SCIM user by ID.
+func (c *UsersClient) Delete(ctx context.Context, userID string) error {
+	_, err := c.client.Delete(ctx, fmt.Sprintf("/%s", userID))
+	return err
+}

--- a/internal/provider/aaa/data_source_coralogix_user.go
+++ b/internal/provider/aaa/data_source_coralogix_user.go
@@ -36,7 +36,7 @@ func NewUserDataSource() datasource.DataSource {
 }
 
 type UserDataSource struct {
-	client *cxsdk.UsersClient
+	client *clientset.UsersClient
 }
 
 func (d *UserDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/aaa/resource_coralogix_user.go
+++ b/internal/provider/aaa/resource_coralogix_user.go
@@ -46,7 +46,7 @@ func NewUserResource() resource.Resource {
 }
 
 type UserResource struct {
-	client *cxsdk.UsersClient
+	client *clientset.UsersClient
 }
 
 func (r *UserResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -114,7 +114,7 @@ func OldProvider() *oldSchema.Provider {
 				Optional: true,
 				//ForceNew: true,
 				//DefaultFunc:   oldSchema.EnvDefaultFunc("CORALOGIX_DOMAIN", nil),
-				Description:   "The Coralogix domain. Conflict With 'env'. environment variable 'CORALOGIX_DOMAIN' can be defined instead.",
+				Description:   "The Coralogix domain. For AWS PrivateLink use the management API host (e.g. api.private.eu2.coralogix.com). Conflict With 'env'. environment variable 'CORALOGIX_DOMAIN' can be defined instead.",
 				ConflictsWith: []string{"env"},
 			},
 			"api_key": {
@@ -153,7 +153,7 @@ func OldProvider() *oldSchema.Provider {
 					cxEnv = env.(string)
 				}
 			} else if domain, ok := d.GetOk("domain"); ok && domain.(string) != "" {
-				targetUrl = fmt.Sprintf("ng-api-grpc.%s:443", domain)
+				targetUrl = clientset.GrpcTargetFromDomain(domain.(string))
 				cxEnv = domain.(string)
 			} else if env = strings.ToUpper(os.Getenv("CORALOGIX_ENV")); env != "" {
 				if url, ok := terraformEnvironmentAliasToGrpcUrl[env.(string)]; !ok {
@@ -163,7 +163,7 @@ func OldProvider() *oldSchema.Provider {
 					cxEnv = env.(string)
 				}
 			} else if domain := os.Getenv("CORALOGIX_DOMAIN"); domain != "" {
-				targetUrl = fmt.Sprintf("ng-api-grpc.%s:443", domain)
+				targetUrl = clientset.GrpcTargetFromDomain(domain)
 				cxEnv = domain
 			} else {
 				return nil, diag.Errorf("At least one of the fields 'env' or 'domain', or one of the environment variables 'CORALOGIX_ENV' or 'CORALOGIX_DOMAIN' have to be defined")
@@ -222,7 +222,7 @@ func (p *coralogixProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("domain")),
 				},
-				Description: "The Coralogix domain. Conflict With 'env'. environment variable 'CORALOGIX_DOMAIN' can be defined instead.",
+				Description: "The Coralogix domain. For AWS PrivateLink use the management API host (e.g. api.private.eu2.coralogix.com). Conflict With 'env'. environment variable 'CORALOGIX_DOMAIN' can be defined instead.",
 			},
 			"api_key": schema.StringAttribute{
 				Optional:    true,
@@ -344,7 +344,7 @@ func (p *coralogixProvider) Configure(ctx context.Context, req provider.Configur
 	if terraformEnvironmentAlias != "" {
 		targetUrl = terraformEnvironmentAliasToGrpcUrl[terraformEnvironmentAlias]
 	} else {
-		targetUrl = fmt.Sprintf("ng-api-grpc.%s:443", domain)
+		targetUrl = clientset.GrpcTargetFromDomain(domain)
 	}
 
 	sdkEnvironment := terraformEnvironmentAliasToSdkEnvironment[terraformEnvironmentAlias]


### PR DESCRIPTION
### Description

Fixes CDS-2936 and NSR-139.

When domain is a PrivateLink management host (`api.private.<region>.coralogix.com`), use that host for gRPC (:443) instead of `ng-api-grpc.<domain>`, which is not published in Private DNS. REST already used the same host via URLFromDomain; dashboards and other gRPC resources failed with "no such host".

Route all Terraform SDK gRPC calls through an explicit grpc target from the provider. Validated on EU2 PrivateLink: `coralogix_action` and `coralogix_dashboard` apply with domain = `api.private.eu2.coralogix.com`.

### Acceptance tests

```
➜  terraform-provider-coralogix git:(fix-grpc-pl-hosts) ✗ TF_ACC=1 go 
test ./internal/provider/... -run TestAccCoralogixResourceDashboard -v 
-timeout 30m

=== RUN   TestAccCoralogixResourceDashboard
--- PASS: TestAccCoralogixResourceDashboard (39.02s)
=== RUN   TestAccCoralogixResourceDashboardHexagonWidget
--- PASS: TestAccCoralogixResourceDashboardHexagonWidget (11.05s)
=== RUN   TestAccCoralogixResourceDashboardLinechartWidget
--- PASS: TestAccCoralogixResourceDashboardLinechartWidget (12.07s)
=== RUN   TestAccCoralogixResourceDashboardGaugeWidget
--- PASS: TestAccCoralogixResourceDashboardGaugeWidget (12.48s)
=== RUN   TestAccCoralogixResourceDashboardGaugeWidgetDataPrime
--- PASS: TestAccCoralogixResourceDashboardGaugeWidgetDataPrime (12.23s)
=== RUN   TestAccCoralogixResourceDashboardDataTableWidget
--- PASS: TestAccCoralogixResourceDashboardDataTableWidget (11.40s)
=== RUN   TestAccCoralogixResourceDashboardFromJson
--- PASS: TestAccCoralogixResourceDashboardFromJson (1.64s)
=== RUN   TestAccCoralogixResourceDashboardFromJsonWithFolder
--- PASS: TestAccCoralogixResourceDashboardFromJsonWithFolder (1.97s)
=== RUN   TestAccCoralogixResourceDashboardFromJsonWithVar
--- PASS: TestAccCoralogixResourceDashboardFromJsonWithVar (1.65s)
=== RUN   TestAccCoralogixResourceDashboardLayoutColor
--- PASS: TestAccCoralogixResourceDashboardLayoutColor (10.78s)
=== RUN   TestAccCoralogixResourceDashboardsFolder
--- PASS: TestAccCoralogixResourceDashboardsFolder (1.41s)
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider    116.228s
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/aaa        (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/actions    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/alerts     (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/alerts/alert_schema        [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/alerts/alert_types [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/apm        [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema        [no test files]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_widgets       (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/data_exploration   [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/dataengine [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/dataplans  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/enrichment_rules   (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/events2metrics     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/integrations       (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/logs       [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/metrics    [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/notifications      [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/notifications/global_router_schema [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/parsing_rules      [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/recording_rules    [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/slo_mgmt   [no test files]
```

+ added some tests for `endpoints` and `clientset`

### Release Note

Already add it to `Unreleased` section, let me know if it needs to be removed.

```
#### provider

- FIX: When `domain` is an AWS PrivateLink management host (`api.private.<region>.coralogix.com`), dial gRPC on that host instead of `ng-api-grpc.<domain>` so dashboards and other gRPC resources work over PrivateLink.
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment