### PR TITLE
Fixed AI custom evaluation examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+#### resource/coralogix_ai_custom_evaluation
+- FIX: Correct example score mapping and clearing of empty `criteria.*.examples` lists.
+
+
 # Release 3.6.0
 
 #### resource/coralogix_alert

--- a/internal/provider/ai/resource_coralogix_ai_custom_evaluation.go
+++ b/internal/provider/ai/resource_coralogix_ai_custom_evaluation.go
@@ -48,10 +48,11 @@ import (
 )
 
 const (
-	aiCustomEvaluationAcceptableScore    = "0"
-	aiCustomEvaluationProhibitedScore    = "1"
+	aiCustomEvaluationAcceptableScore    = "1"
+	aiCustomEvaluationProhibitedScore    = "0"
 	aiCustomEvaluationPolicyTypeQuality  = "quality"
 	aiCustomEvaluationPolicyTypeSecurity = "security"
+	aiCustomEvaluationExamplesUpdateMask = "examples"
 )
 
 var (
@@ -359,6 +360,18 @@ func (r *AICustomEvaluationResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
+	updated := result.GetItem()
+	if len(rq.Examples) == 0 {
+		updated, httpResponse, err = r.clearCustomEvaluationExamples(ctx, plan.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error clearing coralogix_ai_custom_evaluation examples",
+				utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Update", rq),
+			)
+			return
+		}
+	}
+
 	err = r.reconcileApplicationLinks(ctx, plan.ID.ValueString(), applicationIDsFromSet(ctx, state.ApplicationIDs), applicationIDs(applications))
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -368,7 +381,6 @@ func (r *AICustomEvaluationResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	updated := result.GetItem()
 	updated.ApplicationIds = applicationIDs(applications)
 	statePtr, diags := flattenAICustomEvaluation(ctx, updated, applications, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -537,6 +549,23 @@ func extractUpdateAICustomEvaluation(ctx context.Context, plan AICustomEvaluatio
 	}
 
 	return rq, diags
+}
+
+func (r *AICustomEvaluationResource) clearCustomEvaluationExamples(ctx context.Context, id string) (aievaluations.CustomEvaluation, *http.Response, error) {
+	rq := aievaluations.AiEvaluationsServiceUpdateCustomEvaluationRequest{
+		Examples:   []aievaluations.CustomEvaluationExample{},
+		UpdateMask: aievaluations.PtrString(aiCustomEvaluationExamplesUpdateMask),
+	}
+
+	result, httpResponse, err := r.aiEvaluationsClient.
+		AiEvaluationsServiceUpdateCustomEvaluation(ctx, id).
+		AiEvaluationsServiceUpdateCustomEvaluationRequest(rq).
+		Execute()
+	if err != nil {
+		return aievaluations.CustomEvaluation{}, httpResponse, err
+	}
+
+	return result.GetItem(), httpResponse, nil
 }
 
 func extractAICustomEvaluationCriteria(ctx context.Context, model *AICustomEvaluationCriteriaModel) ([]aievaluations.CustomEvaluationExample, string, string, diag.Diagnostics) {

--- a/internal/provider/ai/resource_coralogix_ai_custom_evaluation_test.go
+++ b/internal/provider/ai/resource_coralogix_ai_custom_evaluation_test.go
@@ -16,6 +16,7 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,6 +25,8 @@ import (
 
 	aiapplications "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/ai_applications_service"
 	aievaluations "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/ai_evaluations_service"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestGetCustomEvaluationByIDTreatsListNotFoundAsEmpty(t *testing.T) {
@@ -126,6 +129,162 @@ func TestListAIApplicationsRequestsConsecutivePageOffsets(t *testing.T) {
 	}
 	if applications[200].ID != "app-200" {
 		t.Fatalf("expected last application from page 1, got %q", applications[200].ID)
+	}
+}
+
+func TestExtractUpdateAICustomEvaluationKeepsEmptyExamplesNonNil(t *testing.T) {
+	t.Parallel()
+
+	acceptable := aiCustomEvaluationEmptyCriterionModel()
+	prohibited := aiCustomEvaluationEmptyCriterionModel()
+	plan := AICustomEvaluationResourceModel{
+		Name:                      types.StringValue("custom evaluation"),
+		PolicyType:                types.StringValue(aiCustomEvaluationPolicyTypeQuality),
+		Description:               types.StringValue("description"),
+		Instructions:              types.StringValue("Score whether {response} matches the policy."),
+		ShouldIncludeSystemPrompt: types.BoolValue(false),
+		Criteria: &AICustomEvaluationCriteriaModel{
+			Acceptable: &acceptable,
+			Prohibited: &prohibited,
+		},
+	}
+
+	rq, diags := extractUpdateAICustomEvaluation(context.Background(), plan)
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics, got %v", diags)
+	}
+	if rq.UpdateMask != nil {
+		t.Fatalf("expected no update mask on the primary update request, got %q", *rq.UpdateMask)
+	}
+	if rq.Examples == nil {
+		t.Fatal("expected examples to be a non-nil empty slice")
+	}
+	if len(rq.Examples) != 0 {
+		t.Fatalf("expected no examples, got %d", len(rq.Examples))
+	}
+}
+
+func TestExtractAICustomEvaluationCriteriaMapsExampleScores(t *testing.T) {
+	t.Parallel()
+
+	acceptable := aiCustomEvaluationEmptyCriterionModel()
+	acceptable.Examples = types.ListValueMust(
+		types.StringType,
+		[]attr.Value{
+			types.StringValue("acceptable example"),
+		},
+	)
+	prohibited := aiCustomEvaluationEmptyCriterionModel()
+	prohibited.Examples = types.ListValueMust(
+		types.StringType,
+		[]attr.Value{
+			types.StringValue("prohibited example"),
+		},
+	)
+	criteria := &AICustomEvaluationCriteriaModel{
+		Acceptable: &acceptable,
+		Prohibited: &prohibited,
+	}
+
+	examples, _, _, diags := extractAICustomEvaluationCriteria(context.Background(), criteria)
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics, got %v", diags)
+	}
+	if len(examples) != 2 {
+		t.Fatalf("expected 2 examples, got %d", len(examples))
+	}
+	if got := examples[0].GetConversation(); got != "acceptable example" {
+		t.Fatalf("expected first example to be acceptable, got %q", got)
+	}
+	if got := examples[0].GetScore(); got != aiCustomEvaluationAcceptableScore {
+		t.Fatalf("expected acceptable score %q, got %q", aiCustomEvaluationAcceptableScore, got)
+	}
+	if got := examples[1].GetConversation(); got != "prohibited example" {
+		t.Fatalf("expected second example to be prohibited, got %q", got)
+	}
+	if got := examples[1].GetScore(); got != aiCustomEvaluationProhibitedScore {
+		t.Fatalf("expected prohibited score %q, got %q", aiCustomEvaluationProhibitedScore, got)
+	}
+}
+
+func TestClearCustomEvaluationExamplesSendsExamplesUpdateMask(t *testing.T) {
+	t.Parallel()
+
+	customEvaluationID := "00000000-0000-0000-0000-000000000000"
+	cfg := aievaluations.NewConfiguration()
+	cfg.Servers = aievaluations.ServerConfigurations{
+		{
+			URL: "https://example.test",
+		},
+	}
+	cfg.HTTPClient = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method != http.MethodPatch {
+				t.Fatalf("expected PATCH, got %s", r.Method)
+			}
+			if r.URL.Path != "/ai/custom-evaluations/v3/"+customEvaluationID {
+				t.Fatalf("unexpected request path: %s", r.URL.Path)
+			}
+
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("failed to read request body: %v", err)
+			}
+			var body map[string]any
+			if err := json.Unmarshal(bodyBytes, &body); err != nil {
+				t.Fatalf("failed to decode request body %q: %v", string(bodyBytes), err)
+			}
+			if got := body["updateMask"]; got != aiCustomEvaluationExamplesUpdateMask {
+				t.Fatalf("expected updateMask %q, got %v", aiCustomEvaluationExamplesUpdateMask, got)
+			}
+			examples, ok := body["examples"].([]any)
+			if !ok {
+				t.Fatalf("expected examples array, got %T", body["examples"])
+			}
+			if len(examples) != 0 {
+				t.Fatalf("expected empty examples, got %v", examples)
+			}
+			if _, ok := body["policyType"]; ok {
+				t.Fatalf("did not expect policyType in examples clear request: %v", body)
+			}
+
+			response := fmt.Sprintf(`{
+				"item": {
+					"id": %q,
+					"name": "custom evaluation",
+					"description": "",
+					"config": {
+						"instructions": "Score whether {response} matches the policy.",
+						"policyType": "quality",
+						"safe": "",
+						"violates": "",
+						"shouldIncludeSystemPrompt": false,
+						"examples": []
+					}
+				}
+			}`, customEvaluationID)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body:    io.NopCloser(strings.NewReader(response)),
+				Request: r,
+			}, nil
+		}),
+	}
+	resource := &AICustomEvaluationResource{
+		aiEvaluationsClient: aievaluations.NewAPIClient(cfg).AIEvaluationsServiceAPI,
+	}
+
+	customEvaluation, _, err := resource.clearCustomEvaluationExamples(context.Background(), customEvaluationID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	config := customEvaluation.GetConfig()
+	if examples := config.GetExamples(); len(examples) != 0 {
+		t.Fatalf("expected cleared examples, got %v", examples)
 	}
 }
 

--- a/internal/provider/resource_coralogix_ai_custom_evaluation_test.go
+++ b/internal/provider/resource_coralogix_ai_custom_evaluation_test.go
@@ -173,6 +173,75 @@ func TestAccCoralogixResourceAICustomEvaluationWithoutApplicationsOrCriteria(t *
 	})
 }
 
+func TestAccCoralogixResourceAICustomEvaluationClearAcceptableExamples(t *testing.T) {
+	application := &aiEvaluationApplication{}
+	name := acctest.RandomWithPrefix("tf-acc-ai-custom-evaluation-clear-examples")
+	configDir := t.TempDir()
+	createConfigFile := filepath.Join(configDir, "create.tf")
+	updateConfigFile := filepath.Join(configDir, "update.tf")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			*application = testAccFirstAICustomEvaluationApplication(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAICustomEvaluationDestroy,
+		Steps: []resource.TestStep{
+			{
+				ConfigFile: testAccAICustomEvaluationConfigFile(
+					t,
+					createConfigFile,
+					application,
+					name,
+					false,
+					testAccAICustomEvaluationAcceptableExamplesCriteria(),
+				),
+				Check: testAccAICustomEvaluationCheck(
+					application,
+					name,
+					"quality",
+					false,
+					resource.TestCheckResourceAttr(aiCustomEvaluationResourceName, "criteria.acceptable.flags", "Does not mention competitor products."),
+					resource.TestCheckResourceAttr(aiCustomEvaluationResourceName, "criteria.acceptable.examples.#", "1"),
+					resource.TestCheckResourceAttr(aiCustomEvaluationResourceName, "criteria.acceptable.examples.0", "User: which tool should I use?\nAssistant: Our product is a strong fit."),
+					resource.TestCheckResourceAttr(aiCustomEvaluationResourceName, "criteria.prohibited.examples.#", "0"),
+				),
+			},
+			{
+				ConfigFile: testAccAICustomEvaluationConfigFile(
+					t,
+					updateConfigFile,
+					application,
+					name,
+					false,
+					testAccAICustomEvaluationEmptyExamplesCriteria(),
+				),
+				Check: testAccAICustomEvaluationCheck(
+					application,
+					name,
+					"quality",
+					false,
+					resource.TestCheckResourceAttr(aiCustomEvaluationResourceName, "criteria.acceptable.flags", "Does not mention competitor products."),
+					resource.TestCheckResourceAttr(aiCustomEvaluationResourceName, "criteria.acceptable.examples.#", "0"),
+					resource.TestCheckResourceAttr(aiCustomEvaluationResourceName, "criteria.prohibited.examples.#", "0"),
+				),
+			},
+			{
+				ConfigFile: testAccAICustomEvaluationConfigFile(
+					t,
+					updateConfigFile,
+					application,
+					name,
+					false,
+					testAccAICustomEvaluationEmptyExamplesCriteria(),
+				),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccCoralogixResourceAICustomEvaluationUnlinkAllApplications(t *testing.T) {
 	application := &aiEvaluationApplication{}
 	name := acctest.RandomWithPrefix("tf-acc-ai-custom-evaluation")
@@ -555,6 +624,32 @@ func testAccAICustomEvaluationUpdateCriteria() string {
       examples = [
         "User: what should I buy?\nAssistant: You should buy CompetitorY.",
       ]
+    }
+`
+}
+
+func testAccAICustomEvaluationAcceptableExamplesCriteria() string {
+	return `    acceptable = {
+      flags = "Does not mention competitor products."
+      examples = [
+        "User: which tool should I use?\nAssistant: Our product is a strong fit.",
+      ]
+    }
+    prohibited = {
+      flags = "Mentions a competitor product."
+      examples = []
+    }
+`
+}
+
+func testAccAICustomEvaluationEmptyExamplesCriteria() string {
+	return `    acceptable = {
+      flags = "Does not mention competitor products."
+      examples = []
+    }
+    prohibited = {
+      flags = "Mentions a competitor product."
+      examples = []
     }
 `
 }


### PR DESCRIPTION
### Description

Fixes AI custom evaluation example handling by correcting the acceptable/prohibited score mapping sent to the API. Also ensures updates that set criteria.*.examples to an empty list actually clear existing backend examples by sending the required update mask.
Validation: added unit coverage for score mapping and empty-example update payloads, plus an acceptance test for clearing examples.

Related to: https://github.com/coralogix/coralogix-operator/pull/524#discussion_r3498484880

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceAICustomEvaluation'

go test ./internal/provider -run TestAccCoralogixResourceAICustomEvaluation -v -timeout 120m -count=1
=== RUN   TestAccCoralogixResourceAICustomEvaluation
--- PASS: TestAccCoralogixResourceAICustomEvaluation (2.48s)
=== RUN   TestAccCoralogixResourceAICustomEvaluationMissingApplicationCreate
--- PASS: TestAccCoralogixResourceAICustomEvaluationMissingApplicationCreate (0.37s)
=== RUN   TestAccCoralogixResourceAICustomEvaluationWithoutApplicationsOrCriteria
--- PASS: TestAccCoralogixResourceAICustomEvaluationWithoutApplicationsOrCriteria (1.17s)
=== RUN   TestAccCoralogixResourceAICustomEvaluationClearAcceptableExamples
--- PASS: TestAccCoralogixResourceAICustomEvaluationClearAcceptableExamples (2.05s)
=== RUN   TestAccCoralogixResourceAICustomEvaluationUnlinkAllApplications
--- PASS: TestAccCoralogixResourceAICustomEvaluationUnlinkAllApplications (1.82s)
=== RUN   TestAccCoralogixResourceAICustomEvaluationMissingApplicationUpdate
--- PASS: TestAccCoralogixResourceAICustomEvaluationMissingApplicationUpdate (1.43s)
=== RUN   TestAccCoralogixResourceAICustomEvaluationInvalidInstructions
--- PASS: TestAccCoralogixResourceAICustomEvaluationInvalidInstructions (0.17s)
=== RUN   TestAccCoralogixResourceAICustomEvaluationInvalidPolicyType
--- PASS: TestAccCoralogixResourceAICustomEvaluationInvalidPolicyType (0.15s)
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider     10.404s
```

### Release Note
```release-note
- FIX: Correct example score mapping and clearing of empty `criteria.*.examples` lists.
```