### PR TITLE
Restrict AI Evaluation Schema to match proto

### DIFF
--- a/internal/provider/ai/resource_coralogix_ai_custom_evaluation.go
+++ b/internal/provider/ai/resource_coralogix_ai_custom_evaluation.go
@@ -29,6 +29,7 @@ import (
 	aiapplications "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/ai_applications_service"
 	aievaluations "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/ai_evaluations_service"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -188,21 +189,24 @@ func (r *AICustomEvaluationResource) Schema(_ context.Context, _ resource.Schema
 				Optional: true,
 				Computed: true,
 				Default:  setdefault.StaticValue(aiCustomEvaluationApplicationsDefaultValue()),
+				Validators: []validator.Set{
+					setvalidator.SizeAtMost(1024),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"application": schema.StringAttribute{
 							Required: true,
 							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
+								stringvalidator.LengthBetween(1, 256),
 							},
 							MarkdownDescription: "AI application name.",
 						},
 						"subsystem": schema.StringAttribute{
 							Required: true,
 							Validators: []validator.String{
-								stringvalidator.LengthBetween(0, 256),
+								stringvalidator.LengthBetween(1, 256),
 							},
-							MarkdownDescription: "AI application subsystem. Use an empty string only for applications without a subsystem.",
+							MarkdownDescription: "AI application subsystem.",
 						},
 					},
 				},
@@ -554,6 +558,13 @@ func extractAICustomEvaluationCriteria(ctx context.Context, model *AICustomEvalu
 	prohibitedFlags, prohibitedExamples, prohibitedDiags := extractAICustomEvaluationCriterion(ctx, prohibited)
 	diags.Append(prohibitedDiags...)
 	if diags.HasError() {
+		return nil, "", "", diags
+	}
+	if len(acceptableExamples)+len(prohibitedExamples) > 100 {
+		diags.AddError(
+			"Too many AI custom evaluation examples",
+			"Custom evaluation criteria can include at most 100 total examples across acceptable and prohibited criteria.",
+		)
 		return nil, "", "", diags
 	}
 

--- a/internal/provider/ai/resource_coralogix_ai_evaluation.go
+++ b/internal/provider/ai/resource_coralogix_ai_evaluation.go
@@ -185,7 +185,7 @@ func (r *AIEvaluationResource) Schema(_ context.Context, _ resource.SchemaReques
 			"application": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
+					stringvalidator.LengthBetween(1, 256),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -193,9 +193,9 @@ func (r *AIEvaluationResource) Schema(_ context.Context, _ resource.SchemaReques
 				MarkdownDescription: "Name of the AI application this evaluation belongs to.",
 			},
 			"subsystem": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
+					stringvalidator.LengthBetween(1, 256),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -478,7 +478,8 @@ func aiEvaluationStringSetAttribute(markdownDescription string) schema.SetAttrib
 		Required:    true,
 		Validators: []validator.Set{
 			setvalidator.SizeAtLeast(1),
-			setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+			setvalidator.SizeAtMost(1024),
+			setvalidator.ValueStringsAre(stringvalidator.LengthBetween(1, 256)),
 		},
 		MarkdownDescription: markdownDescription,
 	}
@@ -493,6 +494,7 @@ func aiEvaluationPIIConfigAttribute() schema.SingleNestedAttribute {
 				Required:    true,
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),
+					setvalidator.SizeAtMost(1024),
 					setvalidator.ValueStringsAre(stringvalidator.OneOf(aiEvaluationValidPIICategories...)),
 				},
 				MarkdownDescription: fmt.Sprintf("PII categories to detect. Can include %q.", aiEvaluationValidPIICategories),
@@ -584,13 +586,11 @@ func extractCreateAIEvaluation(ctx context.Context, plan AIEvaluationResourceMod
 
 	rq := &aievaluations.AiEvaluationsServiceCreateAiEvaluationRequest{
 		Application: aievaluations.PtrString(plan.Application.ValueString()),
+		Subsystem:   aievaluations.PtrString(plan.Subsystem.ValueString()),
 		Target:      target.Ptr(),
 		Threshold:   aievaluations.PtrFloat64(plan.Threshold.ValueFloat64()),
 		IsEnabled:   aievaluations.PtrBool(plan.IsEnabled.ValueBool()),
 		Config:      config,
-	}
-	if !plan.Subsystem.IsNull() {
-		rq.Subsystem = aievaluations.PtrString(plan.Subsystem.ValueString())
 	}
 
 	return rq, diags


### PR DESCRIPTION
### Description

- Require subsystem for coralogix_ai_evaluation and always send it in create requests.
- Align AI evaluation validators with API bounds for application/subsystem names and repeated config fields.
- Tighten AI custom evaluation application selector and example count validation.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceAIEvaluation'
go test ./internal/provider -run TestAccCoralogixResourceAIEvaluation -v -timeout 120m -count=1
=== RUN   TestAccCoralogixResourceAIEvaluation
=== RUN   TestAccCoralogixResourceAIEvaluation/allowed_topics
=== RUN   TestAccCoralogixResourceAIEvaluation/competition
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_completeness
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_context_adherence
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_context_relevance
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_correctness
=== RUN   TestAccCoralogixResourceAIEvaluation/hallucination_task_adherence
=== RUN   TestAccCoralogixResourceAIEvaluation/language_mismatch
=== RUN   TestAccCoralogixResourceAIEvaluation/pii
=== RUN   TestAccCoralogixResourceAIEvaluation/prompt_injection
=== RUN   TestAccCoralogixResourceAIEvaluation/restricted_topics
=== RUN   TestAccCoralogixResourceAIEvaluation/sexism
=== RUN   TestAccCoralogixResourceAIEvaluation/sql_allowed_tables
=== RUN   TestAccCoralogixResourceAIEvaluation/sql_hallucination
=== RUN   TestAccCoralogixResourceAIEvaluation/sql_read_only
=== RUN   TestAccCoralogixResourceAIEvaluation/sql_restricted_tables
=== RUN   TestAccCoralogixResourceAIEvaluation/toxicity
--- PASS: TestAccCoralogixResourceAIEvaluation (34.04s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/allowed_topics (2.45s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/competition (2.02s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_completeness (1.94s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_context_adherence (1.97s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_context_relevance (1.97s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_correctness (2.01s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/hallucination_task_adherence (1.99s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/language_mismatch (2.01s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/pii (1.99s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/prompt_injection (1.94s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/restricted_topics (1.99s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sexism (1.95s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sql_allowed_tables (1.98s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sql_hallucination (1.93s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sql_read_only (1.93s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/sql_restricted_tables (1.98s)
    --- PASS: TestAccCoralogixResourceAIEvaluation/toxicity (1.98s)
PASS
...
```