### PR TITLE
release 3.4.2 + bump coralogix-management-sdk to latest master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# Release 3.4.2
 
 #### provider
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@
 
 - FIX: When `domain` is an AWS PrivateLink management host (`api.private.<region>.coralogix.com`), dial gRPC on that host instead of `ng-api-grpc.<domain>` so dashboards and other gRPC resources work over PrivateLink.
 - FIX: Route SCIM users and groups REST clients to the PrivateLink management host (`https://api.private.<region>.coralogix.com/scim/...`) instead of `ng-api-http.api.private...`.
+- CHORE: Bump `coralogix-management-sdk` to latest master.
 
 #### resource/coralogix_integration
 
 - FIX: Support importing integrations when Terraform has not populated dynamic `parameters` state yet.
+
+#### resource/coralogix_slo_v2
+
+- FIX: Adapt SLO create to the renamed SDK request type (`SlosServiceReplaceSloRequest`).
 
 # Release 3.4.1
 

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,10 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260601102833-4ca808288d61
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
+	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
@@ -40,7 +41,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
 	github.com/hashicorp/cli v1.1.7 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3 h1:s9A0yKgkinPwoed3x1rvSkWDgqzh6UESyeMB8hBANsY=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260601102833-4ca808288d61 h1:edSVyzZBcC67iIsWEb0cYn6wLig3BYPE12ycGhBbFiU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260601102833-4ca808288d61/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/clientset/version.go
+++ b/internal/clientset/version.go
@@ -14,4 +14,4 @@
 
 package clientset
 
-const TF_PROVIDER_VERSION = "3.4.1"
+const TF_PROVIDER_VERSION = "3.4.2"

--- a/internal/provider/slo_mgmt/resource_coralogix_slo_v2.go
+++ b/internal/provider/slo_mgmt/resource_coralogix_slo_v2.go
@@ -287,12 +287,12 @@ func (r *SLOV2Resource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics = diags
 		return
 	}
-	rq := slos.SlosServiceCreateSloRequest{
+	rq := slos.SlosServiceReplaceSloRequest{
 		SloRequestBasedMetricSli: slo.SloRequestBasedMetricSli,
 		SloWindowBasedMetricSli:  slo.SloWindowBasedMetricSli,
 	}
 
-	result, httpResponse, err := r.client.SlosServiceCreateSlo(ctx).SlosServiceCreateSloRequest(rq).Execute()
+	result, httpResponse, err := r.client.SlosServiceCreateSlo(ctx).SlosServiceReplaceSloRequest(rq).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating coralogix_slo_v2",
 			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Create", rq),


### PR DESCRIPTION
### Description

Cuts the **3.4.2** release and bumps `coralogix-management-sdk` to the latest master pseudo-version.

- **Release:** `TF_PROVIDER_VERSION` bumped `3.4.1` → `3.4.2`; the accumulated `# Unreleased` changelog section is promoted to `# Release 3.4.2`. It covers everything merged since 3.4.1: the PrivateLink gRPC/SCIM routing fixes (#540), the integration import fix (#539), the SDK bump, and the `coralogix_slo_v2` adaptation.
- **SDK bump:** `v1.9.4-0.20260419071831-7155b4fd20d3` → `v1.9.4-0.20260601102833-4ca808288d61` (master HEAD; no `v1.9.4` tag exists yet). Pulls the latest OpenAPI sync from openapi-facade.
- **Adaptation:** the sync renamed the SLO create request type `SlosServiceCreateSloRequest` → `SlosServiceReplaceSloRequest`. `coralogix_slo_v2` Create now uses the new type and `.SlosServiceReplaceSloRequest(...)` builder (Update already used it). This was the only compile break across the provider.
- **`go mod tidy`** promoted `go-grpc-middleware` to a direct dependency.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

> **Pending:** `make testacc` was **not** run for this release. The SDK bump touches many provider-consumed services (slos, integration, policies, api_keys, scopes, etc.), so the acceptance suite should be run against a real Coralogix environment before merge.

Verified locally:

```
go build ./...   # clean
go vet ./...     # clean
```

### Release Note

```release-note
release: 3.4.2 — bump coralogix-management-sdk to latest master
```

### References

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
