### PR TITLE
ci: auto-close resolved issue when a marked fix PR merges

### DIFF
--- a/.github/workflows/link-issue-on-merge.yml
+++ b/.github/workflows/link-issue-on-merge.yml
@@ -1,0 +1,39 @@
+name: link-issue-on-merge
+
+# When a fix PR carrying a `<!-- cx-resolves-issue: N -->` marker merges, close the
+# referenced issue with a "Resolved by <pr>" comment. The marker (a bare number in an
+# HTML comment) is injected by the triage automation at PR-open and never autolinks, so
+# the issue stays clean during the PR's life and is closed only here, at merge. PRs
+# without the marker (human PRs, non-GitHub-sourced fixes) are a no-op.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  link:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const m = (pr.body || "").match(/<!--\s*cx-resolves-issue:\s*(\d+)\s*-->/);
+            if (!m) { core.info("no cx-resolves-issue marker; nothing to do"); return; }
+            const issue_number = Number(m[1]);
+            if (issue_number === pr.number) { core.info("marker points at the PR itself; skipping"); return; }
+            let issue;
+            try {
+              issue = (await github.rest.issues.get({ ...context.repo, issue_number })).data;
+            } catch {
+              core.info(`#${issue_number} not found in this repo; skipping`); return;
+            }
+            if (issue.pull_request) { core.info(`#${issue_number} is a PR, not an issue; skipping`); return; }
+            if (issue.state === "closed") { core.info(`#${issue_number} already closed; skipping`); return; }
+            await github.rest.issues.createComment({ ...context.repo, issue_number, body: `Resolved by ${pr.html_url}` });
+            await github.rest.issues.update({ ...context.repo, issue_number, state: "closed", state_reason: "completed" });
+            core.info(`commented + closed #${issue_number}`);

--- a/.github/workflows/link-issue-on-merge.yml
+++ b/.github/workflows/link-issue-on-merge.yml
@@ -7,7 +7,7 @@ name: link-issue-on-merge
 # without the marker (human PRs, non-GitHub-sourced fixes) are a no-op.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:

--- a/.github/workflows/link-issue-on-merge.yml
+++ b/.github/workflows/link-issue-on-merge.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
+            if (pr.user.login !== 'cx-ryu[bot]') { core.info(`PR not authored by the triage bot (${pr.user.login}); skipping`); return; }
             const m = (pr.body || "").match(/<!--\s*cx-resolves-issue:\s*(\d+)\s*-->/);
             if (!m) { core.info("no cx-resolves-issue marker; nothing to do"); return; }
             const issue_number = Number(m[1]);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Unreleased
 
-#### ci
-
-- FEAT: Add `link-issue-on-merge` workflow — when a fix PR carrying a `cx-resolves-issue` marker merges, the referenced issue is auto-closed with a "Resolved by <pr>" comment. No-op for PRs without the marker.
-
 #### resource/coralogix_dashboard
 
 - FIX: Every `*.query.logs.filters[*]` block (across all widget types — `data_table`, `line_chart`, `bar_chart`, `pie_chart`, `gauge`, `hexagon`, `horizontal_bar_chart`) and the top-level `filters[*].source.logs` block now accept `observation_field` as the sole filter target. `field` is `Optional` (was `Required`), and a `stringvalidator.ExactlyOneOf` on `field` keeps the field-vs-observation_field misconfiguration explicit. Configs copied from a `data "coralogix_dashboard"` whose backend filter used `observation_field` no longer fail validation with `Missing Configuration for Required Attribute`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+#### ci
+
+- FEAT: Add `link-issue-on-merge` workflow — when a fix PR carrying a `cx-resolves-issue` marker merges, the referenced issue is auto-closed with a "Resolved by <pr>" comment. No-op for PRs without the marker.
+
 #### resource/coralogix_dashboard
 
 - FIX: Every `*.query.logs.filters[*]` block (across all widget types — `data_table`, `line_chart`, `bar_chart`, `pie_chart`, `gauge`, `hexagon`, `horizontal_bar_chart`) and the top-level `filters[*].source.logs` block now accept `observation_field` as the sole filter target. `field` is `Optional` (was `Required`), and a `stringvalidator.ExactlyOneOf` on `field` keeps the field-vs-observation_field misconfiguration explicit. Configs copied from a `data "coralogix_dashboard"` whose backend filter used `observation_field` no longer fail validation with `Missing Configuration for Required Attribute`.


### PR DESCRIPTION
Adds the merge-time half of the triage automation's "link issue at merge" design.

## What
A `link-issue-on-merge` workflow: when a PR merges, if its body carries a hidden marker `<!-- cx-resolves-issue: N -->` (injected by the triage automation at PR-open), it comments `Resolved by <pr>` on issue `N` and closes it.

## Why a hidden marker (not `Fixes #N`)
Fix PRs deliberately keep the issue *unlinked* during their life — a `#N` in the body/commits would cross-reference the issue and drag it through the PR's review/redesign/force-push churn. The marker is a **bare number in an HTML comment**, so it never autolinks; the issue is touched only here, at merge.

## Guards (no-op unless it's clearly right)
- No marker → skip (human PRs, non-GitHub-sourced fixes).
- Marker points at the PR's own number → skip.
- `N` isn't a real **open issue** in this repo (404 / it's a PR / already closed) → skip.

Pairs with the marker injection on the Ryu side (done in code at PR-open, so it can't be missed).