### PR TITLE
docs(tco_policies_logs): document priority as the quota-based fallback

### DIFF
--- a/docs/data-sources/tco_policies_logs.md
+++ b/docs/data-sources/tco_policies_logs.md
@@ -39,8 +39,8 @@ Read-Only:
 - `id` (String) tco-policy ID.
 - `name` (String) tco-policy name.
 - `order` (Number) The policy's order between the other policies.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"].
-- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
+- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
+- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
 

--- a/docs/resources/tco_policies_logs.md
+++ b/docs/resources/tco_policies_logs.md
@@ -97,8 +97,12 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
     {
       name        = "Example tco_policy with quota-based override"
       description = "Drop priority as daily quota is consumed"
-      priority    = "high"
-      severities  = ["info", "warning"]
+      # priority is the "Route the remaining quota to" fallback, applied once all
+      # usage_tiers are exhausted. It must be more restrictive than the last tier
+      # (most to least restrictive: block, low, medium, high); the last tier here
+      # is "low", so the fallback is "block".
+      priority   = "block"
+      severities = ["info", "warning"]
       quota_based_priority_override = {
         usage_tiers = [
           { daily_quota_percentage = 50, priority = "medium" },

--- a/docs/resources/tco_policies_logs.md
+++ b/docs/resources/tco_policies_logs.md
@@ -127,7 +127,7 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
 Required:
 
 - `name` (String) tco-policy name.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"].
+- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
 
 Optional:
 
@@ -136,7 +136,7 @@ Optional:
 - `description` (String) The policy description
 - `dpxl_expression` (String) DataPrime expression to match logs for this policy. Mutually exclusive with `severities` — set exactly one. The expression must include a version prefix, e.g. `<v1> $d.severity == 'INFO'`.
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
-- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
+- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
 

--- a/examples/resources/coralogix_tco_policies_logs/resource.tf
+++ b/examples/resources/coralogix_tco_policies_logs/resource.tf
@@ -82,8 +82,12 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
     {
       name        = "Example tco_policy with quota-based override"
       description = "Drop priority as daily quota is consumed"
-      priority    = "high"
-      severities  = ["info", "warning"]
+      # priority is the "Route the remaining quota to" fallback, applied once all
+      # usage_tiers are exhausted. It must be more restrictive than the last tier
+      # (most to least restrictive: block, low, medium, high); the last tier here
+      # is "low", so the fallback is "block".
+      priority   = "block"
+      severities = ["info", "warning"]
       quota_based_priority_override = {
         usage_tiers = [
           { daily_quota_percentage = 50, priority = "medium" },

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -185,7 +185,7 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 							Validators: []validator.String{
 								stringvalidator.OneOf(tcoPoliciesValidPriorities...),
 							},
-							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q.", tcoPoliciesValidPriorities),
+							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of \"Route the remaining quota to\" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).", tcoPoliciesValidPriorities),
 						},
 						"order": schema.Int64Attribute{
 							Computed:            true,
@@ -292,7 +292,7 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 									MarkdownDescription: "Ordered list of quota-consumption tiers; the policy's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached.",
 								},
 							},
-							MarkdownDescription: "Dynamically reassign the policy's priority based on daily quota consumption tiers.",
+							MarkdownDescription: "Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback (\"Route the remaining quota to\" in the UI), which must be more restrictive than the last tier.",
 						},
 					},
 				},


### PR DESCRIPTION
## What
Documents that, for a quota-based TCO log policy (when `quota_based_priority_override` is set), the policy's top-level **`priority`** is the **"Route the remaining quota to"** fallback — the priority applied once all `usage_tiers` are exhausted — and that it must be more restrictive than the last tier (most→least restrictive: `block`, `low`, `medium`, `high`).

## Why
Users had no way to know how to set the UI's "Route the remaining quota to" value in Terraform; the attribute that controls it (`priority`) was documented only generically, and the quota fallback mapping was undocumented. This led to a support ticket where a user added a non-existent setting and set `priority` equal to the last tier, hitting the "fallback must be more restrictive than the last tier" error.

## How
Schema-only change: updated the `MarkdownDescription` for `priority` and `quota_based_priority_override` in `resource_coralogix_tco_policies_logs.go`. Docs regenerated via `make generate` (tfplugindocs) — `docs/resources/tco_policies_logs.md` and `docs/data-sources/tco_policies_logs.md`. No behavior change.

Refs CDS-3036

🤖 Generated with [Claude Code](https://claude.com/claude-code)