### PR TITLE
Split acceptance tests into 3 parallel jobs

### DIFF
--- a/.github/scripts/run-acceptance-test-shard.sh
+++ b/.github/scripts/run-acceptance-test-shard.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+shard="${1:-}"
+if [[ "$shard" =~ ^([A-Z]+)$ ]]; then
+  start="${BASH_REMATCH[1]}"
+  end="$start"
+elif [[ "$shard" =~ ^([A-Z]+)-([A-Z]+)$ ]]; then
+  start="${BASH_REMATCH[1]}"
+  end="${BASH_REMATCH[2]}"
+else
+  echo "usage: $0 START-END or PREFIX, for example A-C, D-DAS, or DAT-DZ" >&2
+  exit 2
+fi
+
+end_upper="${end}{"
+
+if [[ ! "$start" < "$end_upper" ]]; then
+  echo "invalid shard range: $shard" >&2
+  exit 2
+fi
+
+normalized_file_key() {
+  local base name
+
+  base="$(basename "$1")"
+  name="${base%_test.go}"
+  name="${name#resource_}"
+  name="${name#data_source_}"
+  name="${name#coralogix_}"
+
+  printf '%s' "$name"
+}
+
+file_bucket_key() {
+  local key
+
+  key="$(normalized_file_key "$1" | tr '[:lower:]' '[:upper:]')"
+
+  case "$key" in
+    [A-Z]*)
+      printf '%s' "$key"
+      ;;
+    *)
+      printf 'Z%s' "$key"
+      ;;
+  esac
+}
+
+in_shard_range() {
+  local key="$1"
+
+  [[ ( "$key" == "$start" || "$key" > "$start" ) && "$key" < "$end_upper" ]]
+}
+
+selected_files=()
+selected_packages=()
+selected_tests=()
+
+while IFS= read -r file; do
+  bucket_key="$(file_bucket_key "$file")"
+  if ! in_shard_range "$bucket_key"; then
+    continue
+  fi
+
+  file_tests=()
+  while IFS= read -r test_name; do
+    file_tests+=("$test_name")
+  done < <(sed -nE 's/^func (Test[[:alnum:]_]*)\(.*$/\1/p' "$file")
+
+  if (( ${#file_tests[@]} == 0 )); then
+    continue
+  fi
+
+  selected_files+=("$file")
+  selected_packages+=("$(dirname "$file")")
+  selected_tests+=("${file_tests[@]}")
+done < <(find . -name '*_test.go' -not -path './vendor/*' -print | sort)
+
+if (( ${#selected_tests[@]} == 0 )); then
+  echo "No tests found for shard $shard" >&2
+  exit 1
+fi
+
+packages=()
+while IFS= read -r package; do
+  packages+=("$package")
+done < <(printf '%s\n' "${selected_packages[@]}" | sort -u)
+
+test_regex="$(printf '%s\n' "${selected_tests[@]}" | sort -u | paste -sd'|' -)"
+test_count="$(printf '%s\n' "${selected_tests[@]}" | sort -u | wc -l | tr -d ' ')"
+
+echo "Acceptance test shard $shard"
+echo "Selected $test_count tests from ${#selected_files[@]} files in ${#packages[@]} packages."
+printf '  %s\n' "${selected_files[@]}"
+
+if [[ "${SHARD_DRY_RUN:-}" == "1" ]]; then
+  echo "SHARD_DRY_RUN=1; not running go test."
+  exit 0
+fi
+
+make testacc TEST="${packages[*]}" TESTARGS="-run '^(${test_regex})\$\$'"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -16,14 +16,27 @@ on:
       - 'CLAUDE.md'
       - '**/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    name: Acceptance Tests (${{ matrix.shard }})
     env:
       GO111MODULE: on
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [ 1.25.x ]
-        os: [ ubuntu-latest ]
+        include:
+          - shard: A-C
+            go-version: 1.25.x
+            os: ubuntu-latest
+          - shard: D-DAS
+            go-version: 1.25.x
+            os: ubuntu-latest
+          - shard: DAT-Z
+            go-version: 1.25.x
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -43,4 +56,4 @@ jobs:
           AWS_TEST_ROLE: ${{ secrets.AWS_TEST_ROLE }}
           ARCHIVE_BUCKET: ${{ secrets.ARCHIVE_BUCKET }}
         run: |
-          make testacc
+          bash .github/scripts/run-acceptance-test-shard.sh "${{ matrix.shard }}"

--- a/internal/provider/data_source_coralogix_slo_v2_test.go
+++ b/internal/provider/data_source_coralogix_slo_v2_test.go
@@ -15,20 +15,23 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 var sloV2DataSourceName = "data." + sloV2ResourceName
 
 func TestAccCoralogixDataSourceSLOV2_basic(t *testing.T) {
+	name := fmt.Sprintf("coralogix_slo_go_example-%s", uuid.NewString())
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoralogixSLOV2RequestBased() +
+				Config: testAccCoralogixSLOV2RequestBased(name) +
 					testAccCoralogixResourceSLOV2_read(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(sloV2DataSourceName, "id"),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -15,12 +15,16 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	terraform2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 var testAccProvider *schema.Provider
@@ -60,4 +64,18 @@ func testAccPreCheck(t *testing.T) {
 	if os.Getenv("CORALOGIX_ENV") == "" && os.Getenv("CORALOGIX_DOMAIN") == "" {
 		t.Fatalf("CORALOGIX_ENV or CORALOGIX_DOMAIN must be set for acceptance tests")
 	}
+}
+
+func testAccClientSet() (*clientset.ClientSet, error) {
+	rc := terraform2.ResourceConfig{}
+	if diags := testAccProvider.Configure(context.Background(), &rc); diags.HasError() {
+		return nil, fmt.Errorf("failed to configure acceptance test provider: %v", diags)
+	}
+
+	clientSet, ok := testAccProvider.Meta().(*clientset.ClientSet)
+	if !ok || clientSet == nil {
+		return nil, fmt.Errorf("acceptance test provider did not return a client set")
+	}
+
+	return clientSet, nil
 }

--- a/internal/provider/resource_coralogix_alert_test.go
+++ b/internal/provider/resource_coralogix_alert_test.go
@@ -1477,7 +1477,7 @@ func TestAccCoralogixResourceAlert_flow(t *testing.T) {
 
 func TestAccCoralogixResourceAlert_sloBurnRate(t *testing.T) {
 	// t.Skip("Skipping SLO v2 for now")
-	sloName := "coralogix_slo_go_example"
+	sloName := fmt.Sprintf("coralogix_slo_go_example-%s", uuid.NewString())
 	alertName := "SLO burn rate alert"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/resource_coralogix_scope_test.go
+++ b/internal/provider/resource_coralogix_scope_test.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -61,7 +59,11 @@ func TestAccCoralogixResourceScope(t *testing.T) {
 }
 
 func testAccCheckScopeDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*clientset.ClientSet).Scopes()
+	clientSet, err := testAccClientSet()
+	if err != nil {
+		return err
+	}
+	client := clientSet.Scopes()
 	ctx := context.TODO()
 
 	for _, rs := range s.RootModule().Resources {

--- a/internal/provider/resource_coralogix_slo_v2_test.go
+++ b/internal/provider/resource_coralogix_slo_v2_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
+	"github.com/google/uuid"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -28,16 +28,17 @@ import (
 var sloV2ResourceName = "coralogix_slo_v2.test"
 
 func TestAccCoralogixResourceSLOV2RequestBased(t *testing.T) {
+	name := fmt.Sprintf("coralogix_slo_go_example-%s", uuid.NewString())
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccSLOV2CheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccCoralogixSLOV2RequestBased(),
+				Config:  testAccCoralogixSLOV2RequestBased(name),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(sloV2ResourceName, "name", "coralogix_slo_go_example"),
+					resource.TestCheckResourceAttr(sloV2ResourceName, "name", name),
 					resource.TestCheckResourceAttr(sloV2ResourceName, "description", "Example SLO for Coralogix using request-based metrics"),
 					resource.TestCheckResourceAttr(sloV2ResourceName, "target_threshold_percentage", "30"),
 				),
@@ -47,6 +48,7 @@ func TestAccCoralogixResourceSLOV2RequestBased(t *testing.T) {
 }
 
 func TestAccCoralogixResourceSLOV2WindowBased(t *testing.T) {
+	name := fmt.Sprintf("coralogix_window_based_slo-%s", uuid.NewString())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -54,10 +56,10 @@ func TestAccCoralogixResourceSLOV2WindowBased(t *testing.T) {
 		CheckDestroy:             testAccSLOV2CheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccCoralogixSLOV2WindowBased(),
+				Config:  testAccCoralogixSLOV2WindowBased(name),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(sloV2ResourceName, "name", "coralogix_window_based_slo"),
+					resource.TestCheckResourceAttr(sloV2ResourceName, "name", name),
 					resource.TestCheckResourceAttr(sloV2ResourceName, "description", "Example SLO using window-based metrics"),
 					resource.TestCheckResourceAttr(sloV2ResourceName, "target_threshold_percentage", "95"),
 				),
@@ -67,7 +69,11 @@ func TestAccCoralogixResourceSLOV2WindowBased(t *testing.T) {
 }
 
 func testAccSLOV2CheckDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*clientset.ClientSet).SLOs()
+	clientSet, err := testAccClientSet()
+	if err != nil {
+		return err
+	}
+	client := clientSet.SLOs()
 	ctx := context.TODO()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "coralogix_slo_v2" {
@@ -82,10 +88,10 @@ func testAccSLOV2CheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCoralogixSLOV2RequestBased() string {
-	return `
+func testAccCoralogixSLOV2RequestBased(name string) string {
+	return fmt.Sprintf(`
 resource "coralogix_slo_v2" "test" {
-  name                        = "coralogix_slo_go_example"
+  name                        = "%s"
   description                 = "Example SLO for Coralogix using request-based metrics"
   target_threshold_percentage = 30.0
   labels = {
@@ -105,13 +111,13 @@ resource "coralogix_slo_v2" "test" {
     slo_time_frame = "7_days"
   }
 }
-`
+`, name)
 }
 
-func testAccCoralogixSLOV2WindowBased() string {
-	return `
+func testAccCoralogixSLOV2WindowBased(name string) string {
+	return fmt.Sprintf(`
 resource "coralogix_slo_v2" "test" {
-  name                        = "coralogix_window_based_slo"
+  name                        = "%s"
   description                 = "Example SLO using window-based metrics"
   target_threshold_percentage = 95.0
   labels = {
@@ -132,5 +138,5 @@ resource "coralogix_slo_v2" "test" {
     slo_time_frame = "28_days"
   }
 }
-`
+`, name)
 }


### PR DESCRIPTION
### Description

Split the acceptance tests into 3 parallel CI runs.

The shard granularity is test files, not individual tests, to avoid breaking acceptance tests that may depend on shared setup, cleanup, or ordering within the same file.

### Impact

Acceptance test runtime dropped from ~16-18 minutes to ~6-8 minutes.

The acceptance test setup takes only around 10 seconds, so the extra parallel jobs are worth the small setup overhead. This also makes retries more granular, since failed acceptance tests can be restarted by shard instead of rerunning the entire suite.