### PR TITLE
docs(dashboard): regenerate docs after section/row/widget id schema change (#547)

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -20,6 +20,8 @@ description: "Use when creating a PR for a non-trivial bug fix in this repo. Ass
 
 **Fill the rest of the template:** answer the Acceptance tests checkboxes, paste relevant `make testacc TESTARGS='-run=...'` output, write a meaningful Release Note (`NONE` for chore/internal), link related PRs/issues in References, keep Community Note verbatim.
 
+**If you touched schema or examples:** run `make generate` and commit any `docs/` changes in a separate "regenerate docs" commit.
+
 **Before `gh pr create`:** show the assembled description and wait for explicit approval. PR creation is visible-to-others.
 
 **Why:** reviewers shouldn't redo the archaeology you did. Symptom-and-fix descriptions push the work back onto them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### resource/coralogix_dashboard
 
+- DOCS: Regenerate docs — `layout.sections[*].id`, `layout.sections[*].rows[*].id`, and `layout.sections[*].rows[*].widgets[*].id` now correctly listed as Optional (was Read-Only).
 - FIX: Stop perpetual drift on the `line_chart.stacked_line` attribute when it is omitted from config. The attribute now defaults to `"unspecified"` (matching the sibling `scale_type` / `data_mode_type` pattern), so plans no longer mark it `(known after apply)` on every cycle.
 - FIX: Eliminate "Provider produced inconsistent result after apply" on `layout.sections[*].id`, `layout.sections[*].rows[*].id`, and `layout.sections[*].rows[*].widgets[*].id` by marking the `id` attributes `Optional+Computed` so the provider-generated UUID can round-trip on first Create (#505).
 - FIX: `layout.sections[*].options.collapsed` now reflects the API value instead of being forced to `null` whenever `description` is unset (typo in flatten nil-guard) (#505).

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -1116,12 +1116,9 @@ Optional:
 
 Optional:
 
+- `id` (String)
 - `options` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--options))
 - `rows` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows))
-
-Read-Only:
-
-- `id` (String)
 
 <a id="nestedatt--layout--sections--options"></a>
 ### Nested Schema for `layout.sections.options`
@@ -1146,11 +1143,8 @@ Required:
 
 Optional:
 
-- `widgets` (Attributes List) The list of widgets to display in the dashboard. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets))
-
-Read-Only:
-
 - `id` (String)
+- `widgets` (Attributes List) The list of widgets to display in the dashboard. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets))
 
 <a id="nestedatt--layout--sections--rows--widgets"></a>
 ### Nested Schema for `layout.sections.rows.widgets`
@@ -1162,12 +1156,9 @@ Required:
 Optional:
 
 - `description` (String) Widget description.
+- `id` (String)
 - `title` (String) Widget title. Required for all widgets except markdown.
 - `width` (Number, Deprecated) Deprecated: the widget appearance.width field is ignored by the API and has no effect.
-
-Read-Only:
-
-- `id` (String)
 
 <a id="nestedatt--layout--sections--rows--widgets--definition"></a>
 ### Nested Schema for `layout.sections.rows.widgets.definition`


### PR DESCRIPTION
### Description

## Summary
Regenerate `docs/resources/dashboard.md` after PR #547 and add `make generate` reminder to the `create-pr` skill.

## Root Cause
PR #547 changed `layout.sections.id`, `layout.sections.rows.id`, and `layout.sections.rows.widgets.id` from `Computed`-only to `Optional+Computed` in the schema, but `make generate` was not run after merge. The published docs listed those three `id` fields as `Read-Only` instead of `Optional`.

## Why was it introduced
Introduced by `3a15ca7` (the squash-merge of #547) — no docs regen step was included in that PR.

## Breaking change?
No. Docs-only and internal tooling.

## Risks
- None. Generated file only; schema and provider behavior are unchanged.

## Changes

| File | Change |
|---|---|
| `docs/resources/dashboard.md` | Regenerated via `make generate` — `id` on `sections`, `rows`, `widgets` now correctly listed as Optional |
| `.claude/skills/create-pr/SKILL.md` | Add one-line reminder to run `make generate` before opening a PR when schema or examples are touched |

## Test plan
- [x] `make generate` ran clean, diff matches expected schema state
- [x] `go build ./...` unaffected (no Go changes)

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added? — N/A (docs + tooling only)
- [ ] Have you run the acceptance tests on this branch? — N/A

### Release Note

```release-note
NONE
```

### References
Closes the docs gap left by #547.

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment