### PR TITLE
Fix alert custom evaluation delay unset handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### resource/coralogix_alert
 
 - FIX: The `priority` deprecation warning is now type-aware — emitted only for the alert types that embed an `override` block, and suppressed for the types where top-level `priority` is the only mechanism and is therefore not deprecated.
+- FIX: Preserve omitted `custom_evaluation_delay` as unset instead of defaulting it to `0`; existing omitted configurations previously stored as `0` will plan an update to unset the field on the next apply.
 
 #### resource/coralogix_ai_evaluation
 

--- a/docs/data-sources/alert.md
+++ b/docs/data-sources/alert.md
@@ -238,7 +238,7 @@ Read-Only:
 
 Read-Only:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `logs_filter` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_anomaly--logs_filter))
 - `notification_payload_filter` (Set of String)
 - `percentage_of_deviation` (Number) The percentage of deviation from the baseline for triggering the alert.
@@ -439,7 +439,7 @@ Read-Only:
 
 Read-Only:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `denominator` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_ratio_threshold--denominator))
 - `denominator_alias` (String)
 - `group_by_for` (String) Group by for. Valid values: ["Both" "Denominator Only" "Numerator Only"]. 'Both' by default.
@@ -572,7 +572,7 @@ Read-Only:
 
 Read-Only:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `logs_filter` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_threshold--logs_filter))
 - `no_data_policy` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_threshold--no_data_policy))
 - `notification_payload_filter` (Set of String)
@@ -675,7 +675,7 @@ Read-Only:
 
 Read-Only:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `ignore_infinity` (Boolean) Whether to ignore infinite ratios when the denominator is zero. False by default.
 - `logs_filter` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_time_relative_threshold--logs_filter))
 - `notification_payload_filter` (Set of String)
@@ -843,7 +843,7 @@ Read-Only:
 
 Read-Only:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `metric_filter` (Attributes) (see [below for nested schema](#nestedatt--type_definition--metric_anomaly--metric_filter))
 - `percentage_of_deviation` (Number) The percentage of deviation from the baseline for triggering the alert.
 - `rules` (Attributes Set) (see [below for nested schema](#nestedatt--type_definition--metric_anomaly--rules))
@@ -882,7 +882,7 @@ Read-Only:
 
 Read-Only:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `metric_filter` (Attributes) (see [below for nested schema](#nestedatt--type_definition--metric_threshold--metric_filter))
 - `missing_values` (Attributes) (see [below for nested schema](#nestedatt--type_definition--metric_threshold--missing_values))
 - `no_data_policy` (Attributes) (see [below for nested schema](#nestedatt--type_definition--metric_threshold--no_data_policy))

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -807,7 +807,7 @@ Required:
 
 Optional:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `logs_filter` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_anomaly--logs_filter))
 - `notification_payload_filter` (Set of String)
 - `percentage_of_deviation` (Number) The percentage of deviation from the baseline for triggering the alert.
@@ -1037,7 +1037,7 @@ Required:
 
 Optional:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `denominator` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_ratio_threshold--denominator))
 - `group_by_for` (String) Group by for. Valid values: ["Both" "Denominator Only" "Numerator Only"]. 'Both' by default.
 - `ignore_infinity` (Boolean) Whether to ignore infinite ratios when the denominator is zero. False by default.
@@ -1183,7 +1183,7 @@ Required:
 
 Optional:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `logs_filter` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_threshold--logs_filter))
 - `no_data_policy` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_threshold--no_data_policy))
 - `notification_payload_filter` (Set of String)
@@ -1295,7 +1295,7 @@ Required:
 
 Optional:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `ignore_infinity` (Boolean) Whether to ignore infinite ratios when the denominator is zero. False by default.
 - `logs_filter` (Attributes) (see [below for nested schema](#nestedatt--type_definition--logs_time_relative_threshold--logs_filter))
 - `notification_payload_filter` (Set of String)
@@ -1482,7 +1482,7 @@ Required:
 
 Optional:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `percentage_of_deviation` (Number) The percentage of deviation from the baseline for triggering the alert.
 
 <a id="nestedatt--type_definition--metric_anomaly--metric_filter"></a>
@@ -1525,7 +1525,7 @@ Required:
 
 Optional:
 
-- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. Defaults to 0.
+- `custom_evaluation_delay` (Number) Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.
 - `no_data_policy` (Attributes) (see [below for nested schema](#nestedatt--type_definition--metric_threshold--no_data_policy))
 - `undetected_values_management` (Attributes) (see [below for nested schema](#nestedatt--type_definition--metric_threshold--undetected_values_management))
 

--- a/internal/provider/alerts/alert_schema/common.go
+++ b/internal/provider/alerts/alert_schema/common.go
@@ -31,7 +31,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -281,12 +280,10 @@ func (c ComputedForSomeAlerts) PlanModifyList(ctx context.Context, request planm
 func evaluationDelaySchema() schema.Attribute {
 	return schema.Int32Attribute{
 		Optional: true,
-		Computed: true,
-		Default:  int32default.StaticInt32(0),
 		Validators: []validator.Int32{
 			int32validator.AtLeast(0),
 		},
-		MarkdownDescription: "Delay evaluation of the rules by n milliseconds. Defaults to 0.",
+		MarkdownDescription: "Delay evaluation of the rules by n milliseconds. When omitted, the provider does not send a custom evaluation delay.",
 	}
 }
 

--- a/internal/provider/alerts/alert_schema/common_test.go
+++ b/internal/provider/alerts/alert_schema/common_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alertschema
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+func TestEvaluationDelaySchemaModelsOptionalOverride(t *testing.T) {
+	attr, ok := evaluationDelaySchema().(schema.Int32Attribute)
+	if !ok {
+		t.Fatalf("evaluationDelaySchema() returned %T, want schema.Int32Attribute", evaluationDelaySchema())
+	}
+
+	if !attr.Optional {
+		t.Fatal("custom_evaluation_delay must remain optional")
+	}
+	if attr.Computed {
+		t.Fatal("custom_evaluation_delay must not be computed; omitted config should remain unset")
+	}
+	if attr.Default != nil {
+		t.Fatal("custom_evaluation_delay must not default to 0; omitted config should be sent as nil")
+	}
+	if len(attr.PlanModifiers) != 0 {
+		t.Fatalf("custom_evaluation_delay must not preserve prior state; got %d plan modifier(s)", len(attr.PlanModifiers))
+	}
+}

--- a/internal/provider/alerts/resource_coralogix_alert.go
+++ b/internal/provider/alerts/resource_coralogix_alert.go
@@ -283,6 +283,14 @@ func extractAlertProperties(ctx context.Context, plan *alerttypes.AlertResourceM
 	return alertProperties, nil
 }
 
+func extractCustomEvaluationDelay(delay types.Int32) *int32 {
+	if delay.IsNull() || delay.IsUnknown() {
+		return nil
+	}
+
+	return delay.ValueInt32Pointer()
+}
+
 func extractIncidentsSettings(ctx context.Context, incidentsSettingsObject types.Object) (*alerts.AlertDefIncidentSettings, diag.Diagnostics) {
 	if incidentsSettingsObject.IsNull() || incidentsSettingsObject.IsUnknown() {
 		return nil, nil
@@ -1027,7 +1035,7 @@ func expandLogsThresholdTypeDefinition(ctx context.Context, properties *alerts.A
 		NotificationPayloadFilter:  notificationPayloadFilter,
 		UndetectedValuesManagement: undetected,
 		NoDataPolicy:               noDataPolicy,
-		EvaluationDelayMs:          thresholdModel.CustomEvaluationDelay.ValueInt32Pointer(),
+		EvaluationDelayMs:          extractCustomEvaluationDelay(thresholdModel.CustomEvaluationDelay),
 	}
 
 	properties.AlertDefPropertiesLogsThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_THRESHOLD.Ptr()
@@ -1218,7 +1226,7 @@ func expandLogsAnomalyAlertTypeDefinition(ctx context.Context, properties *alert
 		LogsFilter:                logsFilter,
 		Rules:                     rules,
 		NotificationPayloadFilter: notificationPayloadFilter,
-		EvaluationDelayMs:         anomalyModel.CustomEvaluationDelay.ValueInt32Pointer(),
+		EvaluationDelayMs:         extractCustomEvaluationDelay(anomalyModel.CustomEvaluationDelay),
 		AnomalyAlertSettings:      anomalyAlertSettings,
 	}
 
@@ -1344,7 +1352,7 @@ func expandLogsRatioThresholdTypeDefinition(ctx context.Context, properties *ale
 		Rules:                     rules,
 		NotificationPayloadFilter: notificationPayloadFilter,
 		GroupByFor:                alerttypes.LogsRatioGroupByForSchemaToProtoMap[groupByFor].Ptr(),
-		EvaluationDelayMs:         ratioThresholdModel.CustomEvaluationDelay.ValueInt32Pointer(),
+		EvaluationDelayMs:         extractCustomEvaluationDelay(ratioThresholdModel.CustomEvaluationDelay),
 		IgnoreInfinity:            ratioThresholdModel.IgnoreInfinity.ValueBoolPointer(),
 	}
 	properties.AlertDefPropertiesLogsRatioThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_RATIO_THRESHOLD.Ptr()
@@ -1731,7 +1739,7 @@ func expandLogsTimeRelativeThresholdAlertTypeDefinition(ctx context.Context, pro
 		Rules:                      rules,
 		NotificationPayloadFilter:  notificationPayloadFilter,
 		UndetectedValuesManagement: undetected,
-		EvaluationDelayMs:          relativeThresholdModel.CustomEvaluationDelay.ValueInt32Pointer(),
+		EvaluationDelayMs:          extractCustomEvaluationDelay(relativeThresholdModel.CustomEvaluationDelay),
 		IgnoreInfinity:             relativeThresholdModel.IgnoreInfinity.ValueBoolPointer(),
 	}
 	properties.AlertDefPropertiesLogsTimeRelativeThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_TIME_RELATIVE_THRESHOLD.Ptr()
@@ -1857,7 +1865,7 @@ func expandMetricThresholdAlertTypeDefinition(ctx context.Context, properties *a
 		MissingValues:              missingValues,
 		UndetectedValuesManagement: undetected,
 		NoDataPolicy:               noDataPolicy,
-		EvaluationDelayMs:          metricThresholdModel.CustomEvaluationDelay.ValueInt32Pointer(),
+		EvaluationDelayMs:          extractCustomEvaluationDelay(metricThresholdModel.CustomEvaluationDelay),
 	}
 	properties.AlertDefPropertiesMetricThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_THRESHOLD.Ptr()
 
@@ -2323,7 +2331,7 @@ func expandMetricAnomalyAlertTypeDefinition(ctx context.Context, properties *ale
 	properties.AlertDefPropertiesMetricAnomaly.MetricAnomaly = alerts.MetricAnomalyType{
 		MetricFilter:         metricFilter,
 		Rules:                rules,
-		EvaluationDelayMs:    metricAnomalyModel.CustomEvaluationDelay.ValueInt32Pointer(),
+		EvaluationDelayMs:    extractCustomEvaluationDelay(metricAnomalyModel.CustomEvaluationDelay),
 		AnomalyAlertSettings: anomalyAlertSettings,
 	}
 	properties.AlertDefPropertiesMetricAnomaly.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_ANOMALY.Ptr()

--- a/internal/provider/alerts/resource_coralogix_alert_test.go
+++ b/internal/provider/alerts/resource_coralogix_alert_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	alerttypes "github.com/coralogix/terraform-provider-coralogix/internal/provider/alerts/alert_types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	alerts "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/alert_definitions_service"
@@ -92,4 +93,56 @@ func TestFlattenTracingSimpleFilter_InvalidLatency(t *testing.T) {
 	if !found {
 		t.Errorf("expected diagnostic summary 'Invalid Latency Threshold Ms', got: %v", diags.Errors())
 	}
+}
+
+func TestExtractCustomEvaluationDelay(t *testing.T) {
+	cases := []struct {
+		name string
+		in   types.Int32
+		want *int32
+	}{
+		{
+			name: "null is omitted",
+			in:   types.Int32Null(),
+			want: nil,
+		},
+		{
+			name: "unknown is omitted",
+			in:   types.Int32Unknown(),
+			want: nil,
+		},
+		{
+			name: "explicit zero is preserved",
+			in:   types.Int32Value(0),
+			want: int32Ptr(0),
+		},
+		{
+			name: "explicit non-zero is preserved",
+			in:   types.Int32Value(60),
+			want: int32Ptr(60),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractCustomEvaluationDelay(tc.in)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("extractCustomEvaluationDelay() = %v, want nil", *got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("extractCustomEvaluationDelay() = nil, want %v", *tc.want)
+			}
+			if *got != *tc.want {
+				t.Fatalf("extractCustomEvaluationDelay() = %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
 }

--- a/internal/provider/resource_coralogix_alert_test.go
+++ b/internal/provider/resource_coralogix_alert_test.go
@@ -17,7 +17,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/google/uuid"
@@ -27,6 +30,10 @@ import (
 )
 
 var alertResourceName = "coralogix_alert.test"
+
+const (
+	alertCustomEvaluationDelayExplicitZeroMs int32 = 0
+)
 
 func TestAccCoralogixResourceAlert_logs_immediate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -305,6 +312,28 @@ func TestAccCoralogixResourceAlert_logs_less_than(t *testing.T) {
 	},
 	)
 
+}
+
+func TestAccCoralogixResourceAlert_custom_evaluation_delay_omitted_and_explicit(t *testing.T) {
+	name := uuid.NewString()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAlertDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceAlertCustomEvaluationDelayOmittedAndExplicit(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAlertCustomEvaluationDelayUnset("coralogix_alert.more_than_omitted"),
+					resource.TestCheckNoResourceAttr("coralogix_alert.more_than_omitted", "type_definition.logs_threshold.custom_evaluation_delay"),
+					testAccCheckAlertCustomEvaluationDelayUnset("coralogix_alert.less_than_omitted"),
+					resource.TestCheckNoResourceAttr("coralogix_alert.less_than_omitted", "type_definition.logs_threshold.custom_evaluation_delay"),
+					testAccCheckAlertCustomEvaluationDelay("coralogix_alert.explicit_zero", alertCustomEvaluationDelayExplicitZeroMs),
+					resource.TestCheckResourceAttr("coralogix_alert.explicit_zero", "type_definition.logs_threshold.custom_evaluation_delay", fmt.Sprint(alertCustomEvaluationDelayExplicitZeroMs)),
+				),
+			},
+		},
+	})
 }
 
 func TestAccCoralogixResourceAlert_logs_less_than_with_routing(t *testing.T) {
@@ -1506,6 +1535,94 @@ func testAccCheckAlertDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckAlertCustomEvaluationDelay(resourceName string, expected int32) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		delay, ok, err := testAccGetAlertCustomEvaluationDelay(s, resourceName)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("alert %q evaluation delay is unset, want %d", resourceName, expected)
+		}
+		if delay != expected {
+			return fmt.Errorf("alert %q evaluation delay = %d, want %d", resourceName, delay, expected)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAlertCustomEvaluationDelayUnset(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		delay, ok, err := testAccGetAlertCustomEvaluationDelay(s, resourceName)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return fmt.Errorf("alert %q evaluation delay = %d, want unset", resourceName, delay)
+		}
+
+		return nil
+	}
+}
+
+func testAccGetAlertCustomEvaluationDelay(s *terraform.State, resourceName string) (int32, bool, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return 0, false, fmt.Errorf("resource %q not found in state", resourceName)
+	}
+	if rs.Primary == nil || rs.Primary.ID == "" {
+		return 0, false, fmt.Errorf("resource %q has no ID in state", resourceName)
+	}
+
+	clientSet, err := testAccAlertClientSet()
+	if err != nil {
+		return 0, false, err
+	}
+	client := clientSet.Alerts()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, _, err := client.AlertDefsServiceGetAlertDef(ctx, rs.Primary.ID).Execute()
+	if err != nil {
+		return 0, false, fmt.Errorf("read alert %q: %w", resourceName, err)
+	}
+
+	alertDef := resp.GetAlertDef()
+	properties := alertDef.GetAlertDefProperties()
+	if properties.AlertDefPropertiesLogsThreshold == nil {
+		return 0, false, fmt.Errorf("alert %q is not a logs threshold alert", resourceName)
+	}
+
+	delay, ok := properties.AlertDefPropertiesLogsThreshold.LogsThreshold.GetEvaluationDelayMsOk()
+	if !ok {
+		return 0, false, nil
+	}
+	return *delay, true, nil
+}
+
+func testAccAlertClientSet() (*clientset.ClientSet, error) {
+	apiKey := os.Getenv("CORALOGIX_API_KEY")
+	domain := os.Getenv("CORALOGIX_DOMAIN")
+	terraformEnvironmentAlias := strings.ToUpper(os.Getenv("CORALOGIX_ENV"))
+
+	if domain != "" && terraformEnvironmentAlias != "" {
+		return nil, fmt.Errorf("only one of CORALOGIX_ENV or CORALOGIX_DOMAIN can be set")
+	}
+	if domain != "" {
+		targetURL := clientset.GrpcTargetFromDomain(domain)
+		return clientset.NewClientSet(domain, apiKey, targetURL), nil
+	}
+
+	targetURL, ok := terraformEnvironmentAliasToGrpcUrl[terraformEnvironmentAlias]
+	if !ok {
+		return nil, fmt.Errorf("the Coralogix env must be one of %q", validEnvironmentAliases)
+	}
+	sdkEnvironment := terraformEnvironmentAliasToSdkEnvironment[terraformEnvironmentAlias]
+	return clientset.NewClientSet(sdkEnvironment, apiKey, targetURL), nil
+}
+
 func testAccCoralogixResourceAlertLogsImmediateUpdated() string {
 	return `resource "coralogix_alert" "test" {
   name        = "logs immediate alert updated"
@@ -1858,6 +1975,89 @@ func testAccCoralogixResourceAlertLogsLessThan() string {
   }
 }
 `
+}
+
+func testAccCoralogixResourceAlertCustomEvaluationDelayOmittedAndExplicit(name string) string {
+	return fmt.Sprintf(`
+resource "coralogix_alert" "more_than_omitted" {
+  name        = "custom-evaluation-delay-more-than-omitted-%[1]s"
+  description = "custom evaluation delay omitted more-than alert"
+  priority    = "P2"
+
+  type_definition = {
+    logs_threshold = {
+      logs_filter = {
+        simple_filter = {
+          lucene_query = "message:\"error\""
+        }
+      }
+      rules = [
+        {
+          condition = {
+            threshold      = 2
+            time_window    = "10_MINUTES"
+            condition_type = "MORE_THAN"
+          }
+          override = {}
+        }
+      ]
+    }
+  }
+}
+
+resource "coralogix_alert" "less_than_omitted" {
+  name        = "custom-evaluation-delay-less-than-omitted-%[1]s"
+  description = "custom evaluation delay omitted less-than alert"
+  priority    = "P2"
+
+  type_definition = {
+    logs_threshold = {
+      logs_filter = {
+        simple_filter = {
+          lucene_query = "message:\"error\""
+        }
+      }
+      rules = [
+        {
+          condition = {
+            threshold      = 2
+            time_window    = "10_MINUTES"
+            condition_type = "LESS_THAN"
+          }
+          override = {}
+        }
+      ]
+    }
+  }
+}
+
+resource "coralogix_alert" "explicit_zero" {
+  name        = "custom-evaluation-delay-explicit-zero-%[1]s"
+  description = "custom evaluation delay explicit zero alert"
+  priority    = "P2"
+
+  type_definition = {
+    logs_threshold = {
+      custom_evaluation_delay = 0
+      logs_filter = {
+        simple_filter = {
+          lucene_query = "message:\"error\""
+        }
+      }
+      rules = [
+        {
+          condition = {
+            threshold      = 2
+            time_window    = "10_MINUTES"
+            condition_type = "MORE_THAN"
+          }
+          override = {}
+        }
+      ]
+    }
+  }
+}
+`, name)
 }
 
 func testAccCoralogixResourceAlertLogsLessThanWithRoutingUpdated(name string) string {


### PR DESCRIPTION
### Description

Fix `coralogix_alert.custom_evaluation_delay` so omitted configuration is preserved as unset instead of being defaulted to `0`.

The Terraform-side default was removed because `0` is a meaningful explicit value. `Computed` was also removed because when the field is omitted, the API returns it as unset; the effective evaluation delay is an implicit backend default based on the alert type, not a value returned on the alert definition.

Manual Tests (on top add added unit + e2e tests):

- Migration:
  - Created alerts with the old provider behavior, where omitted `custom_evaluation_delay` became `0`.
  - Installed the new provider and ran `terraform plan`.
  - Verified only omitted configs planned `custom_evaluation_delay = 0 -> null`.
  - Applied the plan and verified omitted values became unset.
  - Verified explicit values were preserved: `0`, MORE_THAN `60000`, and LESS_THAN `180000`.
  - Verified final `terraform plan` had no changes.

- Non-migration:
  - Created fresh alerts with the new provider code.
  - Verified omitted config stayed unset.
  - Verified explicit `0` stayed `0`.
  - Verified explicit values were preserved: MORE_THAN `60000` and LESS_THAN `180000`.
  - Verified final `terraform plan` had no changes.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceAlert_custom_evaluation_delay_omitted_and_explicit'
=== RUN   TestAccCoralogixResourceAlert_custom_evaluation_delay_omitted_and_explicit
--- PASS: TestAccCoralogixResourceAlert_custom_evaluation_delay_omitted_and_explicit (3.20s)
PASS
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- FIX: Preserve omitted `custom_evaluation_delay` as unset instead of defaulting it to `0`; existing omitted configurations previously stored as `0` will plan an update to unset the field on the next apply.
```