### PR TITLE
[TEST] fix(events2metric): return after failed create to avoid adopting an unrelated metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+#### resource/coralogix_events2metric
+
+- FIX: A failed create no longer writes an empty-ID resource into Terraform state. The empty ID caused the next refresh to fetch an arbitrary Events2Metric (typically an internal one), which the subsequent plan would try to destroy and replace. Refresh now also drops legacy empty-ID entries from state instead of adopting an unrelated Events2Metric.
+
 #### resource/coralogix_alert
 
 - FIX: `schedule.active_on` now accepts overnight windows (e.g. `start_time = "22:00"`, `end_time = "08:00"`). The provider was rejecting them with "End time is before start time" because both values get parsed against Go's zero date, making any earlier-clock-time end_time appear "before" start_time. The Coralogix API has no such ordering constraint.

--- a/internal/provider/events2metrics/resource_coralogix_events2metric.go
+++ b/internal/provider/events2metrics/resource_coralogix_events2metric.go
@@ -871,6 +871,7 @@ func (r *Events2MetricResource) Create(ctx context.Context, req resource.CreateR
 			"Error creating Events2Metric",
 			utils.FormatRpcErrors(err, cxsdk.E2MCreateRPC, protojson.Format(e2mCreateReq)),
 		)
+		return
 	}
 	log.Printf("[INFO] Submitted new Events2metric: %s", protojson.Format(e2mCreateResp))
 
@@ -890,6 +891,10 @@ func (r *Events2MetricResource) Read(ctx context.Context, req resource.ReadReque
 
 	//Get refreshed Events2Metric value from Coralogix
 	id := state.ID.ValueString()
+	if len(id) == 0 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	log.Printf("[INFO] Reading Events2metric: %s", id)
 	getE2MReq := &cxsdk.GetE2MRequest{Id: wrapperspb.String(id)}
 	getE2MResp, err := r.client.Get(ctx, getE2MReq)

--- a/internal/provider/resource_coralogix_events2metric_create_conflict_test.go
+++ b/internal/provider/resource_coralogix_events2metric_create_conflict_test.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCoralogixResourceEvents2MetricCreateConflict(t *testing.T) {
+	suffix := acctest.RandStringFromCharSet(8, "abcdefghijklmnopqrstuvwxyz")
+	metricField := "tfacc_conflict_" + suffix
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEvents2MetricDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvents2MetricConflictFirst(suffix, metricField),
+				Check:  resource.TestCheckResourceAttrSet("coralogix_events2metric.first", "id"),
+			},
+			{
+				Config:      testAccEvents2MetricConflictBoth(suffix, metricField),
+				ExpectError: regexp.MustCompile("Error creating Events2Metric"),
+			},
+			{
+				Config:   testAccEvents2MetricConflictFirst(suffix, metricField),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      "coralogix_events2metric.first",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEvents2MetricConflictFirst(suffix, metricField string) string {
+	return fmt.Sprintf(`resource %q %q {
+  name        = "tf_acc_e2m_conflict_first_%s"
+  description = "first events2metric owning the generated metric name"
+  logs_query = {
+    lucene = "remote_addr_enriched:/.*/"
+  }
+
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+    }
+  }
+
+  permutations = {
+    limit = 1000
+  }
+}
+`, "coralogix_events2metric", "first", suffix, metricField)
+}
+
+func testAccEvents2MetricConflictBoth(suffix, metricField string) string {
+	return testAccEvents2MetricConflictFirst(suffix, metricField) + fmt.Sprintf(`
+resource %q %q {
+  name        = "tf_acc_e2m_conflict_second_%s"
+  description = "second events2metric reusing the same metric name"
+  logs_query = {
+    lucene = "remote_addr_enriched:/.*/"
+  }
+
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+    }
+  }
+
+  permutations = {
+    limit = 1000
+  }
+
+  depends_on = [coralogix_events2metric.first]
+}
+`, "coralogix_events2metric", "second", suffix, metricField)
+}


### PR DESCRIPTION
*What*

coralogix_events2metric could overwrite an internal events2metric after a failed create.

When CreateE2M returns an error, Create recorded the diagnostic but did not return. Execution fell through to flattenE2M with the nil create response, producing a model whose id is the empty string, which Terraform then persisted. On the next refresh, Read sent that empty id to GetE2M, the backend answered with an arbitrary (often internal) events2metric, and the subsequent plan proposed destroying and replacing it.

*Fix*

- Add the missing return after the create-error diagnostic in Create, so a failed create no longer writes empty-ID state.
- In Read, remove the resource from state when its stored id is empty rather than fetching an unrelated events2metric.

*Test*

Adds TestAccCoralogixResourceEvents2MetricCreateConflict: creates one events2metric, then attempts a second that reuses the same generated metric name (rejected by the API), asserts the create error surfaces, and re-plans the first resource expecting an empty plan. Red on the pre-fix code, green with this change.

*Validation*

No single-apply reproducer was attached at triage: the bug needs a metric-name collision plus a two-step apply, so a single terraform apply cannot surface it. The acceptance test above encodes the scenario instead; live TF_ACC verification against a tenant is deferred.

TEST-MODE pipeline-validation PR. Draft, not for merge.