### PR TITLE
Limit AI Evaluation Target to prompt and response

### DIFF
--- a/docs/resources/ai_evaluation.md
+++ b/docs/resources/ai_evaluation.md
@@ -257,7 +257,7 @@ resource "coralogix_ai_evaluation" "example" {
 
 - `application` (String) Name of the AI application this evaluation belongs to.
 - `config` (Attributes) AI evaluation configuration. (see [below for nested schema](#nestedatt--config))
-- `target` (String) Target span content the evaluation runs against. Can be one of ["conversation" "prompt" "response"].
+- `target` (String) Target span content the evaluation runs against. Can be one of ["prompt" "response"].
 - `threshold` (Number) Score threshold. Must be between 0.0 and 1.0 inclusive.
 
 ### Optional

--- a/internal/provider/ai/resource_coralogix_ai_evaluation.go
+++ b/internal/provider/ai/resource_coralogix_ai_evaluation.go
@@ -47,9 +47,8 @@ var (
 	_ resource.ResourceWithImportState      = &AIEvaluationResource{}
 
 	aiEvaluationTargetSchemaToAPI = map[string]aievaluations.EvaluationTarget{
-		"prompt":       aievaluations.EVALUATIONTARGET_PROMPT,
-		"response":     aievaluations.EVALUATIONTARGET_RESPONSE,
-		"conversation": aievaluations.EVALUATIONTARGET_CONVERSATION,
+		"prompt":   aievaluations.EVALUATIONTARGET_PROMPT,
+		"response": aievaluations.EVALUATIONTARGET_RESPONSE,
 	}
 	aiEvaluationTargetAPIToSchema = utils.ReverseMap(aiEvaluationTargetSchemaToAPI)
 	aiEvaluationValidTargets      = utils.GetKeys(aiEvaluationTargetSchemaToAPI)

--- a/internal/provider/resource_coralogix_ai_evaluation_test.go
+++ b/internal/provider/resource_coralogix_ai_evaluation_test.go
@@ -294,7 +294,7 @@ func testAccFirstAIApplication(t *testing.T, evaluationType aievaluations.Evalua
 	}
 
 	if len(targetCandidates) == 0 {
-		targetCandidates = []string{"response", "conversation", "prompt"}
+		targetCandidates = []string{"response", "prompt"}
 	}
 
 	for _, application := range aiEvaluationApplicationsCache {

--- a/internal/provider/resource_coralogix_group_test.go
+++ b/internal/provider/resource_coralogix_group_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 
@@ -31,8 +30,7 @@ import (
 var groupResourceName = "coralogix_group.test"
 
 func TestAccCoralogixResourceGroup(t *testing.T) {
-	// Use a unique username to avoid 409 Conflict (user already exists) when re-running or from other tests
-	userName := fmt.Sprintf("test-group-acc-%d@coralogix.com", time.Now().UnixNano())
+	userName := randUserName()
 	displayName := acctest.RandomWithPrefix("tf-acc-test-group")
 	scopeName := acctest.RandomWithPrefix("tf-acc-test-scope")
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_coralogix_user_test.go
+++ b/internal/provider/resource_coralogix_user_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -74,7 +75,7 @@ func testAccCheckUserDestroy(s *terraform.State) error {
 }
 
 func randUserName() string {
-	return "test@coralogix.com"
+	return fmt.Sprintf("%s@coralogix.com", acctest.RandomWithPrefix("tf-acc-user"))
 }
 
 func testAccCoralogixResourceUser(userName string) string {


### PR DESCRIPTION
### Description

Limit `coralogix_ai_evaluation.target` to `prompt` and `response` for now. The UI currently handles `conversation` by sending two create requests, one for `prompt` and one for `response`; backend support is expected to change so `conversation` can be sent and managed as a single evaluation. Until then, the Terraform resource is limited to the two currently supported target types.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceAIEvaluation'

=== RUN   TestAccCoralogixResourceAIEvaluation/competition
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_completeness
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_context_adherence
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_context_relevance
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_correctness
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_task_adherence
=== RUN   TestAccCoralogixResourceAIEvaluation/language_mismatch
=== RUN   TestAccCoralogixResourceAIEvaluation/pii
=== RUN   TestAccCoralogixResourceAIEvaluation/prompt_injection
=== RUN   TestAccCoralogixResourceAIEvaluation/restricted_topics
=== RUN   TestAccCoralogixResourceAIEvaluation/sexism
=== RUN   TestAccCoralogixResourceAIEvaluation/sql_allowed_tables
=== RUN   TestAccCoralogixResourceAIEvaluation/sql_hallucination
=== RUN   TestAccCoralogixResourceAIEvaluation/sql_read_only
=== RUN   TestAccCoralogixResourceAIEvaluation/sql_restricted_tables
=== RUN   TestAccCoralogixResourceAIEvaluation/toxicity
--- PASS: TestAccCoralogixResourceAIEvaluation (82.75s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/allowed_topics (5.06s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/competition (5.02s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_completeness (4.98s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_context_adherence (4.86s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_context_relevance (4.83s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_correctness (4.86s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_task_adherence (4.80s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/language_mismatch (4.80s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/pii (4.81s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/prompt_injection (4.87s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/restricted_topics (4.82s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sexism (4.83s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sql_allowed_tables (4.82s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sql_hallucination (4.80s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sql_read_only (4.87s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sql_restricted_tables (4.84s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/toxicity (4.89s)
PASS
```