### PR TITLE
Add target-level TCO policy support

### DIFF
--- a/docs/data-sources/tco_policies_logs.md
+++ b/docs/data-sources/tco_policies_logs.md
@@ -39,10 +39,11 @@ Read-Only:
 - `id` (String) tco-policy ID.
 - `name` (String) tco-policy name.
 - `order` (Number) The policy's order between the other policies.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"].
+- `priority` (String) Legacy policy-level priority. Required when `targets` is not set. Can be one of ["block" "high" "low" "medium"].
 - `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
+- `targets` (Attributes List) Target-level routing destinations for this policy. When set, legacy top-level priority, archive_retention_id, and quota_based_priority_override must not be set. (see [below for nested schema](#nestedatt--policies--targets))
 
 <a id="nestedatt--policies--applications"></a>
 ### Nested Schema for `policies.applications`
@@ -77,3 +78,30 @@ Read-Only:
 
 - `names` (Set of String)
 - `rule_type` (String)
+
+
+<a id="nestedatt--policies--targets"></a>
+### Nested Schema for `policies.targets`
+
+Read-Only:
+
+- `archive_retention_id` (String) Allowing logs routed to this target to be tagged with a specific retention.
+- `dataset` (String) The dataset routed by this target.
+- `dataspace` (String) The dataspace routed by this target.
+- `priority` (String) The target priority. Can be one of ["block" "high" "low" "medium"].
+- `quota_based_priority_override` (Attributes) Dynamically reassign this target's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--targets--quota_based_priority_override))
+
+<a id="nestedatt--policies--targets--quota_based_priority_override"></a>
+### Nested Schema for `policies.targets.quota_based_priority_override`
+
+Read-Only:
+
+- `usage_tiers` (Attributes List) Ordered list of quota-consumption tiers for this target. (see [below for nested schema](#nestedatt--policies--targets--quota_based_priority_override--usage_tiers))
+
+<a id="nestedatt--policies--targets--quota_based_priority_override--usage_tiers"></a>
+### Nested Schema for `policies.targets.quota_based_priority_override.usage_tiers`
+
+Read-Only:
+
+- `daily_quota_percentage` (Number) Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.
+- `priority` (String) The priority to apply when this tier is active. Can be one of ["block" "high" "low" "medium"].

--- a/docs/data-sources/tco_policies_traces.md
+++ b/docs/data-sources/tco_policies_traces.md
@@ -39,10 +39,11 @@ Read-Only:
 - `id` (String) tco-policy ID.
 - `name` (String) tco-policy name.
 - `order` (Number) The policy's order between the other policies.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"].
+- `priority` (String) Legacy policy-level priority. Required when `targets` is not set. Can be one of ["block" "high" "low" "medium"].
 - `services` (Attributes) The services to apply the policy on. Applies the policy on all the services by default. (see [below for nested schema](#nestedatt--policies--services))
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
 - `tags` (Attributes Map) The tags to apply the policy on. Applies the policy on all the tags by default. (see [below for nested schema](#nestedatt--policies--tags))
+- `targets` (Attributes List) Target-level routing destinations for this policy. When set, legacy top-level priority and archive_retention_id must not be set. (see [below for nested schema](#nestedatt--policies--targets))
 
 <a id="nestedatt--policies--actions"></a>
 ### Nested Schema for `policies.actions`
@@ -87,3 +88,14 @@ Read-Only:
 
 - `names` (Set of String)
 - `rule_type` (String)
+
+
+<a id="nestedatt--policies--targets"></a>
+### Nested Schema for `policies.targets`
+
+Read-Only:
+
+- `archive_retention_id` (String) Allowing traces routed to this target to be tagged with a specific retention.
+- `dataset` (String) The dataset routed by this target.
+- `dataspace` (String) The dataspace routed by this target.
+- `priority` (String) The target priority. Can be one of ["block" "high" "low" "medium"].

--- a/docs/resources/tco_policies_logs.md
+++ b/docs/resources/tco_policies_logs.md
@@ -127,7 +127,6 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
 Required:
 
 - `name` (String) tco-policy name.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"].
 
 Optional:
 
@@ -136,9 +135,11 @@ Optional:
 - `description` (String) The policy description
 - `dpxl_expression` (String) DataPrime expression to match logs for this policy. Mutually exclusive with `severities` — set exactly one. The expression must include a version prefix, e.g. `<v1> $d.severity == 'INFO'`.
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
+- `priority` (String) Legacy policy-level priority. Required when `targets` is not set. Can be one of ["block" "high" "low" "medium"].
 - `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
+- `targets` (Attributes List) Target-level routing destinations for this policy. When set, legacy top-level priority, archive_retention_id, and quota_based_priority_override must not be set. (see [below for nested schema](#nestedatt--policies--targets))
 
 Read-Only:
 
@@ -184,3 +185,33 @@ Required:
 Optional:
 
 - `rule_type` (String)
+
+
+<a id="nestedatt--policies--targets"></a>
+### Nested Schema for `policies.targets`
+
+Required:
+
+- `dataset` (String) The dataset routed by this target.
+- `priority` (String) The target priority. Can be one of ["block" "high" "low" "medium"].
+
+Optional:
+
+- `archive_retention_id` (String) Allowing logs routed to this target to be tagged with a specific retention.
+- `dataspace` (String) The dataspace routed by this target.
+- `quota_based_priority_override` (Attributes) Dynamically reassign this target's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--targets--quota_based_priority_override))
+
+<a id="nestedatt--policies--targets--quota_based_priority_override"></a>
+### Nested Schema for `policies.targets.quota_based_priority_override`
+
+Required:
+
+- `usage_tiers` (Attributes List) Ordered list of quota-consumption tiers for this target. (see [below for nested schema](#nestedatt--policies--targets--quota_based_priority_override--usage_tiers))
+
+<a id="nestedatt--policies--targets--quota_based_priority_override--usage_tiers"></a>
+### Nested Schema for `policies.targets.quota_based_priority_override.usage_tiers`
+
+Required:
+
+- `daily_quota_percentage` (Number) Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.
+- `priority` (String) The priority to apply when this tier is active. Can be one of ["block" "high" "low" "medium"].

--- a/docs/resources/tco_policies_traces.md
+++ b/docs/resources/tco_policies_traces.md
@@ -125,7 +125,6 @@ resource "coralogix_tco_policies_traces" "tco_policies" {
 Required:
 
 - `name` (String) tco-policy name.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"].
 
 Optional:
 
@@ -134,9 +133,11 @@ Optional:
 - `archive_retention_id` (String) Allowing logs with a specific retention to be tagged.
 - `description` (String) The policy description
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
+- `priority` (String) Legacy policy-level priority. Required when `targets` is not set. Can be one of ["block" "high" "low" "medium"].
 - `services` (Attributes) The services to apply the policy on. Applies the policy on all the services by default. (see [below for nested schema](#nestedatt--policies--services))
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
 - `tags` (Attributes Map) The tags to apply the policy on. Applies the policy on all the tags by default. (see [below for nested schema](#nestedatt--policies--tags))
+- `targets` (Attributes List) Target-level routing destinations for this policy. When set, legacy top-level priority and archive_retention_id must not be set. (see [below for nested schema](#nestedatt--policies--targets))
 
 Read-Only:
 
@@ -201,3 +202,17 @@ Required:
 Optional:
 
 - `rule_type` (String)
+
+
+<a id="nestedatt--policies--targets"></a>
+### Nested Schema for `policies.targets`
+
+Required:
+
+- `dataset` (String) The dataset routed by this target.
+- `priority` (String) The target priority. Can be one of ["block" "high" "low" "medium"].
+
+Optional:
+
+- `archive_retention_id` (String) Allowing traces routed to this target to be tagged with a specific retention.
+- `dataspace` (String) The dataspace routed by this target.

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -18,13 +18,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
-
-	"regexp"
 
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 	tcoPolicys "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/policies_service"
@@ -46,9 +45,10 @@ import (
 )
 
 var (
-	_                              resource.ResourceWithConfigure   = &TCOPoliciesLogsResource{}
-	_                              resource.ResourceWithImportState = &TCOPoliciesLogsResource{}
-	tcoPoliciesPrioritySchemaToApi                                  = map[string]tcoPolicys.QuotaV1Priority{
+	_                              resource.ResourceWithConfigure      = &TCOPoliciesLogsResource{}
+	_                              resource.ResourceWithValidateConfig = &TCOPoliciesLogsResource{}
+	_                              resource.ResourceWithImportState    = &TCOPoliciesLogsResource{}
+	tcoPoliciesPrioritySchemaToApi                                     = map[string]tcoPolicys.QuotaV1Priority{
 		"block":  tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_BLOCK,
 		"high":   tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_HIGH,
 		"low":    tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_LOW,
@@ -80,6 +80,10 @@ var (
 	LogSource = tcoPolicys.V1SOURCETYPE_SOURCE_TYPE_LOGS
 )
 
+const tcoPolicyDefaultDataspace = "default"
+
+var tcoPolicyTargetDataspaceRegexp = regexp.MustCompile(`^[A-Za-z](?:[A-Za-z0-9_]|\.[A-Za-z0-9_])*$`)
+
 func NewTCOPoliciesLogsResource() resource.Resource {
 	return &TCOPoliciesLogsResource{}
 }
@@ -110,6 +114,22 @@ type TCOPolicyLogsModel struct {
 	ArchiveRetentionID         types.String `tfsdk:"archive_retention_id"`
 	DpxlExpression             types.String `tfsdk:"dpxl_expression"`
 	QuotaBasedPriorityOverride types.Object `tfsdk:"quota_based_priority_override"` // QuotaBasedPriorityOverrideModel
+	Targets                    types.List   `tfsdk:"targets"`                       // []TCOPolicyLogTargetModel
+}
+
+type TCOPolicyLogTargetModel struct {
+	Dataset                    types.String `tfsdk:"dataset"`
+	Dataspace                  types.String `tfsdk:"dataspace"`
+	Priority                   types.String `tfsdk:"priority"`
+	ArchiveRetentionID         types.String `tfsdk:"archive_retention_id"`
+	QuotaBasedPriorityOverride types.Object `tfsdk:"quota_based_priority_override"` // QuotaBasedPriorityOverrideModel
+}
+
+type TCOPolicyTraceTargetModel struct {
+	Dataset            types.String `tfsdk:"dataset"`
+	Dataspace          types.String `tfsdk:"dataspace"`
+	Priority           types.String `tfsdk:"priority"`
+	ArchiveRetentionID types.String `tfsdk:"archive_retention_id"`
 }
 
 type TCORuleModel struct {
@@ -181,11 +201,11 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 							MarkdownDescription: "Determines weather the policy will be enabled. True by default.",
 						},
 						"priority": schema.StringAttribute{
-							Required: true,
+							Optional: true,
 							Validators: []validator.String{
 								stringvalidator.OneOf(tcoPoliciesValidPriorities...),
 							},
-							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q.", tcoPoliciesValidPriorities),
+							MarkdownDescription: fmt.Sprintf("Legacy policy-level priority. Required when `targets` is not set. Can be one of %q.", tcoPoliciesValidPriorities),
 						},
 						"order": schema.Int64Attribute{
 							Computed:            true,
@@ -293,6 +313,78 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 								},
 							},
 							MarkdownDescription: "Dynamically reassign the policy's priority based on daily quota consumption tiers.",
+						},
+						"targets": schema.ListNestedAttribute{
+							Optional: true,
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+							},
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"dataset": schema.StringAttribute{
+										Required: true,
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+										MarkdownDescription: "The dataset routed by this target.",
+									},
+									"dataspace": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+										Default:  stringdefault.StaticString(tcoPolicyDefaultDataspace),
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(tcoPolicyTargetDataspaceRegexp, "dataspace must start with a letter and contain only letters, numbers, underscores, or dots between segments"),
+										},
+										MarkdownDescription: "The dataspace routed by this target.",
+									},
+									"priority": schema.StringAttribute{
+										Required: true,
+										Validators: []validator.String{
+											stringvalidator.OneOf(tcoPoliciesValidPriorities...),
+										},
+										MarkdownDescription: fmt.Sprintf("The target priority. Can be one of %q.", tcoPoliciesValidPriorities),
+									},
+									"archive_retention_id": schema.StringAttribute{
+										Optional:    true,
+										Description: "Allowing logs routed to this target to be tagged with a specific retention.",
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+									},
+									"quota_based_priority_override": schema.SingleNestedAttribute{
+										Optional: true,
+										Attributes: map[string]schema.Attribute{
+											"usage_tiers": schema.ListNestedAttribute{
+												Required: true,
+												Validators: []validator.List{
+													listvalidator.SizeAtLeast(1),
+												},
+												NestedObject: schema.NestedAttributeObject{
+													Attributes: map[string]schema.Attribute{
+														"daily_quota_percentage": schema.Float64Attribute{
+															Required: true,
+															Validators: []validator.Float64{
+																float64validator.Between(0, 100),
+															},
+															MarkdownDescription: "Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.",
+														},
+														"priority": schema.StringAttribute{
+															Required: true,
+															Validators: []validator.String{
+																stringvalidator.OneOf(tcoPoliciesValidPriorities...),
+															},
+															MarkdownDescription: fmt.Sprintf("The priority to apply when this tier is active. Can be one of %q.", tcoPoliciesValidPriorities),
+														},
+													},
+												},
+												MarkdownDescription: "Ordered list of quota-consumption tiers for this target.",
+											},
+										},
+										MarkdownDescription: "Dynamically reassign this target's priority based on daily quota consumption tiers.",
+									},
+								},
+							},
+							MarkdownDescription: "Target-level routing destinations for this policy. When set, legacy top-level priority, archive_retention_id, and quota_based_priority_override must not be set.",
 						},
 					},
 				},
@@ -544,6 +636,17 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 	if diags.HasError() {
 		return nil, diags
 	}
+	targets, diags := flattenTCOLogPolicyTargets(ctx, logsPolicy.GetTargets())
+	if diags.HasError() {
+		return nil, diags
+	}
+	priority := types.StringValue(tcoPoliciesPriorityApiToSchema[logsPolicy.GetPriority()])
+	archiveRetentionID := flattenArchiveRetention(logsPolicy.ArchiveRetention)
+	if len(logsPolicy.GetTargets()) > 0 {
+		priority = types.StringNull()
+		archiveRetentionID = types.StringNull()
+		quotaBased = types.ObjectNull(quotaBasedPriorityOverrideAttributes())
+	}
 
 	return &TCOPolicyLogsModel{
 		ID:                         types.StringValue(logsPolicy.GetId()),
@@ -551,13 +654,14 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 		Description:                types.StringValue(logsPolicy.GetDescription()),
 		Enabled:                    types.BoolValue(logsPolicy.GetEnabled()),
 		Order:                      types.Int64Value(int64(logsPolicy.GetOrder())),
-		Priority:                   types.StringValue(tcoPoliciesPriorityApiToSchema[logsPolicy.GetPriority()]),
+		Priority:                   priority,
 		Applications:               applications,
 		Subsystems:                 subsystems,
-		ArchiveRetentionID:         flattenArchiveRetention(logsPolicy.ArchiveRetention),
+		ArchiveRetentionID:         archiveRetentionID,
 		Severities:                 flattenTCOPolicySeverities(logRules.GetSeverities()),
 		DpxlExpression:             types.StringPointerValue(logRules.DpxlExpression),
 		QuotaBasedPriorityOverride: quotaBased,
+		Targets:                    targets,
 	}, nil
 }
 
@@ -587,6 +691,41 @@ func flattenQuotaBasedPriorityOverride(ctx context.Context, po *tcoPolicys.Prior
 	})
 }
 
+func flattenTCOLogPolicyTargets(ctx context.Context, targets []tcoPolicys.V1Target) (types.List, diag.Diagnostics) {
+	if len(targets) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: tcoPolicyLogTargetAttributes()}), nil
+	}
+
+	targetModels := make([]TCOPolicyLogTargetModel, 0, len(targets))
+	var diags diag.Diagnostics
+	for _, target := range targets {
+		priority := types.StringNull()
+		if target.Priority != nil {
+			priority = types.StringValue(tcoPoliciesPriorityApiToSchema[*target.Priority])
+		}
+		dataspace := types.StringValue(tcoPolicyDefaultDataspace)
+		if target.Dataspace != nil {
+			dataspace = types.StringValue(*target.Dataspace)
+		}
+		quotaBased, dgs := flattenQuotaBasedPriorityOverride(ctx, target.PriorityOverride)
+		if dgs.HasError() {
+			diags.Append(dgs...)
+			continue
+		}
+		targetModels = append(targetModels, TCOPolicyLogTargetModel{
+			Dataset:                    types.StringPointerValue(target.Dataset),
+			Dataspace:                  dataspace,
+			Priority:                   priority,
+			ArchiveRetentionID:         flattenArchiveRetention(target.ArchiveRetention),
+			QuotaBasedPriorityOverride: quotaBased,
+		})
+	}
+	if diags.HasError() {
+		return types.ListNull(types.ObjectType{AttrTypes: tcoPolicyLogTargetAttributes()}), diags
+	}
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: tcoPolicyLogTargetAttributes()}, targetModels)
+}
+
 func policiesLogsAttr() map[string]attr.Type {
 	return map[string]attr.Type{
 		"id":                            types.StringType,
@@ -601,6 +740,26 @@ func policiesLogsAttr() map[string]attr.Type {
 		"archive_retention_id":          types.StringType,
 		"dpxl_expression":               types.StringType,
 		"quota_based_priority_override": types.ObjectType{AttrTypes: quotaBasedPriorityOverrideAttributes()},
+		"targets":                       types.ListType{ElemType: types.ObjectType{AttrTypes: tcoPolicyLogTargetAttributes()}},
+	}
+}
+
+func tcoPolicyLogTargetAttributes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"dataset":                       types.StringType,
+		"dataspace":                     types.StringType,
+		"priority":                      types.StringType,
+		"archive_retention_id":          types.StringType,
+		"quota_based_priority_override": types.ObjectType{AttrTypes: quotaBasedPriorityOverrideAttributes()},
+	}
+}
+
+func tcoPolicyTraceTargetAttributes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"dataset":              types.StringType,
+		"dataspace":            types.StringType,
+		"priority":             types.StringType,
+		"archive_retention_id": types.StringType,
 	}
 }
 
@@ -662,7 +821,6 @@ func extractOverwriteTcoPoliciesLogs(ctx context.Context, plan *TCOPoliciesListM
 }
 
 func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPolicys.CreateLogPolicyRequest, diag.Diagnostics) {
-	priority := tcoPoliciesPrioritySchemaToApi[plan.Priority.ValueString()]
 	applicationRule, diags := expandTCOPolicyRule(ctx, plan.Applications)
 	if diags.HasError() {
 		return nil, diags
@@ -671,12 +829,7 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 	if diags.HasError() {
 		return nil, diags
 	}
-	archiveRetention := expandActiveRetention(plan.ArchiveRetentionID)
 	severities, diags := expandTCOPolicySeverities(ctx, plan.Severities.Elements())
-	if diags.HasError() {
-		return nil, diags
-	}
-	priorityOverride, diags := expandQuotaBasedPriorityOverride(ctx, plan.QuotaBasedPriorityOverride)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -689,19 +842,97 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 		logRules.Severities = severities
 	}
 
+	policy := tcoPolicys.CreateGenericPolicyRequest{
+		Name:            plan.Name.ValueString(),
+		Description:     plan.Description.ValueString(),
+		ApplicationRule: applicationRule,
+		SubsystemRule:   subsystemRule,
+		Disabled:        &enabled,
+	}
+	targetsConfigured := !plan.Targets.IsNull() && !plan.Targets.IsUnknown()
+	legacyPriorityConfigured := !plan.Priority.IsNull() && !plan.Priority.IsUnknown()
+	if targetsConfigured {
+		if legacyPriorityConfigured || !plan.ArchiveRetentionID.IsNull() || !plan.QuotaBasedPriorityOverride.IsNull() {
+			diags.AddError(
+				"TCO log policy cannot mix targets with top-level priority, archive_retention_id, or quota_based_priority_override",
+				"Move priority, archive retention, and quota-based priority override settings into each target, or remove targets and use the legacy top-level fields.",
+			)
+			return nil, diags
+		}
+		targets, dgs := expandTCOLogPolicyTargets(ctx, plan.Targets)
+		if dgs.HasError() {
+			diags.Append(dgs...)
+			return nil, diags
+		}
+		policy.Priority = tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED
+		policy.Targets = targets
+	} else {
+		if !legacyPriorityConfigured {
+			diags.AddError(
+				"TCO log policy must use either targets or legacy top-level priority",
+				"Set targets for target-level routing, or set the legacy top-level priority field.",
+			)
+			return nil, diags
+		}
+		priorityOverride, dgs := expandQuotaBasedPriorityOverride(ctx, plan.QuotaBasedPriorityOverride)
+		if dgs.HasError() {
+			diags.Append(dgs...)
+			return nil, diags
+		}
+		policy.Priority = tcoPoliciesPrioritySchemaToApi[plan.Priority.ValueString()]
+		policy.ArchiveRetention = expandActiveRetention(plan.ArchiveRetentionID)
+		policy.PriorityOverride = priorityOverride
+	}
+
 	return &tcoPolicys.CreateLogPolicyRequest{
-		Policy: tcoPolicys.CreateGenericPolicyRequest{
-			Name:             plan.Name.ValueString(),
-			Description:      plan.Description.ValueString(),
-			Priority:         priority,
-			ApplicationRule:  applicationRule,
-			SubsystemRule:    subsystemRule,
-			ArchiveRetention: archiveRetention,
-			Disabled:         &enabled,
-			PriorityOverride: priorityOverride,
-		},
+		Policy:   policy,
 		LogRules: logRules,
 	}, nil
+}
+
+func expandTCOLogPolicyTargets(ctx context.Context, targets types.List) ([]tcoPolicys.V1Target, diag.Diagnostics) {
+	if targets.IsNull() || targets.IsUnknown() {
+		return nil, nil
+	}
+
+	var targetObjects []types.Object
+	diags := targets.ElementsAs(ctx, &targetObjects, true)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	result := make([]tcoPolicys.V1Target, 0, len(targetObjects))
+	for _, targetObject := range targetObjects {
+		var targetModel TCOPolicyLogTargetModel
+		if dgs := targetObject.As(ctx, &targetModel, basetypes.ObjectAsOptions{}); dgs.HasError() {
+			diags.Append(dgs...)
+			continue
+		}
+		target := tcoPolicys.V1Target{
+			Dataset:          targetModel.Dataset.ValueStringPointer(),
+			Dataspace:        targetModel.Dataspace.ValueStringPointer(),
+			ArchiveRetention: expandActiveRetention(targetModel.ArchiveRetentionID),
+		}
+		if targetModel.Dataspace.IsNull() || targetModel.Dataspace.IsUnknown() {
+			dataspace := tcoPolicyDefaultDataspace
+			target.Dataspace = &dataspace
+		}
+		if !targetModel.Priority.IsNull() && !targetModel.Priority.IsUnknown() {
+			priority := tcoPoliciesPrioritySchemaToApi[targetModel.Priority.ValueString()]
+			target.Priority = &priority
+		}
+		priorityOverride, dgs := expandQuotaBasedPriorityOverride(ctx, targetModel.QuotaBasedPriorityOverride)
+		if dgs.HasError() {
+			diags.Append(dgs...)
+			continue
+		}
+		target.PriorityOverride = priorityOverride
+		result = append(result, target)
+	}
+	if diags.HasError() {
+		return nil, diags
+	}
+	return result, nil
 }
 
 func expandQuotaBasedPriorityOverride(ctx context.Context, override types.Object) (*tcoPolicys.PriorityOverride, diag.Diagnostics) {
@@ -767,7 +998,7 @@ func expandTCOPolicyRule(ctx context.Context, rule types.Object) (*tcoPolicys.Qu
 }
 
 func expandActiveRetention(archiveRetention types.String) *tcoPolicys.ArchiveRetention {
-	if archiveRetention.IsNull() {
+	if archiveRetention.IsNull() || archiveRetention.IsUnknown() {
 		return nil
 	}
 

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_targets_test.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_targets_test.go
@@ -1,0 +1,328 @@
+package dataplans
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tcoPolicys "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/policies_service"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestExtractTcoPolicyLogWithTargets(t *testing.T) {
+	ctx := context.Background()
+	targets := logTargetsList(t, ctx, []TCOPolicyLogTargetModel{
+		{
+			Dataset:                    types.StringValue("logs"),
+			Dataspace:                  types.StringValue("default"),
+			Priority:                   types.StringValue("high"),
+			ArchiveRetentionID:         types.StringNull(),
+			QuotaBasedPriorityOverride: types.ObjectNull(quotaBasedPriorityOverrideAttributes()),
+		},
+		{
+			Dataset:                    types.StringValue("logs"),
+			Dataspace:                  types.StringValue("payments"),
+			Priority:                   types.StringValue("low"),
+			ArchiveRetentionID:         types.StringValue("retention-id"),
+			QuotaBasedPriorityOverride: quotaOverrideObject(t, ctx),
+		},
+	})
+
+	request, diags := extractTcoPolicyLog(ctx, baseLogPolicyModel(targets))
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if request.Policy.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+		t.Fatalf("expected unspecified top-level priority, got %v", request.Policy.Priority)
+	}
+	if request.Policy.ArchiveRetention != nil {
+		t.Fatalf("expected nil top-level archive retention, got %#v", request.Policy.ArchiveRetention)
+	}
+	if request.Policy.PriorityOverride != nil {
+		t.Fatalf("expected nil top-level priority override, got %#v", request.Policy.PriorityOverride)
+	}
+	if len(request.Policy.Targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(request.Policy.Targets))
+	}
+	if got := request.Policy.Targets[1].GetDataspace(); got != "payments" {
+		t.Fatalf("expected second target dataspace payments, got %q", got)
+	}
+	if request.Policy.Targets[1].PriorityOverride == nil {
+		t.Fatal("expected target-level priority override")
+	}
+}
+
+func TestFlattenTCOLogsPolicyWithTargets(t *testing.T) {
+	ctx := context.Background()
+	priority := tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_LOW
+	dataset := "logs"
+	dataspace := "payments"
+	policy := tcoPolicys.Policy{
+		PolicyLogRules: &tcoPolicys.PolicyLogRules{
+			Id:          "policy-id",
+			Name:        "targeted-log-policy",
+			Enabled:     true,
+			LogRules:    tcoPolicys.LogRules{},
+			Priority:    tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED,
+			Description: stringPointer(""),
+			Targets: []tcoPolicys.V1Target{
+				{
+					Dataset:          &dataset,
+					Dataspace:        &dataspace,
+					Priority:         &priority,
+					PriorityOverride: quotaOverrideAPI(),
+				},
+			},
+		},
+	}
+
+	model, diags := flattenTCOLogsPolicy(ctx, policy)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !model.Priority.IsNull() {
+		t.Fatalf("expected top-level priority to be null, got %q", model.Priority.ValueString())
+	}
+	if !model.QuotaBasedPriorityOverride.IsNull() {
+		t.Fatal("expected top-level quota override to be null")
+	}
+
+	var targets []TCOPolicyLogTargetModel
+	if diags := model.Targets.ElementsAs(ctx, &targets, false); diags.HasError() {
+		t.Fatalf("unexpected target diagnostics: %v", diags)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if got := targets[0].Dataspace.ValueString(); got != "payments" {
+		t.Fatalf("expected dataspace payments, got %q", got)
+	}
+	if targets[0].QuotaBasedPriorityOverride.IsNull() {
+		t.Fatal("expected target-level quota override")
+	}
+}
+
+func TestExtractTcoPolicyTraceWithTargets(t *testing.T) {
+	ctx := context.Background()
+	targets := traceTargetsList(t, ctx, []TCOPolicyTraceTargetModel{
+		{
+			Dataset:            types.StringValue("spans"),
+			Dataspace:          types.StringValue("default"),
+			Priority:           types.StringValue("high"),
+			ArchiveRetentionID: types.StringNull(),
+		},
+		{
+			Dataset:            types.StringValue("spans"),
+			Dataspace:          types.StringValue("payments"),
+			Priority:           types.StringValue("medium"),
+			ArchiveRetentionID: types.StringValue("retention-id"),
+		},
+	})
+
+	request, diags := extractTcoPolicyTraces(ctx, baseTracePolicyModel(targets))
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if request.Policy.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+		t.Fatalf("expected unspecified top-level priority, got %v", request.Policy.Priority)
+	}
+	if len(request.Policy.Targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(request.Policy.Targets))
+	}
+	if got := request.Policy.Targets[1].GetDataspace(); got != "payments" {
+		t.Fatalf("expected second target dataspace payments, got %q", got)
+	}
+}
+
+func TestExtractTcoPolicyLogLegacyCompatibility(t *testing.T) {
+	ctx := context.Background()
+	model := baseLogPolicyModel(types.ListNull(types.ObjectType{AttrTypes: tcoPolicyLogTargetAttributes()}))
+	model.Priority = types.StringValue("medium")
+	model.ArchiveRetentionID = types.StringValue("retention-id")
+	model.QuotaBasedPriorityOverride = quotaOverrideObject(t, ctx)
+
+	request, diags := extractTcoPolicyLog(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if request.Policy.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_MEDIUM {
+		t.Fatalf("expected medium top-level priority, got %v", request.Policy.Priority)
+	}
+	if request.Policy.ArchiveRetention == nil {
+		t.Fatal("expected top-level archive retention")
+	}
+	if request.Policy.PriorityOverride == nil {
+		t.Fatal("expected top-level priority override")
+	}
+	if len(request.Policy.Targets) != 0 {
+		t.Fatalf("expected no targets, got %d", len(request.Policy.Targets))
+	}
+}
+
+func TestExtractTcoPolicyTraceLegacyCompatibility(t *testing.T) {
+	ctx := context.Background()
+	model := baseTracePolicyModel(types.ListNull(types.ObjectType{AttrTypes: tcoPolicyTraceTargetAttributes()}))
+	model.Priority = types.StringValue("low")
+	model.ArchiveRetentionID = types.StringValue("retention-id")
+
+	request, diags := extractTcoPolicyTraces(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if request.Policy.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_LOW {
+		t.Fatalf("expected low top-level priority, got %v", request.Policy.Priority)
+	}
+	if request.Policy.ArchiveRetention == nil {
+		t.Fatal("expected top-level archive retention")
+	}
+	if len(request.Policy.Targets) != 0 {
+		t.Fatalf("expected no targets, got %d", len(request.Policy.Targets))
+	}
+}
+
+func TestExtractTcoPolicyRejectsAmbiguousAndMissingTargets(t *testing.T) {
+	ctx := context.Background()
+	targets := logTargetsList(t, ctx, []TCOPolicyLogTargetModel{
+		{
+			Dataset:                    types.StringValue("logs"),
+			Dataspace:                  types.StringValue("default"),
+			Priority:                   types.StringValue("high"),
+			ArchiveRetentionID:         types.StringNull(),
+			QuotaBasedPriorityOverride: types.ObjectNull(quotaBasedPriorityOverrideAttributes()),
+		},
+	})
+
+	mixedLog := baseLogPolicyModel(targets)
+	mixedLog.Priority = types.StringValue("high")
+	_, diags := extractTcoPolicyLog(ctx, mixedLog)
+	assertDiagnosticContains(t, diags, "cannot mix targets")
+
+	missingLog := baseLogPolicyModel(types.ListNull(types.ObjectType{AttrTypes: tcoPolicyLogTargetAttributes()}))
+	_, diags = extractTcoPolicyLog(ctx, missingLog)
+	assertDiagnosticContains(t, diags, "must use either targets or legacy top-level priority")
+
+	mixedTrace := baseTracePolicyModel(traceTargetsList(t, ctx, []TCOPolicyTraceTargetModel{
+		{
+			Dataset:            types.StringValue("spans"),
+			Dataspace:          types.StringValue("default"),
+			Priority:           types.StringValue("high"),
+			ArchiveRetentionID: types.StringNull(),
+		},
+	}))
+	mixedTrace.Priority = types.StringValue("high")
+	_, diags = extractTcoPolicyTraces(ctx, mixedTrace)
+	assertDiagnosticContains(t, diags, "cannot mix targets")
+
+	missingTrace := baseTracePolicyModel(types.ListNull(types.ObjectType{AttrTypes: tcoPolicyTraceTargetAttributes()}))
+	_, diags = extractTcoPolicyTraces(ctx, missingTrace)
+	assertDiagnosticContains(t, diags, "must use either targets or legacy top-level priority")
+}
+
+func baseLogPolicyModel(targets types.List) TCOPolicyLogsModel {
+	return TCOPolicyLogsModel{
+		Name:                       types.StringValue("targeted-log-policy"),
+		Description:                types.StringValue(""),
+		Enabled:                    types.BoolValue(true),
+		Priority:                   types.StringNull(),
+		Applications:               types.ObjectNull(tcoPolicyRuleAttributes()),
+		Subsystems:                 types.ObjectNull(tcoPolicyRuleAttributes()),
+		Severities:                 types.SetValueMust(types.StringType, []attr.Value{types.StringValue("info")}),
+		ArchiveRetentionID:         types.StringNull(),
+		DpxlExpression:             types.StringNull(),
+		QuotaBasedPriorityOverride: types.ObjectNull(quotaBasedPriorityOverrideAttributes()),
+		Targets:                    targets,
+	}
+}
+
+func baseTracePolicyModel(targets types.List) TCOPolicyTracesModel {
+	return TCOPolicyTracesModel{
+		Name:               types.StringValue("targeted-trace-policy"),
+		Description:        types.StringValue(""),
+		Enabled:            types.BoolValue(true),
+		Priority:           types.StringNull(),
+		Applications:       types.ObjectNull(tcoPolicyRuleAttributes()),
+		Subsystems:         types.ObjectNull(tcoPolicyRuleAttributes()),
+		ArchiveRetentionID: types.StringNull(),
+		Services:           types.ObjectNull(tcoPolicyRuleAttributes()),
+		Actions:            types.ObjectNull(tcoPolicyRuleAttributes()),
+		Tags:               types.MapValueMust(types.ObjectType{AttrTypes: tcoPolicyRuleAttributes()}, map[string]attr.Value{}),
+		Targets:            targets,
+	}
+}
+
+func logTargetsList(t *testing.T, ctx context.Context, targets []TCOPolicyLogTargetModel) types.List {
+	t.Helper()
+	targetsList, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: tcoPolicyLogTargetAttributes()}, targets)
+	if diags.HasError() {
+		t.Fatalf("unexpected log target diagnostics: %v", diags)
+	}
+	return targetsList
+}
+
+func traceTargetsList(t *testing.T, ctx context.Context, targets []TCOPolicyTraceTargetModel) types.List {
+	t.Helper()
+	targetsList, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: tcoPolicyTraceTargetAttributes()}, targets)
+	if diags.HasError() {
+		t.Fatalf("unexpected trace target diagnostics: %v", diags)
+	}
+	return targetsList
+}
+
+func quotaOverrideObject(t *testing.T, ctx context.Context) types.Object {
+	t.Helper()
+	usageTiers, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: usageTierAttributes()}, []UsageTierModel{
+		{
+			DailyQuotaPercentage: types.Float64Value(0.01),
+			Priority:             types.StringValue("low"),
+		},
+		{
+			DailyQuotaPercentage: types.Float64Value(0.03),
+			Priority:             types.StringValue("medium"),
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected usage tier diagnostics: %v", diags)
+	}
+	object, diags := types.ObjectValueFrom(ctx, quotaBasedPriorityOverrideAttributes(), QuotaBasedPriorityOverrideModel{
+		UsageTiers: usageTiers,
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected quota override diagnostics: %v", diags)
+	}
+	return object
+}
+
+func quotaOverrideAPI() *tcoPolicys.PriorityOverride {
+	low := tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_LOW
+	return &tcoPolicys.PriorityOverride{
+		QuotaBased: &tcoPolicys.QuotaBased{
+			UsageTiers: []tcoPolicys.UsageTier{
+				{
+					DailyQuotaPercentage: float64Pointer(0.01),
+					Priority:             &low,
+				},
+			},
+		},
+	}
+}
+
+func assertDiagnosticContains(t *testing.T, diags diag.Diagnostics, expected string) {
+	t.Helper()
+	for _, err := range diags.Errors() {
+		if strings.Contains(err.Summary(), expected) || strings.Contains(err.Detail(), expected) {
+			return
+		}
+	}
+	t.Fatalf("expected diagnostic containing %q, got %v", expected, diags)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func float64Pointer(value float64) *float64 {
+	return &value
+}

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_traces.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_traces.go
@@ -27,20 +27,20 @@ import (
 
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 	tcoPolicys "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/policies_service"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 var (
@@ -75,6 +75,7 @@ type TCOPolicyTracesModel struct {
 	Services           types.Object `tfsdk:"services"` //TCORuleModel
 	Actions            types.Object `tfsdk:"actions"`  //TCORuleModel
 	Tags               types.Map    `tfsdk:"tags"`     //string -> TCORuleModel
+	Targets            types.List   `tfsdk:"targets"`  // []TCOPolicyTraceTargetModel
 }
 
 func (r *TCOPoliciesTracesResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -132,11 +133,11 @@ func (r *TCOPoliciesTracesResource) Schema(_ context.Context, _ resource.SchemaR
 							MarkdownDescription: "Determines weather the policy will be enabled. True by default.",
 						},
 						"priority": schema.StringAttribute{
-							Required: true,
+							Optional: true,
 							Validators: []validator.String{
 								stringvalidator.OneOf(tcoPoliciesValidPriorities...),
 							},
-							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q.", tcoPoliciesValidPriorities),
+							MarkdownDescription: fmt.Sprintf("Legacy policy-level priority. Required when `targets` is not set. Can be one of %q.", tcoPoliciesValidPriorities),
 						},
 						"order": schema.Int64Attribute{
 							Computed:            true,
@@ -264,6 +265,47 @@ func (r *TCOPoliciesTracesResource) Schema(_ context.Context, _ resource.SchemaR
 								mapvalidator.KeysAre(stringvalidator.RegexMatches(regexp.MustCompile("tags.*"), "tag names must have a 'tags.' prefix")),
 							},
 							MarkdownDescription: "The tags to apply the policy on. Applies the policy on all the tags by default.",
+						},
+						"targets": schema.ListNestedAttribute{
+							Optional: true,
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+							},
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"dataset": schema.StringAttribute{
+										Required: true,
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+										MarkdownDescription: "The dataset routed by this target.",
+									},
+									"dataspace": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+										Default:  stringdefault.StaticString(tcoPolicyDefaultDataspace),
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(tcoPolicyTargetDataspaceRegexp, "dataspace must start with a letter and contain only letters, numbers, underscores, or dots between segments"),
+										},
+										MarkdownDescription: "The dataspace routed by this target.",
+									},
+									"priority": schema.StringAttribute{
+										Required: true,
+										Validators: []validator.String{
+											stringvalidator.OneOf(tcoPoliciesValidPriorities...),
+										},
+										MarkdownDescription: fmt.Sprintf("The target priority. Can be one of %q.", tcoPoliciesValidPriorities),
+									},
+									"archive_retention_id": schema.StringAttribute{
+										Optional:    true,
+										Description: "Allowing traces routed to this target to be tagged with a specific retention.",
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+									},
+								},
+							},
+							MarkdownDescription: "Target-level routing destinations for this policy. When set, legacy top-level priority and archive_retention_id must not be set.",
 						},
 					},
 				},
@@ -457,7 +499,6 @@ func extractOverwriteTcoPoliciesTraces(ctx context.Context, plan *TCOPoliciesLis
 
 func extractTcoPolicyTraces(ctx context.Context, plan TCOPolicyTracesModel) (*tcoPolicys.CreateSpanPolicyRequest, diag.Diagnostics) {
 
-	priority := tcoPoliciesPrioritySchemaToApi[plan.Priority.ValueString()]
 	applicationRule, diags := expandTCOPolicyRule(ctx, plan.Applications)
 	if diags.HasError() {
 		return nil, diags
@@ -474,23 +515,50 @@ func extractTcoPolicyTraces(ctx context.Context, plan TCOPolicyTracesModel) (*tc
 	if diags.HasError() {
 		return nil, diags
 	}
-	archiveRetention := expandActiveRetention(plan.ArchiveRetentionID)
 	tagRules, diags := expandTagsRules(ctx, plan.Tags)
 	if diags.HasError() {
 		return nil, diags
 	}
 	enabled := !plan.Enabled.ValueBool()
 
+	policy := tcoPolicys.CreateGenericPolicyRequest{
+		Name:            plan.Name.ValueString(),
+		Description:     plan.Description.ValueString(),
+		ApplicationRule: applicationRule,
+		SubsystemRule:   subsystemRule,
+		Disabled:        &enabled,
+	}
+	targetsConfigured := !plan.Targets.IsNull() && !plan.Targets.IsUnknown()
+	legacyPriorityConfigured := !plan.Priority.IsNull() && !plan.Priority.IsUnknown()
+	if targetsConfigured {
+		if legacyPriorityConfigured || !plan.ArchiveRetentionID.IsNull() {
+			diags.AddError(
+				"TCO trace policy cannot mix targets with top-level priority or archive_retention_id",
+				"Move priority and archive retention settings into each target, or remove targets and use the legacy top-level fields.",
+			)
+			return nil, diags
+		}
+		targets, dgs := expandTCOTracePolicyTargets(ctx, plan.Targets)
+		if dgs.HasError() {
+			diags.Append(dgs...)
+			return nil, diags
+		}
+		policy.Priority = tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED
+		policy.Targets = targets
+	} else {
+		if !legacyPriorityConfigured {
+			diags.AddError(
+				"TCO trace policy must use either targets or legacy top-level priority",
+				"Set targets for target-level routing, or set the legacy top-level priority field.",
+			)
+			return nil, diags
+		}
+		policy.Priority = tcoPoliciesPrioritySchemaToApi[plan.Priority.ValueString()]
+		policy.ArchiveRetention = expandActiveRetention(plan.ArchiveRetentionID)
+	}
+
 	return &tcoPolicys.CreateSpanPolicyRequest{
-		Policy: tcoPolicys.CreateGenericPolicyRequest{
-			Name:             plan.Name.ValueString(),
-			Description:      plan.Description.ValueString(),
-			Priority:         priority,
-			ApplicationRule:  applicationRule,
-			SubsystemRule:    subsystemRule,
-			ArchiveRetention: archiveRetention,
-			Disabled:         &enabled,
-		},
+		Policy: policy,
 		SpanRules: tcoPolicys.SpanRules{
 			ServiceRule: services,
 			ActionRule:  actions,
@@ -536,7 +604,72 @@ func policiesTracesAttr() map[string]attr.Type {
 		"actions":              types.ObjectType{AttrTypes: tcoPolicyRuleAttributes()},
 		"services":             types.ObjectType{AttrTypes: tcoPolicyRuleAttributes()},
 		"tags":                 types.MapType{ElemType: types.ObjectType{AttrTypes: tcoPolicyRuleAttributes()}},
+		"targets":              types.ListType{ElemType: types.ObjectType{AttrTypes: tcoPolicyTraceTargetAttributes()}},
 	}
+}
+
+func expandTCOTracePolicyTargets(ctx context.Context, targets types.List) ([]tcoPolicys.V1Target, diag.Diagnostics) {
+	if targets.IsNull() || targets.IsUnknown() {
+		return nil, nil
+	}
+
+	var targetObjects []types.Object
+	diags := targets.ElementsAs(ctx, &targetObjects, true)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	result := make([]tcoPolicys.V1Target, 0, len(targetObjects))
+	for _, targetObject := range targetObjects {
+		var targetModel TCOPolicyTraceTargetModel
+		if dgs := targetObject.As(ctx, &targetModel, basetypes.ObjectAsOptions{}); dgs.HasError() {
+			diags.Append(dgs...)
+			continue
+		}
+		target := tcoPolicys.V1Target{
+			Dataset:          targetModel.Dataset.ValueStringPointer(),
+			Dataspace:        targetModel.Dataspace.ValueStringPointer(),
+			ArchiveRetention: expandActiveRetention(targetModel.ArchiveRetentionID),
+		}
+		if targetModel.Dataspace.IsNull() || targetModel.Dataspace.IsUnknown() {
+			dataspace := tcoPolicyDefaultDataspace
+			target.Dataspace = &dataspace
+		}
+		if !targetModel.Priority.IsNull() && !targetModel.Priority.IsUnknown() {
+			priority := tcoPoliciesPrioritySchemaToApi[targetModel.Priority.ValueString()]
+			target.Priority = &priority
+		}
+		result = append(result, target)
+	}
+	if diags.HasError() {
+		return nil, diags
+	}
+	return result, nil
+}
+
+func flattenTCOTracePolicyTargets(ctx context.Context, targets []tcoPolicys.V1Target) (types.List, diag.Diagnostics) {
+	if len(targets) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: tcoPolicyTraceTargetAttributes()}), nil
+	}
+
+	targetModels := make([]TCOPolicyTraceTargetModel, 0, len(targets))
+	for _, target := range targets {
+		priority := types.StringNull()
+		if target.Priority != nil {
+			priority = types.StringValue(tcoPoliciesPriorityApiToSchema[*target.Priority])
+		}
+		dataspace := types.StringValue(tcoPolicyDefaultDataspace)
+		if target.Dataspace != nil {
+			dataspace = types.StringValue(*target.Dataspace)
+		}
+		targetModels = append(targetModels, TCOPolicyTraceTargetModel{
+			Dataset:            types.StringPointerValue(target.Dataset),
+			Dataspace:          dataspace,
+			Priority:           priority,
+			ArchiveRetentionID: flattenArchiveRetention(target.ArchiveRetention),
+		})
+	}
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: tcoPolicyTraceTargetAttributes()}, targetModels)
 }
 
 func flattenGetTCOTracesPoliciesList(ctx context.Context, resp *tcoPolicys.GetCompanyPoliciesResponse) (TCOPoliciesListModel, diag.Diagnostics) {
@@ -584,6 +717,16 @@ func flattenTCOTracesPolicy(ctx context.Context, policy *tcoPolicys.Policy) (*TC
 	if diags.HasError() {
 		return nil, diags
 	}
+	targets, diags := flattenTCOTracePolicyTargets(ctx, spanPolicy.GetTargets())
+	if diags.HasError() {
+		return nil, diags
+	}
+	priority := types.StringValue(tcoPoliciesPriorityApiToSchema[spanPolicy.GetPriority()])
+	archiveRetentionID := flattenArchiveRetention(spanPolicy.ArchiveRetention)
+	if len(spanPolicy.GetTargets()) > 0 {
+		priority = types.StringNull()
+		archiveRetentionID = types.StringNull()
+	}
 
 	return &TCOPolicyTracesModel{
 		ID:                 types.StringValue(spanPolicy.GetId()),
@@ -591,13 +734,14 @@ func flattenTCOTracesPolicy(ctx context.Context, policy *tcoPolicys.Policy) (*TC
 		Description:        types.StringValue(spanPolicy.GetDescription()),
 		Enabled:            types.BoolValue(spanPolicy.GetEnabled()),
 		Order:              types.Int64Value(int64(spanPolicy.GetOrder())),
-		Priority:           types.StringValue(tcoPoliciesPriorityApiToSchema[spanPolicy.GetPriority()]),
+		Priority:           priority,
 		Applications:       applications,
 		Subsystems:         subsystems,
-		ArchiveRetentionID: flattenArchiveRetention(spanPolicy.ArchiveRetention),
+		ArchiveRetentionID: archiveRetentionID,
 		Services:           services,
 		Actions:            actions,
 		Tags:               flattenTCOPolicyTags(ctx, traceRules.TagRules),
+		Targets:            targets,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- add `targets` support to log and trace TCO policy resources
- preserve legacy top-level priority/archive retention behavior and reject mixed target/legacy policy configs
- flatten backend target policies back into Terraform state and regenerate TCO docs

## Testing
- `go test ./internal/provider/dataplans ./internal/provider`
- `go test ./...`
- local provider `terraform plan -refresh=false` with `CORALOGIX_API_KEY=$ECO_API_KEY` and `CORALOGIX_ENV=EU2` for target-based log and trace policies

## Notes
- The local eu2 check used plan-only validation to avoid applying atomic TCO policy overwrite resources against a real account.
