### PR TITLE
Migrate dashboards to OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - FIX: Support importing integrations when Terraform has not populated dynamic `parameters` state yet.
 
+#### resource/coralogix_dashboard
+
+- FIX: Use the OpenAPI custom dashboard API instead of the gRPC API.
+
 # Release 3.4.1
 
 #### resource/coralogix_api_key

--- a/examples/resources/coralogix_dashboard/dashboard_openapi_minimal_folder_path.json
+++ b/examples/resources/coralogix_dashboard/dashboard_openapi_minimal_folder_path.json
@@ -1,0 +1,11 @@
+{
+  "name": "openapi-minimal-folder-path",
+  "layout": {},
+  "relativeTimeFrame": "900s",
+  "off": {},
+  "folderPath": {
+    "segments": [
+      "openapi-test-folder"
+    ]
+  }
+}

--- a/examples/resources/coralogix_dashboard/dashboard_openapi_minimal_root.json
+++ b/examples/resources/coralogix_dashboard/dashboard_openapi_minimal_root.json
@@ -1,0 +1,6 @@
+{
+  "name": "openapi-minimal-root",
+  "layout": {},
+  "relativeTimeFrame": "900s",
+  "off": {}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260528121651-1cb0c1f8e8a0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3 h1:s9A0yKgkinPwoed3x1rvSkWDgqzh6UESyeMB8hBANsY=
 github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260528121651-1cb0c1f8e8a0 h1:QSJ+QawI6dGVD59AXGnHUJ9TTY9t0Y9k1rHOHEjQ2X8=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260528121651-1cb0c1f8e8a0/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -221,6 +221,10 @@ func NewClientSet(region string, apiKey string, targetUrl string) *ClientSet {
 
 	_, found := cxsdkOpenapi.URLFromRegion(strings.ToLower(region))
 	if !found {
+		// The Terraform provider has a legacy domain/CORALOGIX_DOMAIN path that
+		// builds gRPC clients from ng-api-grpc.<domain>. OpenAPI clients need the
+		// API host for that same domain instead. Region aliases still go through
+		// URLFromRegion above.
 		url := openAPIURLFromDomain(region)
 		confBuilder.WithURL(url)
 	} else {

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -28,6 +28,7 @@ import (
 	connectors "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/connectors_service"
 	cess "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/custom_enrichments_service"
 	dbfs "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_folders_service"
+	dashboardService "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
 	ess "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/enrichments_service"
 
 	globalRouters "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/global_routers_service"
@@ -59,6 +60,7 @@ type ClientSet struct {
 	teams          *cxsdk.TeamsClient
 
 	dahboardsFolders      *dbfs.DashboardFoldersServiceAPIService
+	dashboardsOpenAPI     *dashboardService.DashboardServiceAPIService
 	customDataEnrichments *cess.CustomEnrichmentsServiceAPIService
 	dataEnrichments       *ess.EnrichmentsServiceAPIService
 	parsingRuleGroups     *prgs.RuleGroupsServiceAPIService
@@ -113,6 +115,10 @@ func (c *ClientSet) DataSet() *cxsdk.DataSetClient {
 
 func (c *ClientSet) Dashboards() *cxsdk.DashboardsClient {
 	return c.dashboards
+}
+
+func (c *ClientSet) DashboardsOpenAPI() *dashboardService.DashboardServiceAPIService {
+	return c.dashboardsOpenAPI
 }
 
 func (c *ClientSet) Grafana() *GrafanaClient {
@@ -245,6 +251,7 @@ func NewClientSet(region string, apiKey string, targetUrl string) *ClientSet {
 		groupGrpc:      cxsdk.NewGroupsClient(apiKeySdk),
 
 		dahboardsFolders:      cs.DashboardFolders(),
+		dashboardsOpenAPI:     cs.Dashboards(),
 		parsingRuleGroups:     cs.RuleGroups(),
 		archiveMetrics:        cs.ArchiveMetrics(),
 		alerts:                cs.Alerts(),

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -16,6 +16,7 @@ package clientset
 
 import (
 	"log/slog"
+	gourl "net/url"
 	"os"
 	"strings"
 
@@ -220,7 +221,7 @@ func NewClientSet(region string, apiKey string, targetUrl string) *ClientSet {
 
 	_, found := cxsdkOpenapi.URLFromRegion(strings.ToLower(region))
 	if !found {
-		url := cxsdkOpenapi.URLFromDomain(region)
+		url := openAPIURLFromDomain(region)
 		confBuilder.WithURL(url)
 	} else {
 		confBuilder.WithRegion(strings.ToLower(region))
@@ -276,4 +277,22 @@ func NewClientSet(region string, apiKey string, targetUrl string) *ClientSet {
 		grafana:               NewGrafanaClient(apikeyCPC),
 		groups:                NewGroupsClient(apikeyCPC),
 	}
+}
+
+func openAPIURLFromDomain(domain string) string {
+	host := strings.TrimSpace(domain)
+	if parsed, err := gourl.Parse(host); err == nil && parsed.Host != "" {
+		host = parsed.Host
+	}
+	host = strings.Trim(host, "/")
+	if !strings.HasPrefix(host, "api.") {
+		host = "api." + host
+	}
+
+	url := gourl.URL{
+		Scheme: "https",
+		Host:   host,
+		Path:   "mgmt/openapi/5",
+	}
+	return url.String()
 }

--- a/internal/clientset/clientset_test.go
+++ b/internal/clientset/clientset_test.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientset
+
+import "testing"
+
+func TestOpenAPIURLFromDomain(t *testing.T) {
+	tests := map[string]string{
+		"root domain":     "https://api.coralogix.com/mgmt/openapi/5",
+		"api domain":      "https://api.coralogix.com/mgmt/openapi/5",
+		"https domain":    "https://api.coralogix.com/mgmt/openapi/5",
+		"trailing slash":  "https://api.eu2.coralogix.com/mgmt/openapi/5",
+		"regional domain": "https://api.eu2.coralogix.com/mgmt/openapi/5",
+	}
+
+	inputs := map[string]string{
+		"root domain":     "coralogix.com",
+		"api domain":      "api.coralogix.com",
+		"https domain":    "https://coralogix.com",
+		"trailing slash":  "eu2.coralogix.com/",
+		"regional domain": "eu2.coralogix.com",
+	}
+
+	for name, want := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := openAPIURLFromDomain(inputs[name]); got != want {
+				t.Fatalf("openAPIURLFromDomain(%q) = %q, want %q", inputs[name], got, want)
+			}
+		})
+	}
+}

--- a/internal/clientset/clientset_test.go
+++ b/internal/clientset/clientset_test.go
@@ -18,19 +18,17 @@ import "testing"
 
 func TestOpenAPIURLFromDomain(t *testing.T) {
 	tests := map[string]string{
-		"root domain":     "https://api.coralogix.com/mgmt/openapi/5",
-		"api domain":      "https://api.coralogix.com/mgmt/openapi/5",
-		"https domain":    "https://api.coralogix.com/mgmt/openapi/5",
-		"trailing slash":  "https://api.eu2.coralogix.com/mgmt/openapi/5",
-		"regional domain": "https://api.eu2.coralogix.com/mgmt/openapi/5",
+		"root domain":    "https://api.coralogix.com/mgmt/openapi/5",
+		"api domain":     "https://api.coralogix.com/mgmt/openapi/5",
+		"https domain":   "https://api.coralogix.com/mgmt/openapi/5",
+		"trailing slash": "https://api.custom.example/mgmt/openapi/5",
 	}
 
 	inputs := map[string]string{
-		"root domain":     "coralogix.com",
-		"api domain":      "api.coralogix.com",
-		"https domain":    "https://coralogix.com",
-		"trailing slash":  "eu2.coralogix.com/",
-		"regional domain": "eu2.coralogix.com",
+		"root domain":    "coralogix.com",
+		"api domain":     "api.coralogix.com",
+		"https domain":   "https://coralogix.com",
+		"trailing slash": "custom.example/",
 	}
 
 	for name, want := range tests {

--- a/internal/provider/dashboards/dashboard_openapi.go
+++ b/internal/provider/dashboards/dashboard_openapi.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"encoding/json"
+	"strings"
+
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	dashboardService "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+	dashboardschema "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func openAPIDashboardFromProto(dashboard *cxsdk.Dashboard) (dashboardService.Dashboard, diag.Diagnostics) {
+	if dashboard == nil {
+		return dashboardService.Dashboard{}, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting Dashboard to OpenAPI", "dashboard was nil")}
+	}
+
+	dashboardCopy, ok := proto.Clone(dashboard).(*cxsdk.Dashboard)
+	if !ok {
+		return dashboardService.Dashboard{}, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting Dashboard to OpenAPI", "failed to clone dashboard")}
+	}
+
+	if dashboardCopy.GetAutoRefresh() == nil {
+		dashboardCopy.AutoRefresh = &cxsdk.DashboardOff{Off: &cxsdk.DashboardAutoRefreshOff{}}
+	}
+
+	if dashboardCopy.GetTimeFrame() == nil {
+		return dashboardService.Dashboard{}, diag.Diagnostics{diag.NewErrorDiagnostic(
+			"Dashboard time frame is required for OpenAPI",
+			"OpenAPI requires exactly one of absoluteTimeFrame or relativeTimeFrame. Set the dashboard time_frame attribute or include one of those fields in content_json.",
+		)}
+	}
+
+	data, err := protojson.MarshalOptions{EmitUnpopulated: false}.Marshal(dashboardCopy)
+	if err != nil {
+		return dashboardService.Dashboard{}, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting Dashboard to OpenAPI", err.Error())}
+	}
+
+	var openAPIDashboard dashboardService.Dashboard
+	if err := json.Unmarshal(data, &openAPIDashboard); err != nil {
+		return dashboardService.Dashboard{}, diag.Diagnostics{openAPIDashboardDiagnostic(err)}
+	}
+
+	return openAPIDashboard, nil
+}
+
+func protoDashboardFromOpenAPI(dashboard dashboardService.Dashboard) (*cxsdk.Dashboard, diag.Diagnostics) {
+	data, err := json.Marshal(dashboard)
+	if err != nil {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting OpenAPI Dashboard", err.Error())}
+	}
+
+	protoDashboard := new(cxsdk.Dashboard)
+	if err := dashboardschema.JSONUnmarshal.Unmarshal(data, protoDashboard); err != nil {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting OpenAPI Dashboard", err.Error())}
+	}
+
+	return protoDashboard, nil
+}
+
+func newDashboardRequestID() string {
+	return uuid.NewString()
+}
+
+func openAPIDashboardDiagnostic(err error) diag.Diagnostic {
+	if strings.Contains(err.Error(), "oneOf(Dashboard)") {
+		return diag.NewErrorDiagnostic(
+			"Dashboard does not match OpenAPI dashboard schema",
+			"OpenAPI requires exactly one dashboard time frame and exactly one auto-refresh value. Set one of absoluteTimeFrame or relativeTimeFrame, and one of off, twoMinutes, or fiveMinutes. Original error: "+err.Error(),
+		)
+	}
+
+	return diag.NewErrorDiagnostic("Error converting Dashboard to OpenAPI", err.Error())
+}

--- a/internal/provider/dashboards/dashboard_openapi.go
+++ b/internal/provider/dashboards/dashboard_openapi.go
@@ -17,6 +17,7 @@ package dashboards
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	dashboardService "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
@@ -25,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func openAPIDashboardFromProto(dashboard *cxsdk.Dashboard) (dashboardService.Dashboard, diag.Diagnostics) {
@@ -42,10 +44,7 @@ func openAPIDashboardFromProto(dashboard *cxsdk.Dashboard) (dashboardService.Das
 	}
 
 	if dashboardCopy.GetTimeFrame() == nil {
-		return dashboardService.Dashboard{}, diag.Diagnostics{diag.NewErrorDiagnostic(
-			"Dashboard time frame is required for OpenAPI",
-			"OpenAPI requires exactly one of absoluteTimeFrame or relativeTimeFrame. Set the dashboard time_frame attribute or include one of those fields in content_json.",
-		)}
+		dashboardCopy.TimeFrame = &cxsdk.DashboardRelativeTimeFrame{RelativeTimeFrame: durationpb.New(15 * time.Minute)}
 	}
 
 	data, err := protojson.MarshalOptions{EmitUnpopulated: false}.Marshal(dashboardCopy)

--- a/internal/provider/dashboards/dashboard_openapi_test.go
+++ b/internal/provider/dashboards/dashboard_openapi_test.go
@@ -257,6 +257,35 @@ func TestShouldPreserveOmittedDashboardTimeFrame(t *testing.T) {
 	}
 }
 
+func TestPreserveDashboardTimeFrameForReplace(t *testing.T) {
+	dashboard := testDashboardProto()
+	dashboard.TimeFrame = nil
+	existingDashboard := testDashboardProto()
+	existingDashboard.TimeFrame = testAbsoluteTimeFrame()
+
+	preserveDashboardTimeFrameForReplace(dashboard, existingDashboard)
+
+	if _, ok := dashboard.GetTimeFrame().(*cxsdk.DashboardAbsoluteTimeFrame); !ok {
+		t.Fatalf("expected replace dashboard to preserve existing absolute time frame, got %T", dashboard.GetTimeFrame())
+	}
+}
+
+func TestFlattenDashboardUnsupportedAutoRefreshDiagnostics(t *testing.T) {
+	dashboard := unmarshalOpenAPIDashboard(t, `{"name":"unsupported-refresh","layout":{},"relativeTimeFrame":"900s","oneMinute":{}}`)
+	protoDashboard, diags := protoDashboardFromOpenAPI(dashboard)
+	if diags.HasError() {
+		t.Fatalf("unexpected conversion diagnostics: %v", diags)
+	}
+
+	_, diags = flattenDashboard(context.Background(), DashboardResourceModel{}, protoDashboard, false)
+	if !diags.HasError() {
+		t.Fatal("expected unsupported auto-refresh diagnostic")
+	}
+	if detail := diags[0].Detail(); !strings.Contains(detail, "off") || !strings.Contains(detail, "two_minutes") || !strings.Contains(detail, "five_minutes") {
+		t.Fatalf("expected diagnostic to mention supported auto-refresh values, got %q", detail)
+	}
+}
+
 func TestOpenAPIDashboardOneOfConflictDiagnostics(t *testing.T) {
 	tests := map[string]string{
 		"both time frame variants": `{

--- a/internal/provider/dashboards/dashboard_openapi_test.go
+++ b/internal/provider/dashboards/dashboard_openapi_test.go
@@ -206,18 +206,21 @@ func TestProtoDashboardFromOpenAPIReadableUnsupportedRefreshVariants(t *testing.
 	}
 }
 
-func TestOpenAPIDashboardFromProtoMissingTimeFrame(t *testing.T) {
+func TestOpenAPIDashboardFromProtoMissingTimeFrameDefaultsToRelative(t *testing.T) {
 	dashboard := testDashboardProto()
 	dashboard.TimeFrame = nil
 
-	_, diags := openAPIDashboardFromProto(dashboard)
-	if !diags.HasError() {
-		t.Fatal("expected missing time frame diagnostic")
+	openAPIDashboard, diags := openAPIDashboardFromProto(dashboard)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
 
-	detail := diags[0].Detail()
-	if !strings.Contains(detail, "absoluteTimeFrame") || !strings.Contains(detail, "relativeTimeFrame") {
-		t.Fatalf("expected diagnostic to mention required OpenAPI time frame choices, got %q", detail)
+	roundtripped, diags := protoDashboardFromOpenAPI(openAPIDashboard)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics after roundtrip: %v", diags)
+	}
+	if got := roundtripped.GetRelativeTimeFrame().AsDuration(); got != 15*time.Minute {
+		t.Fatalf("expected missing time frame to default to 15m relative, got %s", got)
 	}
 }
 

--- a/internal/provider/dashboards/dashboard_openapi_test.go
+++ b/internal/provider/dashboards/dashboard_openapi_test.go
@@ -1,0 +1,385 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	dashboardService "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+	dashboardschema "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestOpenAPIDashboardFromProtoOneOfVariants(t *testing.T) {
+	tests := map[string]struct {
+		mutate func(*cxsdk.Dashboard)
+		assert func(*testing.T, cxsdk.Dashboard)
+	}{
+		"relative off no folder": {
+			mutate: func(d *cxsdk.Dashboard) {},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if d.GetTimeFrame() == nil || d.GetAutoRefresh() == nil {
+					t.Fatalf("expected time frame and auto refresh after roundtrip")
+				}
+				if d.GetFolderId() != nil || d.GetFolderPath() != nil {
+					t.Fatalf("expected no folder after roundtrip")
+				}
+			},
+		},
+		"relative two minutes": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.AutoRefresh = &cxsdk.DashboardTwoMinutes{TwoMinutes: &cxsdk.DashboardAutoRefreshTwoMinutes{}}
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if _, ok := d.GetAutoRefresh().(*cxsdk.DashboardTwoMinutes); !ok {
+					t.Fatalf("expected two minute auto refresh, got %T", d.GetAutoRefresh())
+				}
+			},
+		},
+		"relative five minutes": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.AutoRefresh = &cxsdk.DashboardFiveMinutes{FiveMinutes: &cxsdk.DashboardAutoRefreshFiveMinutes{}}
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if _, ok := d.GetAutoRefresh().(*cxsdk.DashboardFiveMinutes); !ok {
+					t.Fatalf("expected five minute auto refresh, got %T", d.GetAutoRefresh())
+				}
+			},
+		},
+		"absolute off": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.TimeFrame = testAbsoluteTimeFrame()
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if _, ok := d.GetTimeFrame().(*cxsdk.DashboardAbsoluteTimeFrame); !ok {
+					t.Fatalf("expected absolute time frame, got %T", d.GetTimeFrame())
+				}
+			},
+		},
+		"absolute two minutes": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.TimeFrame = testAbsoluteTimeFrame()
+				d.AutoRefresh = &cxsdk.DashboardTwoMinutes{TwoMinutes: &cxsdk.DashboardAutoRefreshTwoMinutes{}}
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if _, ok := d.GetTimeFrame().(*cxsdk.DashboardAbsoluteTimeFrame); !ok {
+					t.Fatalf("expected absolute time frame, got %T", d.GetTimeFrame())
+				}
+				if _, ok := d.GetAutoRefresh().(*cxsdk.DashboardTwoMinutes); !ok {
+					t.Fatalf("expected two minute auto refresh, got %T", d.GetAutoRefresh())
+				}
+			},
+		},
+		"absolute five minutes": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.TimeFrame = testAbsoluteTimeFrame()
+				d.AutoRefresh = &cxsdk.DashboardFiveMinutes{FiveMinutes: &cxsdk.DashboardAutoRefreshFiveMinutes{}}
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if _, ok := d.GetTimeFrame().(*cxsdk.DashboardAbsoluteTimeFrame); !ok {
+					t.Fatalf("expected absolute time frame, got %T", d.GetTimeFrame())
+				}
+				if _, ok := d.GetAutoRefresh().(*cxsdk.DashboardFiveMinutes); !ok {
+					t.Fatalf("expected five minute auto refresh, got %T", d.GetAutoRefresh())
+				}
+			},
+		},
+		"folder id": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.FolderId = &cxsdk.UUID{Value: "folder-id"}
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if d.GetFolderId().GetValue() != "folder-id" {
+					t.Fatalf("expected folder id to roundtrip, got %q", d.GetFolderId().GetValue())
+				}
+			},
+		},
+		"folder path": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.FolderPath = &cxsdk.FolderPath{Segments: []string{"parent", "child"}}
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if got := strings.Join(d.GetFolderPath().GetSegments(), "/"); got != "parent/child" {
+					t.Fatalf("expected folder path to roundtrip, got %q", got)
+				}
+			},
+		},
+		"both folder fields": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.FolderId = &cxsdk.UUID{Value: "folder-id"}
+				d.FolderPath = &cxsdk.FolderPath{Segments: []string{"parent", "child"}}
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if d.GetFolderId().GetValue() != "folder-id" {
+					t.Fatalf("expected folder id to roundtrip, got %q", d.GetFolderId().GetValue())
+				}
+				if got := strings.Join(d.GetFolderPath().GetSegments(), "/"); got != "parent/child" {
+					t.Fatalf("expected folder path to roundtrip, got %q", got)
+				}
+			},
+		},
+		"missing auto refresh defaults to off": {
+			mutate: func(d *cxsdk.Dashboard) {
+				d.AutoRefresh = nil
+			},
+			assert: func(t *testing.T, d cxsdk.Dashboard) {
+				if _, ok := d.GetAutoRefresh().(*cxsdk.DashboardOff); !ok {
+					t.Fatalf("expected off auto refresh, got %T", d.GetAutoRefresh())
+				}
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			dashboard := testDashboardProto()
+			tt.mutate(dashboard)
+
+			openAPIDashboard, diags := openAPIDashboardFromProto(dashboard)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			roundtripped, diags := protoDashboardFromOpenAPI(openAPIDashboard)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics after roundtrip: %v", diags)
+			}
+
+			tt.assert(t, *roundtripped)
+		})
+	}
+}
+
+func TestProtoDashboardFromOpenAPIReadableUnsupportedRefreshVariants(t *testing.T) {
+	tests := map[string]struct {
+		json   string
+		assert func(*testing.T, *cxsdk.Dashboard)
+	}{
+		"one minute": {
+			json: `{"name":"read-one-minute","layout":{},"relativeTimeFrame":"900s","oneMinute":{}}`,
+			assert: func(t *testing.T, d *cxsdk.Dashboard) {
+				if d.GetOneMinute() == nil {
+					t.Fatalf("expected oneMinute to roundtrip, got %T", d.GetAutoRefresh())
+				}
+			},
+		},
+		"fifteen minutes": {
+			json: `{"name":"read-fifteen-minutes","layout":{},"relativeTimeFrame":"900s","fifteenMinutes":{}}`,
+			assert: func(t *testing.T, d *cxsdk.Dashboard) {
+				if d.GetFifteenMinutes() == nil {
+					t.Fatalf("expected fifteenMinutes to roundtrip, got %T", d.GetAutoRefresh())
+				}
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			openAPIDashboard := unmarshalOpenAPIDashboard(t, tt.json)
+			dashboard, diags := protoDashboardFromOpenAPI(openAPIDashboard)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			tt.assert(t, dashboard)
+		})
+	}
+}
+
+func TestOpenAPIDashboardFromProtoMissingTimeFrame(t *testing.T) {
+	dashboard := testDashboardProto()
+	dashboard.TimeFrame = nil
+
+	_, diags := openAPIDashboardFromProto(dashboard)
+	if !diags.HasError() {
+		t.Fatal("expected missing time frame diagnostic")
+	}
+
+	detail := diags[0].Detail()
+	if !strings.Contains(detail, "absoluteTimeFrame") || !strings.Contains(detail, "relativeTimeFrame") {
+		t.Fatalf("expected diagnostic to mention required OpenAPI time frame choices, got %q", detail)
+	}
+}
+
+func TestOpenAPIDashboardOneOfConflictDiagnostics(t *testing.T) {
+	tests := map[string]string{
+		"both time frame variants": `{
+			"name": "bad-time-frame",
+			"layout": {},
+			"relativeTimeFrame": "900s",
+			"absoluteTimeFrame": {
+				"from": "2026-05-27T09:00:00Z",
+				"to": "2026-05-27T10:00:00Z"
+			},
+			"off": {}
+		}`,
+		"both auto refresh variants": `{
+			"name": "bad-refresh",
+			"layout": {},
+			"relativeTimeFrame": "900s",
+			"off": {},
+			"twoMinutes": {}
+		}`,
+	}
+
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			var openAPIDashboard dashboardService.Dashboard
+			err := json.Unmarshal([]byte(raw), &openAPIDashboard)
+			if err == nil {
+				t.Fatal("expected OpenAPI dashboard oneOf unmarshal to fail")
+			}
+
+			diagnostic := openAPIDashboardDiagnostic(err)
+			if !strings.Contains(diagnostic.Detail(), "exactly one dashboard time frame") {
+				t.Fatalf("expected oneOf diagnostic, got %q", diagnostic.Detail())
+			}
+		})
+	}
+}
+
+func TestOpenAPIDashboardFromProtoFixtures(t *testing.T) {
+	tests := []string{
+		"../../../examples/resources/coralogix_dashboard/dashboard.json",
+		"../../../examples/resources/coralogix_dashboard/dashboard_with_var_path.json",
+		"../../../examples/resources/coralogix_dashboard/dashboard_openapi_minimal_root.json",
+		"../../../examples/resources/coralogix_dashboard/dashboard_openapi_minimal_folder_path.json",
+	}
+
+	for _, fixture := range tests {
+		t.Run(fixture, func(t *testing.T) {
+			data, err := os.ReadFile(fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			dashboard := new(cxsdk.Dashboard)
+			if err := dashboardschema.JSONUnmarshal.Unmarshal(data, dashboard); err != nil {
+				t.Fatal(err)
+			}
+
+			openAPIDashboard, diags := openAPIDashboardFromProto(dashboard)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if _, diags := protoDashboardFromOpenAPI(openAPIDashboard); diags.HasError() {
+				t.Fatalf("unexpected diagnostics after roundtrip: %v", diags)
+			}
+		})
+	}
+}
+
+func TestDashboardStateUpgradeAndOpenAPIIsolation(t *testing.T) {
+	upgraders := DashboardResource{}.UpgradeState(context.Background())
+	for _, version := range []int64{1, 2, 3} {
+		upgrader, ok := upgraders[version]
+		if !ok {
+			t.Fatalf("expected state upgrader for version %d", version)
+		}
+		if upgrader.StateUpgrader == nil {
+			t.Fatalf("expected state upgrader function for version %d", version)
+		}
+	}
+
+	for _, path := range []string{
+		"resource_coralogix_dashboard.go",
+		"data_source_coralogix_dashboard.go",
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		source := string(data)
+		if strings.Contains(source, "cxsdk.Create"+"DashboardRequest") ||
+			strings.Contains(source, "cxsdk.Replace"+"DashboardRequest") ||
+			strings.Contains(source, "cxsdk.Delete"+"DashboardRequest") {
+			t.Fatalf("normal dashboard CRUD in %s must not use legacy gRPC request types", path)
+		}
+	}
+
+	resourceSource, err := os.ReadFile("resource_coralogix_dashboard.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"DashboardsServiceCreateDashboard",
+		"DashboardsServiceGetDashboard",
+		"DashboardsServiceReplaceDashboard",
+		"DashboardsServiceDeleteDashboard",
+	} {
+		if !strings.Contains(string(resourceSource), required) {
+			t.Fatalf("expected resource CRUD to use %s", required)
+		}
+	}
+}
+
+func testDashboardProto() *cxsdk.Dashboard {
+	return &cxsdk.Dashboard{
+		Id:     wrapperspb.String("dashboard-id"),
+		Name:   wrapperspb.String("dashboard-name"),
+		Layout: &cxsdk.DashboardLayout{},
+		TimeFrame: &cxsdk.DashboardRelativeTimeFrame{
+			RelativeTimeFrame: durationpb.New(15 * time.Minute),
+		},
+		AutoRefresh: &cxsdk.DashboardOff{Off: &cxsdk.DashboardAutoRefreshOff{}},
+	}
+}
+
+func testAbsoluteTimeFrame() *cxsdk.DashboardAbsoluteTimeFrame {
+	return &cxsdk.DashboardAbsoluteTimeFrame{
+		AbsoluteTimeFrame: &cxsdk.DashboardTimeFrame{
+			From: timestamppb.New(time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)),
+			To:   timestamppb.New(time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC)),
+		},
+	}
+}
+
+func unmarshalOpenAPIDashboard(t *testing.T, raw string) dashboardService.Dashboard {
+	t.Helper()
+
+	var openAPIDashboard dashboardService.Dashboard
+	if err := json.Unmarshal([]byte(raw), &openAPIDashboard); err != nil {
+		t.Fatalf("unexpected OpenAPI dashboard unmarshal error: %v\njson: %s", err, raw)
+	}
+	return openAPIDashboard
+}
+
+func TestOpenAPIDashboardFixtureNames(t *testing.T) {
+	for _, fixture := range []string{
+		"dashboard.json",
+		"dashboard_with_var_path.json",
+		"dashboard_openapi_minimal_root.json",
+		"dashboard_openapi_minimal_folder_path.json",
+	} {
+		t.Run(fixture, func(t *testing.T) {
+			if !strings.HasSuffix(fixture, ".json") {
+				t.Fatalf("unexpected dashboard fixture name: %s", fixture)
+			}
+			if _, err := os.Stat(fmt.Sprintf("../../../examples/resources/coralogix_dashboard/%s", fixture)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/provider/dashboards/dashboard_openapi_test.go
+++ b/internal/provider/dashboards/dashboard_openapi_test.go
@@ -26,6 +26,7 @@ import (
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	dashboardService "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
 	dashboardschema "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -221,6 +222,38 @@ func TestOpenAPIDashboardFromProtoMissingTimeFrameDefaultsToRelative(t *testing.
 	}
 	if got := roundtripped.GetRelativeTimeFrame().AsDuration(); got != 15*time.Minute {
 		t.Fatalf("expected missing time frame to default to 15m relative, got %s", got)
+	}
+}
+
+func TestFlattenDashboardOmittedTimeFrameModes(t *testing.T) {
+	dashboard := testDashboardProto()
+
+	exposed, diags := flattenDashboard(context.Background(), DashboardResourceModel{}, dashboard, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics exposing dashboard time frame: %v", diags)
+	}
+	if exposed.TimeFrame == nil || exposed.TimeFrame.Relative == nil {
+		t.Fatalf("expected data source/import flatten to expose dashboard time frame, got %#v", exposed.TimeFrame)
+	}
+	if got := exposed.TimeFrame.Relative.Duration.ValueString(); got != "seconds:900" {
+		t.Fatalf("expected exposed dashboard time frame to be seconds:900, got %q", got)
+	}
+
+	preserved, diags := flattenDashboard(context.Background(), DashboardResourceModel{}, dashboard, true)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics preserving omitted dashboard time frame: %v", diags)
+	}
+	if preserved.TimeFrame != nil {
+		t.Fatalf("expected managed resource flatten to preserve omitted time frame, got %#v", preserved.TimeFrame)
+	}
+}
+
+func TestShouldPreserveOmittedDashboardTimeFrame(t *testing.T) {
+	if shouldPreserveOmittedDashboardTimeFrame(DashboardResourceModel{}) {
+		t.Fatal("expected import/data-source shaped state to expose dashboard time frame")
+	}
+	if !shouldPreserveOmittedDashboardTimeFrame(DashboardResourceModel{Name: types.StringValue("managed")}) {
+		t.Fatal("expected managed resource state to preserve omitted dashboard time frame")
 	}
 }
 

--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -1164,8 +1164,8 @@ func flattenDuration(timeFrame *durationpb.Duration) basetypes.StringValue {
 
 func flattenAbsoluteTimeFrame(ctx context.Context, timeFrame *cxsdk.DashboardTimeFrame) (*TimeFrameModel, diag.Diagnostics) {
 	absoluteTimeFrame := &TimeFrameAbsoluteModel{
-		Start: types.StringValue(timeFrame.GetFrom().String()),
-		End:   types.StringValue(timeFrame.GetTo().String()),
+		Start: types.StringValue(timeFrame.GetFrom().AsTime().UTC().Format(time.RFC3339)),
+		End:   types.StringValue(timeFrame.GetTo().AsTime().UTC().Format(time.RFC3339)),
 	}
 
 	flattenedTimeFrame := &TimeFrameModel{

--- a/internal/provider/dashboards/dashboard_widgets/common_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/common_test.go
@@ -18,10 +18,13 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestLogsAggregationValidator(t *testing.T) {
@@ -99,3 +102,18 @@ func TestLogsAggregationValidator(t *testing.T) {
 	}
 }
 
+func TestFlattenAbsoluteTimeFrameUsesRFC3339(t *testing.T) {
+	timeFrame, diags := flattenAbsoluteTimeFrame(context.Background(), &cxsdk.DashboardTimeFrame{
+		From: timestamppb.New(time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)),
+		To:   timestamppb.New(time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC)),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got := timeFrame.Absolute.Start.ValueString(); got != "2026-05-27T09:00:00Z" {
+		t.Fatalf("expected RFC3339 start, got %q", got)
+	}
+	if got := timeFrame.Absolute.End.ValueString(); got != "2026-05-27T10:00:00Z" {
+		t.Fatalf("expected RFC3339 end, got %q", got)
+	}
+}

--- a/internal/provider/dashboards/data_source_coralogix_dashboard.go
+++ b/internal/provider/dashboards/data_source_coralogix_dashboard.go
@@ -22,12 +22,11 @@ import (
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	"google.golang.org/protobuf/encoding/protojson"
-
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	dashboardService "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"google.golang.org/protobuf/types/known/wrapperspb"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var _ datasource.DataSourceWithConfigure = &DashboardDataSource{}
@@ -37,7 +36,7 @@ func NewDashboardDataSource() datasource.DataSource {
 }
 
 type DashboardDataSource struct {
-	client *cxsdk.DashboardsClient
+	client *dashboardService.DashboardServiceAPIService
 }
 
 func (d *DashboardDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -58,7 +57,7 @@ func (d *DashboardDataSource) Configure(_ context.Context, req datasource.Config
 		return
 	}
 
-	d.client = clientSet.Dashboards()
+	d.client = clientSet.DashboardsOpenAPI()
 }
 
 func (d *DashboardDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -79,19 +78,27 @@ func (d *DashboardDataSource) Read(ctx context.Context, req datasource.ReadReque
 	//Get refreshed Dashboard value from Coralogix
 	id := data.ID.ValueString()
 	log.Printf("[INFO] Reading Dashboard: %s", id)
-	getDashboardReq := &cxsdk.GetDashboardRequest{DashboardId: wrapperspb.String(id)}
-	getDashboardResp, err := d.client.Get(ctx, getDashboardReq)
+	getDashboardResp, httpResponse, err := d.client.DashboardsServiceGetDashboard(ctx, id).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error reading Dashboard",
-			utils.FormatRpcErrors(err, cxsdk.GetDashboardRPC, protojson.Format(getDashboardReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "DashboardsServiceGetDashboard", id),
 		)
 		return
 	}
-	log.Printf("[INFO] Received Dashboard: %s", protojson.Format(getDashboardResp))
+	if getDashboardResp.Dashboard == nil {
+		resp.Diagnostics.AddError("Error reading Dashboard", "OpenAPI get response did not include dashboard")
+		return
+	}
+	protoDashboard, diags := protoDashboardFromOpenAPI(getDashboardResp.GetDashboard())
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	log.Printf("[INFO] Received Dashboard: %s", protojson.Format(protoDashboard))
 
-	dashboard, diags := flattenDashboard(ctx, DashboardResourceModel{}, getDashboardResp.GetDashboard())
+	dashboard, diags := flattenDashboard(ctx, DashboardResourceModel{}, protoDashboard)
 	if diags.HasError() {
 		resp.Diagnostics = diags
 		return

--- a/internal/provider/dashboards/data_source_coralogix_dashboard.go
+++ b/internal/provider/dashboards/data_source_coralogix_dashboard.go
@@ -98,7 +98,7 @@ func (d *DashboardDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 	log.Printf("[INFO] Received Dashboard: %s", protojson.Format(protoDashboard))
 
-	dashboard, diags := flattenDashboard(ctx, DashboardResourceModel{}, protoDashboard)
+	dashboard, diags := flattenDashboard(ctx, DashboardResourceModel{}, protoDashboard, false)
 	if diags.HasError() {
 		resp.Diagnostics = diags
 		return

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -27,6 +28,8 @@ import (
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	dashboardService "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -266,7 +269,8 @@ func NewDashboardResource() resource.Resource {
 }
 
 type DashboardResource struct {
-	client *cxsdk.DashboardsClient
+	client     *dashboardService.DashboardServiceAPIService
+	grpcClient *cxsdk.DashboardsClient
 }
 
 func (r DashboardResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
@@ -282,13 +286,13 @@ func (r DashboardResource) UpgradeState(_ context.Context) map[int64]resource.St
 		2: {
 			PriorSchema: &schemaV2,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				upgradeDashboardStateV3ToV4(ctx, req, resp, r.client)
+				upgradeDashboardStateV3ToV4(ctx, req, resp, r.grpcClient)
 			},
 		},
 		3: {
 			PriorSchema: &schemaV3,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				upgradeDashboardStateV3ToV4(ctx, req, resp, r.client)
+				upgradeDashboardStateV3ToV4(ctx, req, resp, r.grpcClient)
 			},
 		},
 	}
@@ -693,38 +697,57 @@ func (r DashboardResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	createDashboardReq := &cxsdk.CreateDashboardRequest{
-		Dashboard: dashboard,
+	openAPIDashboard, diags := openAPIDashboardFromProto(dashboard)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
 	}
-	dashboardStr := protojson.Format(createDashboardReq)
+
+	createDashboardReq := dashboardService.CreateDashboardRequestDataStructure{
+		Dashboard: openAPIDashboard,
+		RequestId: newDashboardRequestID(),
+	}
+	dashboardStr := utils.FormatJSON(createDashboardReq)
 	log.Printf("[INFO] Creating new Dashboard: %s", dashboardStr)
-	createResponse, err := r.client.Create(ctx, createDashboardReq)
+	createResponse, httpResponse, err := r.client.DashboardsServiceCreateDashboard(ctx).
+		CreateDashboardRequestDataStructure(createDashboardReq).
+		Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error creating Dashboard",
-			utils.FormatRpcErrors(err, cxsdk.CreateDashboardRPC, dashboardStr),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "DashboardsServiceCreateDashboard", createDashboardReq),
 		)
 		return
 	}
 
-	getDashboardReq := &cxsdk.GetDashboardRequest{
-		DashboardId: createResponse.DashboardId,
+	dashboardID := createResponse.GetDashboardId()
+	if dashboardID == "" {
+		resp.Diagnostics.AddError("Error creating Dashboard", "OpenAPI create response did not include dashboardId")
+		return
 	}
-	getDashboardResp, err := r.client.Get(ctx, getDashboardReq)
+	getDashboardResp, httpResponse, err := r.client.DashboardsServiceGetDashboard(ctx, dashboardID).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		reqStr := protojson.Format(getDashboardReq)
 		resp.Diagnostics.AddError(
 			"Error getting Dashboard",
-			utils.FormatRpcErrors(err, cxsdk.GetDashboardRPC, reqStr),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "DashboardsServiceGetDashboard", dashboardID),
 		)
 		return
 	}
-	createDashboardRespStr := protojson.Format(getDashboardResp.GetDashboard())
+	if getDashboardResp.Dashboard == nil {
+		resp.Diagnostics.AddError("Error getting Dashboard", "OpenAPI get response did not include dashboard")
+		return
+	}
+	protoDashboard, diags := protoDashboardFromOpenAPI(getDashboardResp.GetDashboard())
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	createDashboardRespStr := protojson.Format(protoDashboard)
 	log.Printf("[INFO] Submitted new Dashboard: %s", createDashboardRespStr)
 
-	flattenedDashboard, diags := flattenDashboard(ctx, plan, getDashboardResp.GetDashboard())
+	flattenedDashboard, diags := flattenDashboard(ctx, plan, protoDashboard)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -6035,11 +6058,11 @@ func (r *DashboardResource) Read(ctx context.Context, req resource.ReadRequest, 
 	//Get refreshed Dashboard value from Coralogix
 	id := state.ID.ValueString()
 	log.Printf("[INFO] Reading Dashboard: %s", id)
-	getDashboardReq := &cxsdk.GetDashboardRequest{DashboardId: wrapperspb.String(id)}
-	getDashboardResp, err := r.client.Get(ctx, getDashboardReq)
+	getDashboardResp, httpResponse, err := r.client.DashboardsServiceGetDashboard(ctx, id).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+		if cxsdkOpenapi.Code(apiErr) == http.StatusNotFound {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Dashboard %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
@@ -6048,14 +6071,23 @@ func (r *DashboardResource) Read(ctx context.Context, req resource.ReadRequest, 
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Dashboard",
-				utils.FormatRpcErrors(err, cxsdk.GetDashboardRPC, protojson.Format(getDashboardReq)),
+				utils.FormatOpenAPIErrors(apiErr, "DashboardsServiceGetDashboard", id),
 			)
 		}
 		return
 	}
-	log.Printf("[INFO] Received Dashboard: %s", protojson.Format(getDashboardResp))
+	if getDashboardResp.Dashboard == nil {
+		resp.Diagnostics.AddError("Error reading Dashboard", "OpenAPI get response did not include dashboard")
+		return
+	}
+	protoDashboard, diags := protoDashboardFromOpenAPI(getDashboardResp.GetDashboard())
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	log.Printf("[INFO] Received Dashboard: %s", protojson.Format(protoDashboard))
 
-	flattenedDashboard, diags := flattenDashboard(ctx, state, getDashboardResp.GetDashboard())
+	flattenedDashboard, diags := flattenDashboard(ctx, state, protoDashboard)
 	if diags != nil {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -6081,36 +6113,57 @@ func (r *DashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	updateReq := &cxsdk.ReplaceDashboardRequest{Dashboard: dashboard}
-	reqStr := protojson.Format(updateReq)
+	openAPIDashboard, diags := openAPIDashboardFromProto(dashboard)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	updateReq := dashboardService.ReplaceDashboardRequestDataStructure{
+		Dashboard: openAPIDashboard,
+		RequestId: newDashboardRequestID(),
+	}
+	reqStr := utils.FormatJSON(updateReq)
 	log.Printf("[INFO] Updating Dashboard: %s", reqStr)
-	_, err := r.client.Replace(ctx, updateReq)
+	_, httpResponse, err := r.client.DashboardsServiceReplaceDashboard(ctx).
+		ReplaceDashboardRequestDataStructure(updateReq).
+		Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error updating Dashboard",
-			utils.FormatRpcErrors(err, cxsdk.ReplaceDashboardRPC, reqStr),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "DashboardsServiceReplaceDashboard", updateReq),
 		)
 		return
 	}
 
-	getDashboardReq := &cxsdk.GetDashboardRequest{
-		DashboardId: dashboard.GetId(),
+	dashboardID := dashboard.GetId().GetValue()
+	if dashboardID == "" {
+		dashboardID = plan.ID.ValueString()
 	}
-	getDashboardResp, err := r.client.Get(ctx, getDashboardReq)
+	getDashboardResp, httpResponse, err := r.client.DashboardsServiceGetDashboard(ctx, dashboardID).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error getting Dashboard",
-			utils.FormatRpcErrors(err, cxsdk.GetDashboardRPC, protojson.Format(getDashboardReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "DashboardsServiceGetDashboard", dashboardID),
 		)
 		return
 	}
+	if getDashboardResp.Dashboard == nil {
+		resp.Diagnostics.AddError("Error getting Dashboard", "OpenAPI get response did not include dashboard")
+		return
+	}
+	protoDashboard, diags := protoDashboardFromOpenAPI(getDashboardResp.GetDashboard())
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
-	updateDashboardRespStr := protojson.Format(getDashboardResp.GetDashboard())
+	updateDashboardRespStr := protojson.Format(protoDashboard)
 	log.Printf("[INFO] Submitted updated Dashboard: %s", updateDashboardRespStr)
 
-	flattenedDashboard, diags := flattenDashboard(ctx, plan, getDashboardResp.GetDashboard())
+	flattenedDashboard, diags := flattenDashboard(ctx, plan, protoDashboard)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -6131,11 +6184,16 @@ func (r *DashboardResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	id := state.ID.ValueString()
 	log.Printf("[INFO] Deleting Dashboard %s", id)
-	deleteReq := &cxsdk.DeleteDashboardRequest{DashboardId: wrapperspb.String(id)}
-	if _, err := r.client.Delete(ctx, deleteReq); err != nil {
+	requestID := newDashboardRequestID()
+	if _, httpResponse, err := r.client.DashboardsServiceDeleteDashboard(ctx, id).RequestId(requestID).Execute(); err != nil {
+		apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+		if cxsdkOpenapi.Code(apiErr) == http.StatusNotFound {
+			log.Printf("[INFO] Dashboard %s was already deleted", id)
+			return
+		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error Deleting Dashboard %s", id),
-			utils.FormatRpcErrors(err, cxsdk.DeleteDashboardRPC, protojson.Format(deleteReq)),
+			utils.FormatOpenAPIErrors(apiErr, "DashboardsServiceDeleteDashboard", map[string]string{"dashboardId": id, "requestId": requestID}),
 		)
 		return
 	}
@@ -6156,5 +6214,6 @@ func (r *DashboardResource) Configure(_ context.Context, req resource.ConfigureR
 		return
 	}
 
-	r.client = clientSet.Dashboards()
+	r.client = clientSet.DashboardsOpenAPI()
+	r.grpcClient = clientSet.Dashboards()
 }

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -3242,6 +3242,12 @@ func shouldPreserveOmittedDashboardTimeFrame(state DashboardResourceModel) bool 
 	return !state.Name.IsNull() && !state.Name.IsUnknown()
 }
 
+func preserveDashboardTimeFrameForReplace(dashboard *cxsdk.Dashboard, existingDashboard *cxsdk.Dashboard) {
+	if dashboard.GetTimeFrame() == nil && existingDashboard.GetTimeFrame() != nil {
+		dashboard.TimeFrame = existingDashboard.GetTimeFrame()
+	}
+}
+
 func flattenDashboardLayout(ctx context.Context, layout *cxsdk.DashboardLayout) (types.Object, diag.Diagnostics) {
 	sections, diags := flattenDashboardSections(ctx, layout.GetSections())
 	if diags.HasError() {
@@ -6057,6 +6063,11 @@ func flattenDashboardAutoRefresh(ctx context.Context, dashboard *cxsdk.Dashboard
 		refreshType.Type = types.StringValue("five_minutes")
 	case *cxsdk.DashboardTwoMinutes:
 		refreshType.Type = types.StringValue("two_minutes")
+	default:
+		return types.ObjectNull(dashboardAutoRefreshModelAttr()), diag.Diagnostics{diag.NewErrorDiagnostic(
+			"Unsupported dashboard auto-refresh",
+			fmt.Sprintf("Dashboard uses auto-refresh variant %T, but Terraform only supports off, two_minutes, and five_minutes.", autoRefresh),
+		)}
 	}
 	return types.ObjectValueFrom(ctx, dashboardAutoRefreshModelAttr(), &refreshType)
 }
@@ -6120,11 +6131,47 @@ func (r *DashboardResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var state DashboardResourceModel
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if plan.ID.IsNull() || plan.ID.IsUnknown() {
+		plan.ID = state.ID
+	}
 
 	dashboard, diags := extractDashboard(ctx, plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
+	}
+	if dashboard.GetTimeFrame() == nil {
+		dashboardID := dashboard.GetId().GetValue()
+		if dashboardID == "" {
+			dashboardID = plan.ID.ValueString()
+		}
+		if dashboardID != "" {
+			getDashboardResp, httpResponse, err := r.client.DashboardsServiceGetDashboard(ctx, dashboardID).Execute()
+			if err != nil {
+				log.Printf("[ERROR] Received error: %s", err.Error())
+				resp.Diagnostics.AddError(
+					"Error getting Dashboard",
+					utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "DashboardsServiceGetDashboard", dashboardID),
+				)
+				return
+			}
+			if getDashboardResp.Dashboard == nil {
+				resp.Diagnostics.AddError("Error getting Dashboard", "OpenAPI get response did not include dashboard")
+				return
+			}
+			existingDashboard, diags := protoDashboardFromOpenAPI(getDashboardResp.GetDashboard())
+			if diags.HasError() {
+				resp.Diagnostics.Append(diags...)
+				return
+			}
+			preserveDashboardTimeFrameForReplace(dashboard, existingDashboard)
+		}
 	}
 
 	openAPIDashboard, diags := openAPIDashboardFromProto(dashboard)

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -3198,9 +3198,13 @@ func flattenDashboard(ctx context.Context, plan DashboardResourceModel, dashboar
 		return nil, diags
 	}
 
-	timeFrame, diags := dashboardwidgets.FlattenDashboardTimeFrame(ctx, dashboard)
-	if diags.HasError() {
-		return nil, diags
+	var timeFrame *dashboardwidgets.TimeFrameModel
+	if plan.TimeFrame != nil {
+		var diags diag.Diagnostics
+		timeFrame, diags = dashboardwidgets.FlattenDashboardTimeFrame(ctx, dashboard)
+		if diags.HasError() {
+			return nil, diags
+		}
 	}
 
 	annotations, diags := flattenDashboardAnnotations(ctx, dashboard.GetAnnotations())

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -330,7 +330,7 @@ func upgradeDashboardStateV3ToV4(ctx context.Context, req resource.UpgradeStateR
 	}
 	log.Printf("[INFO] Received Dashboard: %s", protojson.Format(getDashboardResp))
 
-	flattenedDashboard, diags := flattenDashboard(ctx, state, getDashboardResp.GetDashboard())
+	flattenedDashboard, diags := flattenDashboard(ctx, state, getDashboardResp.GetDashboard(), true)
 	if diags != nil {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -747,7 +747,7 @@ func (r DashboardResource) Create(ctx context.Context, req resource.CreateReques
 	createDashboardRespStr := protojson.Format(protoDashboard)
 	log.Printf("[INFO] Submitted new Dashboard: %s", createDashboardRespStr)
 
-	flattenedDashboard, diags := flattenDashboard(ctx, plan, protoDashboard)
+	flattenedDashboard, diags := flattenDashboard(ctx, plan, protoDashboard, true)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -3140,7 +3140,7 @@ func expandDashboardFolder(ctx context.Context, dashboard *cxsdk.Dashboard, fold
 	return dashboard, nil
 }
 
-func flattenDashboard(ctx context.Context, plan DashboardResourceModel, dashboard *cxsdk.Dashboard) (*DashboardResourceModel, diag.Diagnostics) {
+func flattenDashboard(ctx context.Context, plan DashboardResourceModel, dashboard *cxsdk.Dashboard, preserveOmittedTimeFrame bool) (*DashboardResourceModel, diag.Diagnostics) {
 	folder, diags := flattenDashboardFolder(ctx, plan.Folder, dashboard)
 	if diags.HasError() {
 		return nil, diags
@@ -3199,7 +3199,7 @@ func flattenDashboard(ctx context.Context, plan DashboardResourceModel, dashboar
 	}
 
 	var timeFrame *dashboardwidgets.TimeFrameModel
-	if plan.TimeFrame != nil {
+	if plan.TimeFrame != nil || !preserveOmittedTimeFrame {
 		var diags diag.Diagnostics
 		timeFrame, diags = dashboardwidgets.FlattenDashboardTimeFrame(ctx, dashboard)
 		if diags.HasError() {
@@ -3230,6 +3230,16 @@ func flattenDashboard(ctx context.Context, plan DashboardResourceModel, dashboar
 		AutoRefresh: autoRefresh,
 		ContentJson: types.StringNull(),
 	}, nil
+}
+
+func shouldPreserveOmittedDashboardTimeFrame(state DashboardResourceModel) bool {
+	if state.TimeFrame != nil {
+		return false
+	}
+	if !state.ContentJson.IsNull() && !state.ContentJson.IsUnknown() {
+		return true
+	}
+	return !state.Name.IsNull() && !state.Name.IsUnknown()
 }
 
 func flattenDashboardLayout(ctx context.Context, layout *cxsdk.DashboardLayout) (types.Object, diag.Diagnostics) {
@@ -6091,7 +6101,7 @@ func (r *DashboardResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 	log.Printf("[INFO] Received Dashboard: %s", protojson.Format(protoDashboard))
 
-	flattenedDashboard, diags := flattenDashboard(ctx, state, protoDashboard)
+	flattenedDashboard, diags := flattenDashboard(ctx, state, protoDashboard, shouldPreserveOmittedDashboardTimeFrame(state))
 	if diags != nil {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -6167,7 +6177,7 @@ func (r *DashboardResource) Update(ctx context.Context, req resource.UpdateReque
 	updateDashboardRespStr := protojson.Format(protoDashboard)
 	log.Printf("[INFO] Submitted updated Dashboard: %s", updateDashboardRespStr)
 
-	flattenedDashboard, diags := flattenDashboard(ctx, plan, protoDashboard)
+	flattenedDashboard, diags := flattenDashboard(ctx, plan, protoDashboard, true)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/data_source_coralogix_dashboard_test.go
+++ b/internal/provider/data_source_coralogix_dashboard_test.go
@@ -32,6 +32,7 @@ func TestAccCoralogixDataSourceDashboard_basic(t *testing.T) {
 					testAccCoralogixDataSourceDashboard_read(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dashboardDataSourceName, "name", "test"),
+					resource.TestCheckResourceAttr(dashboardDataSourceName, "time_frame.relative.duration", "seconds:900"),
 				),
 			},
 		},

--- a/internal/provider/data_source_hosted_dashboard_test.go
+++ b/internal/provider/data_source_hosted_dashboard_test.go
@@ -15,30 +15,23 @@
 package provider
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 var hostedDashboardDataSourceName = "data." + hostedDashboardResourceName
 
 func TestAccCoralogixDataSourceGrafanaDashboard_basic(t *testing.T) {
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	parent := filepath.Dir(filepath.Dir(wd))
-	filePath := parent + "/examples/resources/coralogix_hosted_dashboard/grafana_acc_dashboard.json"
-	expectedFolderTitle := "Test Folder"
+	filePath := testAccHostedDashboardJSONFile(t, acctest.RandomWithPrefix("tf-acc-hosted-dashboard-title"), testAccHostedDashboardUID())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoralogixResourceGrafanaDashboard(filePath, expectedFolderTitle) +
+				Config: testAccCoralogixResourceGrafanaDashboardRoot(filePath) +
 					testAccCoralogixDataSourceGrafanaDashboard_read(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(hostedDashboardDataSourceName, "uid"),

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -650,6 +650,11 @@ func TestAccCoralogixResourceDashboardOptionalTimeFrame(t *testing.T) {
 					resource.TestCheckNoResourceAttr(dashboardResourceName, "time_frame.relative.duration"),
 				),
 			},
+			{
+				ResourceName:     dashboardResourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccCheckImportedDashboard(map[string]string{"time_frame.relative.duration": "seconds:900"}),
+			},
 		},
 	})
 }
@@ -1317,4 +1322,20 @@ resource "coralogix_dashboard" "test" {
 			},
 		},
 	})
+}
+
+func testAccCheckImportedDashboard(expected map[string]string) resource.ImportStateCheckFunc {
+	return func(states []*terraform.InstanceState) error {
+		if len(states) == 0 {
+			return fmt.Errorf("expected imported dashboard state, got no state entries")
+		}
+
+		attrs := states[0].Attributes
+		for key, want := range expected {
+			if got := attrs[key]; got != want {
+				return fmt.Errorf("imported %s = %q, want %q", key, got, want)
+			}
+		}
+		return nil
+	}
 }

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -17,16 +17,17 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	"google.golang.org/protobuf/types/known/wrapperspb"
-
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	terraform2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -105,6 +106,111 @@ func TestAccCoralogixResourceDashboard(t *testing.T) {
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceDashboardOpenAPILifecycle(t *testing.T) {
+	var dashboardID string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceDashboardOpenAPIConfig("openapi-lifecycle-root", testAccDashboardRelativeTimeFrame(), "off", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "name", "openapi-lifecycle-root"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "time_frame.relative.duration", "seconds:900"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "auto_refresh.type", "off"),
+					resource.TestCheckNoResourceAttr(dashboardResourceName, "folder.id"),
+					testAccCaptureDashboardID(&dashboardID),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceDashboardOpenAPIConfig("openapi-lifecycle-renamed", testAccDashboardRelativeTimeFrame(), "off", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDashboardIDUnchanged(&dashboardID),
+					resource.TestCheckResourceAttr(dashboardResourceName, "name", "openapi-lifecycle-renamed"),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceDashboardOpenAPIConfig("openapi-lifecycle-renamed", testAccDashboardRelativeTimeFrame(), "two_minutes", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDashboardIDUnchanged(&dashboardID),
+					resource.TestCheckResourceAttr(dashboardResourceName, "auto_refresh.type", "two_minutes"),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceDashboardOpenAPIConfig("openapi-lifecycle-renamed", testAccDashboardRelativeTimeFrame(), "five_minutes", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDashboardIDUnchanged(&dashboardID),
+					resource.TestCheckResourceAttr(dashboardResourceName, "auto_refresh.type", "five_minutes"),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceDashboardOpenAPIConfig("openapi-lifecycle-renamed", testAccDashboardAbsoluteTimeFrame(), "five_minutes", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDashboardIDUnchanged(&dashboardID),
+					resource.TestCheckResourceAttr(dashboardResourceName, "time_frame.absolute.start", "2026-05-27T09:00:00Z"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "time_frame.absolute.end", "2026-05-27T10:00:00Z"),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceDashboardOpenAPIConfig("openapi-lifecycle-renamed", testAccDashboardRelativeTimeFrame(), "off", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDashboardIDUnchanged(&dashboardID),
+					resource.TestCheckResourceAttr(dashboardResourceName, "time_frame.relative.duration", "seconds:900"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "auto_refresh.type", "off"),
+				),
+			},
+			{
+				ResourceName:      dashboardResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceDashboardFolderID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceDashboardWithFolderID(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "folder.id"),
+					resource.TestCheckResourceAttrSet(folderResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      dashboardResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceDashboardFolderPath(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceDashboardWithFolderPath(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "folder.id"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "folder.path", "openapi-folder-path"),
+				),
 			},
 		},
 	})
@@ -514,6 +620,68 @@ func TestAccCoralogixResourceDashboardFromJsonWithFolder(t *testing.T) {
 	})
 }
 
+func TestAccCoralogixResourceDashboardFromJsonWithEmbeddedFolderPath(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceDashboardFromJsonWithEmbeddedFolderPath(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckNoResourceAttr(dashboardResourceName, "folder.id"),
+					resource.TestCheckNoResourceAttr(dashboardResourceName, "folder.path"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceDashboardMissingTimeFrame(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCoralogixResourceDashboardMissingTimeFrame(),
+				ExpectError: regexp.MustCompile("Dashboard time frame is required for OpenAPI|absoluteTimeFrame|relativeTimeFrame"),
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceDashboardContentJSONMissingTimeFrame(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCoralogixResourceDashboardContentJSONMissingTimeFrame(),
+				ExpectError: regexp.MustCompile("Dashboard time frame is required for OpenAPI|absoluteTimeFrame|relativeTimeFrame"),
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceDashboardDeleteAlreadyAbsent(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccCoralogixResourceDashboardOpenAPIConfig("openapi-delete-already-absent", testAccDashboardRelativeTimeFrame(), "off", ""),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					testAccDeleteDashboardRemotely,
+				),
+			},
+		},
+	})
+}
+
 func TestAccCoralogixResourceDashboardFromJsonWithVar(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -535,6 +703,30 @@ func TestAccCoralogixResourceDashboardFromJsonWithVar(t *testing.T) {
 	})
 }
 
+func TestDashboardAcceptanceDestroyUsesOpenAPI(t *testing.T) {
+	data, err := os.ReadFile("resource_coralogix_dashboard_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	source := string(data)
+	start := strings.LastIndex(source, "func testAccCheckDashboardDestroy")
+	if start == -1 {
+		t.Fatal("testAccCheckDashboardDestroy not found")
+	}
+	end := strings.Index(source[start:], "\nfunc ")
+	if end == -1 {
+		end = len(source) - start
+	}
+	functionBody := source[start : start+end]
+	if !strings.Contains(functionBody, "DashboardsOpenAPI()") {
+		t.Fatal("acceptance destroy check must use DashboardsOpenAPI")
+	}
+	if strings.Contains(functionBody, ".Dashboard"+"s()") {
+		t.Fatal("acceptance destroy check must not use legacy dashboard getter")
+	}
+}
+
 func testAccCheckDashboardDestroy(s *terraform.State) error {
 	// Configure the SDK provider so Meta() is set (ProtoV6 tests don't configure testAccProvider).
 	rc := terraform2.ResourceConfig{}
@@ -543,7 +735,7 @@ func testAccCheckDashboardDestroy(s *terraform.State) error {
 	if meta == nil {
 		return nil
 	}
-	client := meta.(*clientset.ClientSet).Dashboards()
+	client := meta.(*clientset.ClientSet).DashboardsOpenAPI()
 
 	ctx := context.TODO()
 
@@ -552,16 +744,71 @@ func testAccCheckDashboardDestroy(s *terraform.State) error {
 			continue
 		}
 
-		dashboardId := wrapperspb.String(rs.Primary.ID)
-		resp, err := client.Get(ctx, &cxsdk.GetDashboardRequest{DashboardId: dashboardId})
-		if err == nil {
-			if resp.GetDashboard().GetId().GetValue() == rs.Primary.ID {
+		resp, _, err := client.DashboardsServiceGetDashboard(ctx, rs.Primary.ID).Execute()
+		if err == nil && resp != nil {
+			if dashboard, ok := resp.GetDashboardOk(); ok && dashboard != nil {
 				return fmt.Errorf("dashboard still exists: %s", rs.Primary.ID)
 			}
 		}
 	}
 
 	return nil
+}
+
+func testAccDeleteDashboardRemotely(s *terraform.State) error {
+	rc := terraform2.ResourceConfig{}
+	_ = testAccProvider.Configure(context.Background(), &rc)
+	meta := testAccProvider.Meta()
+	if meta == nil {
+		return nil
+	}
+	client := meta.(*clientset.ClientSet).DashboardsOpenAPI()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "coralogix_dashboard" {
+			continue
+		}
+
+		_, httpResponse, err := client.DashboardsServiceDeleteDashboard(context.Background(), rs.Primary.ID).
+			RequestId("tf-acc-delete-" + rs.Primary.ID).
+			Execute()
+		if err != nil {
+			apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+			if cxsdkOpenapi.Code(apiErr) == http.StatusNotFound {
+				continue
+			}
+			return fmt.Errorf("failed to delete dashboard %s before Terraform destroy: %w", rs.Primary.ID, apiErr)
+		}
+	}
+
+	return nil
+}
+
+func testAccCaptureDashboardID(target *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dashboardResourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", dashboardResourceName)
+		}
+		*target = rs.Primary.ID
+		return nil
+	}
+}
+
+func testAccCheckDashboardIDUnchanged(expected *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dashboardResourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", dashboardResourceName)
+		}
+		if *expected == "" {
+			return fmt.Errorf("expected dashboard id was not captured")
+		}
+		if rs.Primary.ID != *expected {
+			return fmt.Errorf("dashboard was replaced: expected id %s, got %s", *expected, rs.Primary.ID)
+		}
+		return nil
+	}
 }
 
 func testAccCoralogixResourceDashboard() string {
@@ -781,6 +1028,160 @@ func testAccCoralogixResourceDashboardFromJson(jsonFilePath string) string {
    		content_json = file("%s")
 	}
 `, jsonFilePath)
+}
+
+func testAccCoralogixResourceDashboardOpenAPIConfig(name, timeFrame, autoRefreshType, folder string) string {
+	return fmt.Sprintf(`resource "coralogix_dashboard" "test" {
+  name        = %[1]q
+  description = "openapi migration focused acceptance"
+%[2]s
+  auto_refresh = {
+    type = %[3]q
+  }
+%[4]s
+  layout = {
+    sections = [{
+      rows = [{
+        height = 10
+        widgets = [{
+          title = "openapi-smoke"
+          definition = {
+            line_chart = {
+              query_definitions = [{
+                query = {
+                  metrics = {
+                    promql_query = "vector(1)"
+                  }
+                }
+              }]
+              legend = {
+                is_visible = false
+              }
+            }
+          }
+          width = 0
+        }]
+      }]
+    }]
+  }
+}
+`, name, timeFrame, autoRefreshType, folder)
+}
+
+func testAccDashboardRelativeTimeFrame() string {
+	return `  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+`
+}
+
+func testAccDashboardAbsoluteTimeFrame() string {
+	return `  time_frame = {
+    absolute = {
+      start = "2026-05-27T09:00:00Z"
+      end   = "2026-05-27T10:00:00Z"
+    }
+  }
+`
+}
+
+func testAccCoralogixResourceDashboardWithFolderID() string {
+	return `resource "coralogix_dashboards_folder" "test_folder" {
+  name = "openapi-folder-id"
+}
+
+` + testAccCoralogixResourceDashboardOpenAPIConfig(
+		"openapi-folder-id-dashboard",
+		testAccDashboardRelativeTimeFrame(),
+		"off",
+		`  folder = {
+    id = coralogix_dashboards_folder.test_folder.id
+  }
+`,
+	)
+}
+
+func testAccCoralogixResourceDashboardWithFolderPath() string {
+	return `resource "coralogix_dashboards_folder" "test_folder" {
+  name = "openapi-folder-path"
+}
+
+` + testAccCoralogixResourceDashboardOpenAPIConfig(
+		"openapi-folder-path-dashboard",
+		testAccDashboardRelativeTimeFrame(),
+		"off",
+		`  folder = {
+    path = coralogix_dashboards_folder.test_folder.name
+  }
+`,
+	)
+}
+
+func testAccCoralogixResourceDashboardFromJsonWithEmbeddedFolderPath() string {
+	return `resource "coralogix_dashboards_folder" "test_folder" {
+  name = "openapi-content-json-folder-path"
+}
+
+resource "coralogix_dashboard" "test" {
+  content_json = jsonencode({
+    name = "openapi-content-json-folder-path-dashboard"
+    layout = {}
+    relativeTimeFrame = "900s"
+    off = {}
+    folderPath = {
+      segments = [coralogix_dashboards_folder.test_folder.name]
+    }
+  })
+}
+`
+}
+
+func testAccCoralogixResourceDashboardMissingTimeFrame() string {
+	return `resource "coralogix_dashboard" "test" {
+  name        = "openapi-missing-time-frame"
+  description = "missing time frame should fail before API call"
+  auto_refresh = {
+    type = "off"
+  }
+  layout = {
+    sections = [{
+      rows = [{
+        height = 10
+        widgets = [{
+          title = "placeholder"
+          definition = {
+            line_chart = {
+              query_definitions = [{
+                query = {
+                  metrics = {
+                    promql_query = "vector(1)"
+                  }
+                }
+              }]
+              legend = {
+                is_visible = false
+              }
+            }
+          }
+        }]
+      }]
+    }]
+  }
+}
+`
+}
+
+func testAccCoralogixResourceDashboardContentJSONMissingTimeFrame() string {
+	return `resource "coralogix_dashboard" "test" {
+  content_json = jsonencode({
+    name = "openapi-content-json-missing-time-frame"
+    layout = {}
+    off = {}
+  })
+}
+`
 }
 
 func testAccCoralogixResourceDashboardFromJsonWithFolder(jsonFilePath string) string {

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -638,27 +637,35 @@ func TestAccCoralogixResourceDashboardFromJsonWithEmbeddedFolderPath(t *testing.
 	})
 }
 
-func TestAccCoralogixResourceDashboardMissingTimeFrame(t *testing.T) {
+func TestAccCoralogixResourceDashboardOptionalTimeFrame(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCoralogixResourceDashboardMissingTimeFrame(),
-				ExpectError: regexp.MustCompile("Dashboard time frame is required for OpenAPI|absoluteTimeFrame|relativeTimeFrame"),
+				Config: testAccCoralogixResourceDashboardMissingTimeFrame(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckNoResourceAttr(dashboardResourceName, "time_frame.relative.duration"),
+				),
 			},
 		},
 	})
 }
 
-func TestAccCoralogixResourceDashboardContentJSONMissingTimeFrame(t *testing.T) {
+func TestAccCoralogixResourceDashboardContentJSONOptionalTimeFrame(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCoralogixResourceDashboardContentJSONMissingTimeFrame(),
-				ExpectError: regexp.MustCompile("Dashboard time frame is required for OpenAPI|absoluteTimeFrame|relativeTimeFrame"),
+				Config: testAccCoralogixResourceDashboardContentJSONMissingTimeFrame(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckNoResourceAttr(dashboardResourceName, "time_frame.relative.duration"),
+				),
 			},
 		},
 	})
@@ -1141,7 +1148,7 @@ resource "coralogix_dashboard" "test" {
 func testAccCoralogixResourceDashboardMissingTimeFrame() string {
 	return `resource "coralogix_dashboard" "test" {
   name        = "openapi-missing-time-frame"
-  description = "missing time frame should fail before API call"
+  description = "missing time frame should preserve optional schema behavior"
   auto_refresh = {
     type = "off"
   }

--- a/internal/provider/resource_hosted_dashboard_test.go
+++ b/internal/provider/resource_hosted_dashboard_test.go
@@ -20,11 +20,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/provider/data_exploration"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -33,19 +35,17 @@ var hostedDashboardResourceName = "coralogix_hosted_dashboard.test"
 var hostedDashboardFolderResourceName = "coralogix_grafana_folder.test_folder"
 
 func TestAccCoralogixResourceHostedGrafanaDashboardCreate(t *testing.T) {
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	parent := filepath.Dir(filepath.Dir(wd))
-	filePath := parent + "/examples/resources/coralogix_hosted_dashboard/grafana_acc_dashboard.json"
-	updatedFilePath := parent + "/examples/resources/coralogix_hosted_dashboard/grafana_acc_updated_dashboard.json"
+	dashboardUID := testAccHostedDashboardUID()
+	dashboardTitle := acctest.RandomWithPrefix("tf-acc-hosted-dashboard-title")
+	updatedDashboardTitle := acctest.RandomWithPrefix("tf-acc-hosted-dashboard-title-updated")
+	filePath := testAccHostedDashboardJSONFile(t, dashboardTitle, dashboardUID)
+	updatedFilePath := testAccHostedDashboardJSONFile(t, updatedDashboardTitle, dashboardUID)
 
-	expectedInitialConfig := `{"title":"Title test","uid":"UID"}`
-	expectedUpdatedTitleConfig := `{"title":"Updated Title","uid":"UID"}`
+	expectedInitialConfig := fmt.Sprintf(`{"title":"%s","uid":"%s"}`, dashboardTitle, dashboardUID)
+	expectedUpdatedTitleConfig := fmt.Sprintf(`{"title":"%s","uid":"%s"}`, updatedDashboardTitle, dashboardUID)
 
-	expectedFolderTitle := "Test Folder"
-	expectedFolderUpdateTitle := "Updated Folder Title"
+	expectedFolderTitle := acctest.RandomWithPrefix("tf-acc-hosted-dashboard-folder")
+	expectedFolderUpdateTitle := acctest.RandomWithPrefix("tf-acc-hosted-dashboard-folder-updated")
 
 	var dashboard gapi.Dashboard
 
@@ -76,6 +76,7 @@ func TestAccCoralogixResourceHostedGrafanaDashboardCreate(t *testing.T) {
 					if err != nil {
 						panic(err)
 					}
+					time.Sleep(3 * time.Second)
 				},
 				// Test resource creation.
 				Config: testAccCoralogixResourceGrafanaDashboard(filePath, expectedFolderTitle),
@@ -158,4 +159,29 @@ func testAccCoralogixResourceGrafanaDashboard(filePath, folderTitle string) stri
   					title = "%s"
 				}
 `, filePath, folderTitle)
+}
+
+func testAccCoralogixResourceGrafanaDashboardRoot(filePath string) string {
+	return fmt.Sprintf(
+		`resource "coralogix_hosted_dashboard" test {
+	grafana{
+		config_json = file("%s")
+	}
+}
+`, filePath)
+}
+
+func testAccHostedDashboardJSONFile(t *testing.T, title string, uid string) string {
+	t.Helper()
+
+	filePath := filepath.Join(t.TempDir(), "grafana_acc_dashboard.json")
+	content := fmt.Sprintf(`{"title":%q,"uid":%q}`, title, uid)
+	if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write hosted dashboard fixture: %s", err)
+	}
+	return filePath
+}
+
+func testAccHostedDashboardUID() string {
+	return "tfacc" + acctest.RandStringFromCharSet(12, "abcdefghijklmnopqrstuvwxyz0123456789")
 }

--- a/internal/provider/slo_mgmt/resource_coralogix_slo_v2.go
+++ b/internal/provider/slo_mgmt/resource_coralogix_slo_v2.go
@@ -287,12 +287,12 @@ func (r *SLOV2Resource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics = diags
 		return
 	}
-	rq := slos.SlosServiceCreateSloRequest{
+	rq := slos.SlosServiceReplaceSloRequest{
 		SloRequestBasedMetricSli: slo.SloRequestBasedMetricSli,
 		SloWindowBasedMetricSli:  slo.SloWindowBasedMetricSli,
 	}
 
-	result, httpResponse, err := r.client.SlosServiceCreateSlo(ctx).SlosServiceCreateSloRequest(rq).Execute()
+	result, httpResponse, err := r.client.SlosServiceCreateSlo(ctx).SlosServiceReplaceSloRequest(rq).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating coralogix_slo_v2",
 			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Create", rq),


### PR DESCRIPTION
## Summary
- switch coralogix_dashboard resource and data source CRUD from gRPC to the generated OpenAPI dashboard client
- bump `github.com/coralogix/coralogix-management-sdk` to the merged facade v5 sync commit so the provider consumes the dashboard OpenAPI route fixes
- keep the legacy gRPC dashboard client only for old dashboard state upgrades
- add OpenAPI conversion coverage for dashboard oneOf variants, folder optionality, readable unsupported refresh variants, content_json fixtures, and gRPC isolation
- fix absolute dashboard time-frame flattening to return RFC3339 strings and avoid Terraform state drift

## Testing
- go test ./internal/provider/dashboards/... ./internal/provider/... -run 'Dashboard|DashboardsFolder|FlattenAbsoluteTimeFrame'
- go test ./internal/provider/...
- make build
- TF_ACC=1 go test ./internal/provider -run "TestAccCoralogixDataSourceDashboard|TestAccCoralogixResourceDashboard|TestAccCoralogixDataSourceDashboardsFolder|TestAccCoralogixResourceDashboardsFolder" -count=1 -v

## Notes
- Requested sync with origin/main could not be performed because the repository has no main ref; synced with origin/master, the GitHub default branch, instead.
- Unrelated local tmp/ files were left unstaged.
