### PR TITLE
Prepare for release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Release 3.6.0
+
 #### resource/coralogix_alert
 
 - FIX: The `priority` deprecation warning is now type-aware — emitted only for the alert types that embed an `override` block, and suppressed for the types where top-level `priority` is the only mechanism and is therefore not deprecated.

--- a/internal/clientset/version.go
+++ b/internal/clientset/version.go
@@ -14,4 +14,4 @@
 
 package clientset
 
-const TF_PROVIDER_VERSION = "3.5.0"
+const TF_PROVIDER_VERSION = "3.6.0"


### PR DESCRIPTION
### Description

Cuts the release **3.6.0**.