### PR TITLE
Generate independent oneOf schemas for OpenAPI v3

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -42,5 +42,9 @@ jobs:
           TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}          
           AWS_TEST_ROLE: ${{ secrets.AWS_TEST_ROLE }}
           ARCHIVE_BUCKET: ${{ secrets.ARCHIVE_BUCKET }}
+          SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
+          SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
+          SLACK_INTEGRATION_CHANNEL_UPDATED: ${{ secrets.SLACK_INTEGRATION_CHANNEL_UPDATED }}
+          PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
         run: |
           make testacc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - FIX: Stop perpetual `(known after apply)` drift on `no_data_policy.auto_retire_seconds` when the field is omitted from configuration.
 
 #### provider
-- CHORE: Bump `coralogix-management-sdk`.
+- CHORE: Bump `coralogix-management-sdk` and adapt OpenAPI-backed resources to the regenerated oneOf SDK models.
 
 #### resource/coralogix_ai_custom_evaluation
 - FIX: Correct example score mapping and clearing of empty `criteria.*.examples` lists.

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,12 @@ module github.com/coralogix/terraform-provider-coralogix
 
 go 1.24.0
 
-replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c
+replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5
 
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260707082655-e45a5bb1f4cb
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706130708-908aad88acaf
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
@@ -93,6 +93,5 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251014184007-4626949a642f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251014184007-4626949a642f // indirect
-	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706130708-908aad88acaf
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -40,10 +40,10 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260707082655-e45a5bb1f4cb h1:4maoARuj5E6mkca1jOrltr1UI6qQzHXYzEA6vNyyBjA=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260707082655-e45a5bb1f4cb/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
-github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
-github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706130708-908aad88acaf h1:rFHCQEsexPeWYDpaDAjtiFY45MC4+smV/kLt7rhbnMU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706130708-908aad88acaf/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5 h1:mqmL/WJA8Cdzim6r3jmXY8uiPn9KX4AvqxjEPDRXKj4=
+github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -395,8 +395,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
-gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706130708-908aad88acaf h1:rFHCQEsexPeWYDpaDAjtiFY45MC4+smV/kLt7rhbnMU=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706130708-908aad88acaf/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39 h1:Ng94C0STKyjwhe0PisPAf72EwfWygiE6VIROidRApsY=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5 h1:mqmL/WJA8Cdzim6r3jmXY8uiPn9KX4AvqxjEPDRXKj4=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/aaa/resource_coralogix_api_key.go
+++ b/internal/provider/aaa/resource_coralogix_api_key.go
@@ -541,44 +541,41 @@ func makeCreateApiKeyRequest(ctx context.Context, apiKeyModel *ApiKeyModel) (*ap
 func extractOwner(keyModel *ApiKeyModel) (apiKeys.Owner, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if keyModel.Owner.UserId.ValueString() != "" {
+		userId := keyModel.Owner.UserId.ValueString()
 		return apiKeys.Owner{
-			OwnerUserId: &apiKeys.OwnerUserId{
-				UserId: keyModel.Owner.UserId.ValueString(),
-			},
+			UserId: &userId,
 		}, diags
 	} else {
 		if keyModel.Owner.OrganisationId.ValueString() != "" {
+			organisationId := keyModel.Owner.OrganisationId.ValueString()
 			return apiKeys.Owner{
-				OwnerOrganisationId: &apiKeys.OwnerOrganisationId{
-					OrganisationId: keyModel.Owner.OrganisationId.ValueString(),
-				},
+				OrganisationId: &organisationId,
 			}, diags
 		} else {
 			teamId, err := strconv.Atoi(keyModel.Owner.TeamId.ValueString())
 			if err != nil {
 				diags.AddError("Invalid team id", "Team id must be a int")
 			}
+			teamId64 := int64(teamId)
 			return apiKeys.Owner{
-				OwnerTeamId: &apiKeys.OwnerTeamId{
-					TeamId: int64(teamId),
-				},
+				TeamId: &teamId64,
 			}, diags
 		}
 	}
 }
 
 func flattenOwner(owner *apiKeys.Owner) Owner {
-	if owner.OwnerOrganisationId != nil {
+	if owner.OrganisationId != nil {
 		return Owner{
-			OrganisationId: types.StringValue(owner.OwnerOrganisationId.OrganisationId),
+			OrganisationId: types.StringPointerValue(owner.OrganisationId),
 		}
-	} else if owner.OwnerUserId != nil {
+	} else if owner.UserId != nil {
 		return Owner{
-			UserId: types.StringValue(owner.OwnerUserId.UserId),
+			UserId: types.StringPointerValue(owner.UserId),
 		}
-	} else if owner.OwnerTeamId != nil {
+	} else if owner.TeamId != nil {
 		return Owner{
-			TeamId: types.StringValue(strconv.Itoa(int(owner.OwnerTeamId.TeamId))),
+			TeamId: types.StringValue(strconv.Itoa(int(*owner.TeamId))),
 		}
 	} else {
 		return Owner{}

--- a/internal/provider/aaa/resource_coralogix_custom_role.go
+++ b/internal/provider/aaa/resource_coralogix_custom_role.go
@@ -291,13 +291,10 @@ func extractCreateCustomRoleRequest(ctx context.Context, roleModel *RolesModel) 
 	}
 
 	return &roless.RoleManagementServiceCreateRoleRequest{
-
-		CreateRoleRequestParentRoleName: &roless.CreateRoleRequestParentRoleName{
-			ParentRoleName: roleModel.ParentRole.ValueString(),
-			Name:           roleModel.Name.ValueStringPointer(),
-			Description:    roleModel.Description.ValueStringPointer(),
-			Permissions:    permissions,
-		},
+		ParentRoleName: roleModel.ParentRole.ValueStringPointer(),
+		Name:           roleModel.Name.ValueStringPointer(),
+		Description:    roleModel.Description.ValueStringPointer(),
+		Permissions:    permissions,
 	}, nil
 }
 

--- a/internal/provider/ai/resource_coralogix_ai_evaluation.go
+++ b/internal/provider/ai/resource_coralogix_ai_evaluation.go
@@ -603,44 +603,68 @@ func extractAIEvaluationConfig(ctx context.Context, model *AIEvaluationConfigMod
 		return nil, diags
 	}
 
+	if config, configDiags, ok := extractAIEvaluationValuedConfig(ctx, model); ok {
+		return config, configDiags
+	}
+	if config, ok := extractAIEvaluationMarkerConfig(model); ok {
+		return config, diags
+	}
+
+	diags.AddError("Missing AI evaluation config", "Exactly one AI evaluation config block must be set.")
+	return nil, diags
+}
+
+func extractAIEvaluationValuedConfig(ctx context.Context, model *AIEvaluationConfigModel) (*aievaluations.EvaluationConfig, diag.Diagnostics, bool) {
 	switch {
 	case model.AllowedTopics != nil:
-		return extractAIEvaluationAllowedTopicsConfig(ctx, *model.AllowedTopics)
+		config, diags := extractAIEvaluationAllowedTopicsConfig(ctx, *model.AllowedTopics)
+		return config, diags, true
 	case model.Competition != nil:
-		return extractAIEvaluationCompetitionConfig(ctx, *model.Competition)
-	case model.HallucinationCompleteness != nil:
-		return extractAIEvaluationHallucinationCompletenessConfig(), diags
-	case model.HallucinationContextAdherence != nil:
-		return extractAIEvaluationHallucinationContextAdherenceConfig(), diags
-	case model.HallucinationContextRelevance != nil:
-		return extractAIEvaluationHallucinationContextRelevanceConfig(), diags
-	case model.HallucinationCorrectness != nil:
-		return extractAIEvaluationHallucinationCorrectnessConfig(), diags
-	case model.HallucinationTaskAdherence != nil:
-		return extractAIEvaluationHallucinationTaskAdherenceConfig(), diags
-	case model.LanguageMismatch != nil:
-		return extractAIEvaluationLanguageMismatchConfig(), diags
+		config, diags := extractAIEvaluationCompetitionConfig(ctx, *model.Competition)
+		return config, diags, true
 	case model.PII != nil:
-		return extractAIEvaluationPIIConfig(ctx, *model.PII)
+		config, diags := extractAIEvaluationPIIConfig(ctx, *model.PII)
+		return config, diags, true
 	case model.PromptInjection != nil:
-		return extractAIEvaluationPromptInjectionConfig(*model.PromptInjection), diags
+		return extractAIEvaluationPromptInjectionConfig(*model.PromptInjection), nil, true
 	case model.RestrictedTopics != nil:
-		return extractAIEvaluationRestrictedTopicsConfig(ctx, *model.RestrictedTopics)
-	case model.Sexism != nil:
-		return extractAIEvaluationSexismConfig(), diags
+		config, diags := extractAIEvaluationRestrictedTopicsConfig(ctx, *model.RestrictedTopics)
+		return config, diags, true
 	case model.SQLAllowedTables != nil:
-		return extractAIEvaluationSQLAllowedTablesConfig(ctx, *model.SQLAllowedTables)
-	case model.SQLHallucination != nil:
-		return extractAIEvaluationSQLHallucinationConfig(), diags
-	case model.SQLReadOnly != nil:
-		return extractAIEvaluationSQLReadOnlyConfig(), diags
+		config, diags := extractAIEvaluationSQLAllowedTablesConfig(ctx, *model.SQLAllowedTables)
+		return config, diags, true
 	case model.SQLRestrictedTables != nil:
-		return extractAIEvaluationSQLRestrictedTablesConfig(ctx, *model.SQLRestrictedTables)
-	case model.Toxicity != nil:
-		return extractAIEvaluationToxicityConfig(), diags
+		config, diags := extractAIEvaluationSQLRestrictedTablesConfig(ctx, *model.SQLRestrictedTables)
+		return config, diags, true
 	default:
-		diags.AddError("Missing AI evaluation config", "Exactly one AI evaluation config block must be set.")
-		return nil, diags
+		return nil, nil, false
+	}
+}
+
+func extractAIEvaluationMarkerConfig(model *AIEvaluationConfigModel) (*aievaluations.EvaluationConfig, bool) {
+	switch {
+	case model.HallucinationCompleteness != nil:
+		return extractAIEvaluationHallucinationCompletenessConfig(), true
+	case model.HallucinationContextAdherence != nil:
+		return extractAIEvaluationHallucinationContextAdherenceConfig(), true
+	case model.HallucinationContextRelevance != nil:
+		return extractAIEvaluationHallucinationContextRelevanceConfig(), true
+	case model.HallucinationCorrectness != nil:
+		return extractAIEvaluationHallucinationCorrectnessConfig(), true
+	case model.HallucinationTaskAdherence != nil:
+		return extractAIEvaluationHallucinationTaskAdherenceConfig(), true
+	case model.LanguageMismatch != nil:
+		return extractAIEvaluationLanguageMismatchConfig(), true
+	case model.Sexism != nil:
+		return extractAIEvaluationSexismConfig(), true
+	case model.SQLHallucination != nil:
+		return extractAIEvaluationSQLHallucinationConfig(), true
+	case model.SQLReadOnly != nil:
+		return extractAIEvaluationSQLReadOnlyConfig(), true
+	case model.Toxicity != nil:
+		return extractAIEvaluationToxicityConfig(), true
+	default:
+		return nil, false
 	}
 }
 
@@ -653,11 +677,9 @@ func extractAIEvaluationAllowedTopicsConfig(ctx context.Context, model AIEvaluat
 		return nil, diags
 	}
 
-	config := aievaluations.EvaluationConfigAllowedTopicsAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigAllowedTopics(aievaluations.AllowedTopicsConfig{Topics: topics}),
-	)
-
-	return &config, diags
+	return &aievaluations.EvaluationConfig{
+		AllowedTopics: &aievaluations.AllowedTopicsConfig{Topics: topics},
+	}, diags
 }
 
 func extractAIEvaluationCompetitionConfig(ctx context.Context, model AIEvaluationCompetitionConfigModel) (*aievaluations.EvaluationConfig, diag.Diagnostics) {
@@ -669,59 +691,33 @@ func extractAIEvaluationCompetitionConfig(ctx context.Context, model AIEvaluatio
 		return nil, diags
 	}
 
-	config := aievaluations.EvaluationConfigCompetitionAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigCompetition(aievaluations.CompetitionConfig{Competitors: competitors}),
-	)
-
-	return &config, diags
+	return &aievaluations.EvaluationConfig{
+		Competition: &aievaluations.CompetitionConfig{Competitors: competitors},
+	}, diags
 }
 
 func extractAIEvaluationHallucinationCompletenessConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationCompletenessAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationCompleteness(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{HallucinationCompleteness: map[string]interface{}{}}
 }
 
 func extractAIEvaluationHallucinationContextAdherenceConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationContextAdherenceAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationContextAdherence(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{HallucinationContextAdherence: map[string]interface{}{}}
 }
 
 func extractAIEvaluationHallucinationContextRelevanceConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationContextRelevanceAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationContextRelevance(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{HallucinationContextRelevance: map[string]interface{}{}}
 }
 
 func extractAIEvaluationHallucinationCorrectnessConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationCorrectnessAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationCorrectness(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{HallucinationCorrectness: map[string]interface{}{}}
 }
 
 func extractAIEvaluationHallucinationTaskAdherenceConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationTaskAdherenceAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationTaskAdherence(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{HallucinationTaskAdherence: map[string]interface{}{}}
 }
 
 func extractAIEvaluationLanguageMismatchConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigLanguageMismatchAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigLanguageMismatch(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{LanguageMismatch: map[string]interface{}{}}
 }
 
 func extractAIEvaluationRestrictedTopicsConfig(ctx context.Context, model AIEvaluationRestrictedTopicsConfigModel) (*aievaluations.EvaluationConfig, diag.Diagnostics) {
@@ -733,11 +729,9 @@ func extractAIEvaluationRestrictedTopicsConfig(ctx context.Context, model AIEval
 		return nil, diags
 	}
 
-	config := aievaluations.EvaluationConfigRestrictedTopicsAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigRestrictedTopics(aievaluations.RestrictedTopicsConfig{Topics: topics}),
-	)
-
-	return &config, diags
+	return &aievaluations.EvaluationConfig{
+		RestrictedTopics: &aievaluations.RestrictedTopicsConfig{Topics: topics},
+	}, diags
 }
 
 func extractAIEvaluationPIIConfig(ctx context.Context, model AIEvaluationPIIConfigModel) (*aievaluations.EvaluationConfig, diag.Diagnostics) {
@@ -765,11 +759,9 @@ func extractAIEvaluationPIIConfig(ctx context.Context, model AIEvaluationPIIConf
 		return nil, diags
 	}
 
-	config := aievaluations.EvaluationConfigPiiAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigPii(aievaluations.PiiConfig{Categories: apiCategories}),
-	)
-
-	return &config, diags
+	return &aievaluations.EvaluationConfig{
+		Pii: &aievaluations.PiiConfig{Categories: apiCategories},
+	}, diags
 }
 
 func extractAIEvaluationPromptInjectionConfig(model AIEvaluationPromptInjectionConfigModel) *aievaluations.EvaluationConfig {
@@ -778,19 +770,11 @@ func extractAIEvaluationPromptInjectionConfig(model AIEvaluationPromptInjectionC
 		promptInjectionConfig.AdditionalContext = aievaluations.PtrString(model.AdditionalContext.ValueString())
 	}
 
-	config := aievaluations.EvaluationConfigPromptInjectionAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigPromptInjection(promptInjectionConfig),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{PromptInjection: &promptInjectionConfig}
 }
 
 func extractAIEvaluationSexismConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigSexismAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSexism(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{Sexism: map[string]interface{}{}}
 }
 
 func extractAIEvaluationSQLAllowedTablesConfig(ctx context.Context, model AIEvaluationSQLAllowedTablesConfigModel) (*aievaluations.EvaluationConfig, diag.Diagnostics) {
@@ -802,27 +786,17 @@ func extractAIEvaluationSQLAllowedTablesConfig(ctx context.Context, model AIEval
 		return nil, diags
 	}
 
-	config := aievaluations.EvaluationConfigSqlAllowedTablesAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSqlAllowedTables(aievaluations.SqlAllowedTablesConfig{Tables: tables}),
-	)
-
-	return &config, diags
+	return &aievaluations.EvaluationConfig{
+		SqlAllowedTables: &aievaluations.SqlAllowedTablesConfig{Tables: tables},
+	}, diags
 }
 
 func extractAIEvaluationSQLHallucinationConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigSqlHallucinationAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSqlHallucination(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{SqlHallucination: map[string]interface{}{}}
 }
 
 func extractAIEvaluationSQLReadOnlyConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigSqlReadOnlyAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSqlReadOnly(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{SqlReadOnly: map[string]interface{}{}}
 }
 
 func extractAIEvaluationSQLRestrictedTablesConfig(ctx context.Context, model AIEvaluationSQLRestrictedTablesConfigModel) (*aievaluations.EvaluationConfig, diag.Diagnostics) {
@@ -834,19 +808,13 @@ func extractAIEvaluationSQLRestrictedTablesConfig(ctx context.Context, model AIE
 		return nil, diags
 	}
 
-	config := aievaluations.EvaluationConfigSqlRestrictedTablesAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSqlRestrictedTables(aievaluations.SqlRestrictedTablesConfig{Tables: tables}),
-	)
-
-	return &config, diags
+	return &aievaluations.EvaluationConfig{
+		SqlRestrictedTables: &aievaluations.SqlRestrictedTablesConfig{Tables: tables},
+	}, diags
 }
 
 func extractAIEvaluationToxicityConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigToxicityAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigToxicity(map[string]interface{}{}),
-	)
-
-	return &config
+	return &aievaluations.EvaluationConfig{Toxicity: map[string]interface{}{}}
 }
 
 func flattenAIEvaluation(ctx context.Context, evaluation aievaluations.AiEvaluation) (AIEvaluationResourceModel, diag.Diagnostics) {
@@ -870,59 +838,77 @@ func flattenAIEvaluation(ctx context.Context, evaluation aievaluations.AiEvaluat
 }
 
 func flattenAIEvaluationConfig(ctx context.Context, config aievaluations.EvaluationConfig) (AIEvaluationConfigModel, diag.Diagnostics) {
-	var diags diag.Diagnostics
+	if model, diags, ok := flattenAIEvaluationValuedConfig(ctx, config); ok {
+		return model, diags
+	}
+	if model, ok := flattenAIEvaluationMarkerConfig(config); ok {
+		return model, nil
+	}
 
-	switch actualConfig := config.GetActualInstance().(type) {
-	case *aievaluations.EvaluationConfigAllowedTopics:
-		topics, topicDiags := flattenAIEvaluationAllowedTopics(ctx, actualConfig.GetAllowedTopics())
+	var diags diag.Diagnostics
+	diags.AddError("Unsupported AI evaluation config", "Only Allowed Topics, Competition, Hallucination Completeness, Hallucination Context Adherence, Hallucination Context Relevance, Hallucination Correctness, Hallucination Task Adherence, Language Mismatch, PII, Prompt Injection, Restricted Topics, Sexism, SQL Allowed Tables, SQL Hallucination, SQL Read Only, SQL Restricted Tables, and Toxicity AI evaluation configs are currently supported by this resource.")
+	return AIEvaluationConfigModel{}, diags
+}
+
+func flattenAIEvaluationValuedConfig(ctx context.Context, config aievaluations.EvaluationConfig) (AIEvaluationConfigModel, diag.Diagnostics, bool) {
+	var diags diag.Diagnostics
+	switch {
+	case config.AllowedTopics != nil:
+		topics, topicDiags := flattenAIEvaluationAllowedTopics(ctx, *config.AllowedTopics)
 		diags.Append(topicDiags...)
-		return AIEvaluationConfigModel{AllowedTopics: &AIEvaluationAllowedTopicsConfigModel{Topics: topics}}, diags
-	case *aievaluations.EvaluationConfigCompetition:
-		competitors, competitorDiags := flattenAIEvaluationCompetition(ctx, actualConfig.GetCompetition())
+		return AIEvaluationConfigModel{AllowedTopics: &AIEvaluationAllowedTopicsConfigModel{Topics: topics}}, diags, true
+	case config.Competition != nil:
+		competitors, competitorDiags := flattenAIEvaluationCompetition(ctx, *config.Competition)
 		diags.Append(competitorDiags...)
-		return AIEvaluationConfigModel{Competition: &AIEvaluationCompetitionConfigModel{Competitors: competitors}}, diags
-	case *aievaluations.EvaluationConfigHallucinationCompleteness:
-		return AIEvaluationConfigModel{HallucinationCompleteness: &AIEvaluationHallucinationCompletenessConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigHallucinationContextAdherence:
-		return AIEvaluationConfigModel{HallucinationContextAdherence: &AIEvaluationHallucinationContextAdherenceConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigHallucinationContextRelevance:
-		return AIEvaluationConfigModel{HallucinationContextRelevance: &AIEvaluationHallucinationContextRelevanceConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigHallucinationCorrectness:
-		return AIEvaluationConfigModel{HallucinationCorrectness: &AIEvaluationHallucinationCorrectnessConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigHallucinationTaskAdherence:
-		return AIEvaluationConfigModel{HallucinationTaskAdherence: &AIEvaluationHallucinationTaskAdherenceConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigLanguageMismatch:
-		return AIEvaluationConfigModel{LanguageMismatch: &AIEvaluationLanguageMismatchConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigPii:
-		categories, categoryDiags := flattenAIEvaluationPIICategories(ctx, actualConfig.GetPii())
+		return AIEvaluationConfigModel{Competition: &AIEvaluationCompetitionConfigModel{Competitors: competitors}}, diags, true
+	case config.Pii != nil:
+		categories, categoryDiags := flattenAIEvaluationPIICategories(ctx, *config.Pii)
 		diags.Append(categoryDiags...)
-		return AIEvaluationConfigModel{PII: &AIEvaluationPIIConfigModel{Categories: categories}}, diags
-	case *aievaluations.EvaluationConfigPromptInjection:
-		promptInjection := actualConfig.GetPromptInjection()
-		return AIEvaluationConfigModel{PromptInjection: &AIEvaluationPromptInjectionConfigModel{AdditionalContext: types.StringValue(promptInjection.GetAdditionalContext())}}, diags
-	case *aievaluations.EvaluationConfigRestrictedTopics:
-		topics, topicDiags := flattenAIEvaluationRestrictedTopics(ctx, actualConfig.GetRestrictedTopics())
+		return AIEvaluationConfigModel{PII: &AIEvaluationPIIConfigModel{Categories: categories}}, diags, true
+	case config.PromptInjection != nil:
+		promptInjection := config.PromptInjection
+		return AIEvaluationConfigModel{PromptInjection: &AIEvaluationPromptInjectionConfigModel{AdditionalContext: types.StringValue(promptInjection.GetAdditionalContext())}}, diags, true
+	case config.RestrictedTopics != nil:
+		topics, topicDiags := flattenAIEvaluationRestrictedTopics(ctx, *config.RestrictedTopics)
 		diags.Append(topicDiags...)
-		return AIEvaluationConfigModel{RestrictedTopics: &AIEvaluationRestrictedTopicsConfigModel{Topics: topics}}, diags
-	case *aievaluations.EvaluationConfigSexism:
-		return AIEvaluationConfigModel{Sexism: &AIEvaluationSexismConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigSqlAllowedTables:
-		tables, tableDiags := flattenAIEvaluationSQLAllowedTables(ctx, actualConfig.GetSqlAllowedTables())
+		return AIEvaluationConfigModel{RestrictedTopics: &AIEvaluationRestrictedTopicsConfigModel{Topics: topics}}, diags, true
+	case config.SqlAllowedTables != nil:
+		tables, tableDiags := flattenAIEvaluationSQLAllowedTables(ctx, *config.SqlAllowedTables)
 		diags.Append(tableDiags...)
-		return AIEvaluationConfigModel{SQLAllowedTables: &AIEvaluationSQLAllowedTablesConfigModel{Tables: tables}}, diags
-	case *aievaluations.EvaluationConfigSqlHallucination:
-		return AIEvaluationConfigModel{SQLHallucination: &AIEvaluationSQLHallucinationConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigSqlReadOnly:
-		return AIEvaluationConfigModel{SQLReadOnly: &AIEvaluationSQLReadOnlyConfigModel{}}, diags
-	case *aievaluations.EvaluationConfigSqlRestrictedTables:
-		tables, tableDiags := flattenAIEvaluationSQLRestrictedTables(ctx, actualConfig.GetSqlRestrictedTables())
+		return AIEvaluationConfigModel{SQLAllowedTables: &AIEvaluationSQLAllowedTablesConfigModel{Tables: tables}}, diags, true
+	case config.SqlRestrictedTables != nil:
+		tables, tableDiags := flattenAIEvaluationSQLRestrictedTables(ctx, *config.SqlRestrictedTables)
 		diags.Append(tableDiags...)
-		return AIEvaluationConfigModel{SQLRestrictedTables: &AIEvaluationSQLRestrictedTablesConfigModel{Tables: tables}}, diags
-	case *aievaluations.EvaluationConfigToxicity:
-		return AIEvaluationConfigModel{Toxicity: &AIEvaluationToxicityConfigModel{}}, diags
+		return AIEvaluationConfigModel{SQLRestrictedTables: &AIEvaluationSQLRestrictedTablesConfigModel{Tables: tables}}, diags, true
 	default:
-		diags.AddError("Unsupported AI evaluation config", "Only Allowed Topics, Competition, Hallucination Completeness, Hallucination Context Adherence, Hallucination Context Relevance, Hallucination Correctness, Hallucination Task Adherence, Language Mismatch, PII, Prompt Injection, Restricted Topics, Sexism, SQL Allowed Tables, SQL Hallucination, SQL Read Only, SQL Restricted Tables, and Toxicity AI evaluation configs are currently supported by this resource.")
-		return AIEvaluationConfigModel{}, diags
+		return AIEvaluationConfigModel{}, nil, false
+	}
+}
+
+func flattenAIEvaluationMarkerConfig(config aievaluations.EvaluationConfig) (AIEvaluationConfigModel, bool) {
+	switch {
+	case config.HallucinationCompleteness != nil:
+		return AIEvaluationConfigModel{HallucinationCompleteness: &AIEvaluationHallucinationCompletenessConfigModel{}}, true
+	case config.HallucinationContextAdherence != nil:
+		return AIEvaluationConfigModel{HallucinationContextAdherence: &AIEvaluationHallucinationContextAdherenceConfigModel{}}, true
+	case config.HallucinationContextRelevance != nil:
+		return AIEvaluationConfigModel{HallucinationContextRelevance: &AIEvaluationHallucinationContextRelevanceConfigModel{}}, true
+	case config.HallucinationCorrectness != nil:
+		return AIEvaluationConfigModel{HallucinationCorrectness: &AIEvaluationHallucinationCorrectnessConfigModel{}}, true
+	case config.HallucinationTaskAdherence != nil:
+		return AIEvaluationConfigModel{HallucinationTaskAdherence: &AIEvaluationHallucinationTaskAdherenceConfigModel{}}, true
+	case config.LanguageMismatch != nil:
+		return AIEvaluationConfigModel{LanguageMismatch: &AIEvaluationLanguageMismatchConfigModel{}}, true
+	case config.Sexism != nil:
+		return AIEvaluationConfigModel{Sexism: &AIEvaluationSexismConfigModel{}}, true
+	case config.SqlHallucination != nil:
+		return AIEvaluationConfigModel{SQLHallucination: &AIEvaluationSQLHallucinationConfigModel{}}, true
+	case config.SqlReadOnly != nil:
+		return AIEvaluationConfigModel{SQLReadOnly: &AIEvaluationSQLReadOnlyConfigModel{}}, true
+	case config.Toxicity != nil:
+		return AIEvaluationConfigModel{Toxicity: &AIEvaluationToxicityConfigModel{}}, true
+	default:
+		return AIEvaluationConfigModel{}, false
 	}
 }
 

--- a/internal/provider/alerts/resource_coralogix_alert.go
+++ b/internal/provider/alerts/resource_coralogix_alert.go
@@ -574,9 +574,7 @@ func extractAdvancedTargetSetting(ctx context.Context, webhooksSettingsModel ale
 			return nil, diag
 		}
 		advancedTargetSettings.Integration = &alerts.V3IntegrationType{
-			V3IntegrationTypeIntegrationId: &alerts.V3IntegrationTypeIntegrationId{
-				IntegrationId: *integrationId,
-			},
+			IntegrationId: integrationId,
 		}
 	} else if !webhooksSettingsModel.Recipients.IsNull() && !webhooksSettingsModel.Recipients.IsUnknown() {
 		emails, diags := utils.TypeStringElementsToStringSlice(ctx, webhooksSettingsModel.Recipients.Elements())
@@ -584,10 +582,8 @@ func extractAdvancedTargetSetting(ctx context.Context, webhooksSettingsModel ale
 			return nil, diags
 		}
 		advancedTargetSettings.Integration = &alerts.V3IntegrationType{
-			V3IntegrationTypeRecipients: &alerts.V3IntegrationTypeRecipients{
-				Recipients: alerts.Recipients{
-					Emails: emails,
-				},
+			Recipients: &alerts.Recipients{
+				Emails: emails,
 			},
 		}
 	}
@@ -718,61 +714,75 @@ func expandAlertsTypeDefinition(ctx context.Context, alertProperties *alerts.Ale
 		return nil, diags
 	}
 
-	var diags diag.Diagnostics
-
-	if logsImmediate := alertDefinitionModel.LogsImmediate; !utils.ObjIsNullOrUnknown(logsImmediate) {
-		// LogsImmediate
-		alertProperties, diags = expandLogsImmediateAlertTypeDefinition(ctx, alertProperties, logsImmediate, alertResourceModel)
-	} else if logsThreshold := alertDefinitionModel.LogsThreshold; !utils.ObjIsNullOrUnknown(logsThreshold) {
-		// LogsThreshold
-		alertProperties, diags = expandLogsThresholdTypeDefinition(ctx, alertProperties, logsThreshold, alertResourceModel)
-	} else if logsAnomaly := alertDefinitionModel.LogsAnomaly; !utils.ObjIsNullOrUnknown(logsAnomaly) {
-		// LogsAnomaly
-		alertProperties, diags = expandLogsAnomalyAlertTypeDefinition(ctx, alertProperties, logsAnomaly, alertResourceModel)
-	} else if logsRatioThreshold := alertDefinitionModel.LogsRatioThreshold; !utils.ObjIsNullOrUnknown(logsRatioThreshold) {
-		// LogsRatioThreshold
-		alertProperties, diags = expandLogsRatioThresholdTypeDefinition(ctx, alertProperties, logsRatioThreshold, alertResourceModel)
-	} else if logsNewValue := alertDefinitionModel.LogsNewValue; !utils.ObjIsNullOrUnknown(logsNewValue) {
-		// LogsNewValue
-		alertProperties, diags = expandLogsNewValueAlertTypeDefinition(ctx, alertProperties, logsNewValue, alertResourceModel)
-	} else if logsUniqueCount := alertDefinitionModel.LogsUniqueCount; !utils.ObjIsNullOrUnknown(logsUniqueCount) {
-		// LogsUniqueCount
-		alertProperties, diags = expandLogsUniqueCountAlertTypeDefinition(ctx, alertProperties, logsUniqueCount, alertResourceModel)
-	} else if logsTimeRelativeThreshold := alertDefinitionModel.LogsTimeRelativeThreshold; !utils.ObjIsNullOrUnknown(logsTimeRelativeThreshold) {
-		// LogsTimeRelativeThreshold
-		alertProperties, diags = expandLogsTimeRelativeThresholdAlertTypeDefinition(ctx, alertProperties, logsTimeRelativeThreshold, alertResourceModel)
-	} else if metricThreshold := alertDefinitionModel.MetricThreshold; !utils.ObjIsNullOrUnknown(metricThreshold) {
-		// MetricsThreshold
-		alertProperties, diags = expandMetricThresholdAlertTypeDefinition(ctx, alertProperties, metricThreshold, alertResourceModel)
-	} else if metricAnomaly := alertDefinitionModel.MetricAnomaly; !utils.ObjIsNullOrUnknown(metricAnomaly) {
-		// MetricsAnomaly
-		alertProperties, diags = expandMetricAnomalyAlertTypeDefinition(ctx, alertProperties, metricAnomaly, alertResourceModel)
-	} else if tracingImmediate := alertDefinitionModel.TracingImmediate; !utils.ObjIsNullOrUnknown(tracingImmediate) {
-		// TracingImmediate
-		alertProperties, diags = expandTracingImmediateTypeDefinition(ctx, alertProperties, tracingImmediate, alertResourceModel)
-	} else if tracingThreshold := alertDefinitionModel.TracingThreshold; !utils.ObjIsNullOrUnknown(tracingThreshold) {
-		// TracingThreshold
-		alertProperties, diags = expandTracingThresholdTypeDefinition(ctx, alertProperties, tracingThreshold, alertResourceModel)
-	} else if flow := alertDefinitionModel.Flow; !utils.ObjIsNullOrUnknown(flow) {
-		// Flow
-		alertProperties, diags = expandFlowAlertTypeDefinition(ctx, alertProperties, flow, alertResourceModel)
-	} else if sloThreshold := alertDefinitionModel.SloThreshold; !utils.ObjIsNullOrUnknown(sloThreshold) {
-		// SLOThreshold
-		alertProperties, diags = expandSloThresholdAlertTypeDefinition(ctx, alertProperties, sloThreshold, alertResourceModel)
-	} else {
+	updatedProperties, handled, diags := expandLogsAlertsTypeDefinition(ctx, alertProperties, alertDefinitionModel, alertResourceModel)
+	if !handled {
+		updatedProperties, handled, diags = expandNonLogsAlertsTypeDefinition(ctx, alertProperties, alertDefinitionModel, alertResourceModel)
+	}
+	if !handled {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Invalid Alert Type Definition", "Alert Type Definition is not valid")}
 	}
-
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	return alertProperties, nil
+	return updatedProperties, nil
+}
+
+func expandLogsAlertsTypeDefinition(ctx context.Context, alertProperties *alerts.AlertDefProperties, alertDefinitionModel alerttypes.AlertTypeDefinitionModel, alertResourceModel alerttypes.AlertResourceModel) (*alerts.AlertDefProperties, bool, diag.Diagnostics) {
+	switch {
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.LogsImmediate):
+		properties, diags := expandLogsImmediateAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.LogsImmediate, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.LogsThreshold):
+		properties, diags := expandLogsThresholdTypeDefinition(ctx, alertProperties, alertDefinitionModel.LogsThreshold, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.LogsAnomaly):
+		properties, diags := expandLogsAnomalyAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.LogsAnomaly, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.LogsRatioThreshold):
+		properties, diags := expandLogsRatioThresholdTypeDefinition(ctx, alertProperties, alertDefinitionModel.LogsRatioThreshold, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.LogsNewValue):
+		properties, diags := expandLogsNewValueAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.LogsNewValue, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.LogsUniqueCount):
+		properties, diags := expandLogsUniqueCountAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.LogsUniqueCount, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.LogsTimeRelativeThreshold):
+		properties, diags := expandLogsTimeRelativeThresholdAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.LogsTimeRelativeThreshold, alertResourceModel)
+		return properties, true, diags
+	default:
+		return alertProperties, false, nil
+	}
+}
+
+func expandNonLogsAlertsTypeDefinition(ctx context.Context, alertProperties *alerts.AlertDefProperties, alertDefinitionModel alerttypes.AlertTypeDefinitionModel, alertResourceModel alerttypes.AlertResourceModel) (*alerts.AlertDefProperties, bool, diag.Diagnostics) {
+	switch {
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.MetricThreshold):
+		properties, diags := expandMetricThresholdAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.MetricThreshold, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.MetricAnomaly):
+		properties, diags := expandMetricAnomalyAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.MetricAnomaly, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.TracingImmediate):
+		properties, diags := expandTracingImmediateTypeDefinition(ctx, alertProperties, alertDefinitionModel.TracingImmediate, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.TracingThreshold):
+		properties, diags := expandTracingThresholdTypeDefinition(ctx, alertProperties, alertDefinitionModel.TracingThreshold, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.Flow):
+		properties, diags := expandFlowAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.Flow, alertResourceModel)
+		return properties, true, diags
+	case !utils.ObjIsNullOrUnknown(alertDefinitionModel.SloThreshold):
+		properties, diags := expandSloThresholdAlertTypeDefinition(ctx, alertProperties, alertDefinitionModel.SloThreshold, alertResourceModel)
+		return properties, true, diags
+	default:
+		return alertProperties, false, nil
+	}
 }
 
 func expandLogsImmediateAlertTypeDefinition(ctx context.Context, properties *alerts.AlertDefProperties, logsImmediateObject types.Object, alertResourceModel alerttypes.AlertResourceModel) (*alerts.AlertDefProperties, diag.Diagnostics) {
 	var immediateModel alerttypes.LogsImmediateModel
-	properties.AlertDefPropertiesLogsImmediate = &alerts.AlertDefPropertiesLogsImmediate{}
 	if diags := logsImmediateObject.As(ctx, &immediateModel, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return nil, diags
 	}
@@ -809,22 +819,22 @@ func expandLogsImmediateAlertTypeDefinition(ctx context.Context, properties *ale
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsImmediate.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesLogsImmediate.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesLogsImmediate.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsImmediate.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesLogsImmediate.GroupByKeys = groupBy
-	properties.AlertDefPropertiesLogsImmediate.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesLogsImmediate.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesLogsImmediate.EntityLabels = &labels
-	properties.AlertDefPropertiesLogsImmediate.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsImmediate.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 
-	properties.AlertDefPropertiesLogsImmediate.LogsImmediate = alerts.LogsImmediateType{
+	properties.LogsImmediate = &alerts.LogsImmediateType{
 		LogsFilter:                logsFilter,
 		NotificationPayloadFilter: notificationPayloadFilter,
 	}
-	properties.AlertDefPropertiesLogsImmediate.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_IMMEDIATE_OR_UNSPECIFIED.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_IMMEDIATE_OR_UNSPECIFIED.Ptr()
 	return properties, nil
 }
 
@@ -1001,17 +1011,16 @@ func expandLogsThresholdTypeDefinition(ctx context.Context, properties *alerts.A
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsThreshold = &alerts.AlertDefPropertiesLogsThreshold{}
-	properties.AlertDefPropertiesLogsThreshold.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesLogsThreshold.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesLogsThreshold.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsThreshold.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesLogsThreshold.GroupByKeys = groupBy
-	properties.AlertDefPropertiesLogsThreshold.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesLogsThreshold.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesLogsThreshold.EntityLabels = &labels
-	properties.AlertDefPropertiesLogsThreshold.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsThreshold.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(thresholdObject) {
 		return properties, nil
 	}
@@ -1029,7 +1038,7 @@ func expandLogsThresholdTypeDefinition(ctx context.Context, properties *alerts.A
 		return nil, diags
 	}
 
-	properties.AlertDefPropertiesLogsThreshold.LogsThreshold = alerts.LogsThresholdType{
+	properties.LogsThreshold = &alerts.LogsThresholdType{
 		LogsFilter:                 logsFilter,
 		Rules:                      rules,
 		NotificationPayloadFilter:  notificationPayloadFilter,
@@ -1038,7 +1047,7 @@ func expandLogsThresholdTypeDefinition(ctx context.Context, properties *alerts.A
 		EvaluationDelayMs:          extractCustomEvaluationDelay(thresholdModel.CustomEvaluationDelay),
 	}
 
-	properties.AlertDefPropertiesLogsThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_THRESHOLD.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_THRESHOLD.Ptr()
 	return properties, nil
 }
 
@@ -1194,17 +1203,16 @@ func expandLogsAnomalyAlertTypeDefinition(ctx context.Context, properties *alert
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsAnomaly = &alerts.AlertDefPropertiesLogsAnomaly{}
-	properties.AlertDefPropertiesLogsAnomaly.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesLogsAnomaly.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesLogsAnomaly.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsAnomaly.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesLogsAnomaly.GroupByKeys = groupBy
-	properties.AlertDefPropertiesLogsAnomaly.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesLogsAnomaly.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesLogsAnomaly.EntityLabels = &labels
-	properties.AlertDefPropertiesLogsAnomaly.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsAnomaly.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(anomaly) {
 		return properties, nil
 	}
@@ -1222,7 +1230,7 @@ func expandLogsAnomalyAlertTypeDefinition(ctx context.Context, properties *alert
 		}
 	}
 
-	properties.AlertDefPropertiesLogsAnomaly.LogsAnomaly = alerts.LogsAnomalyType{
+	properties.LogsAnomaly = &alerts.LogsAnomalyType{
 		LogsFilter:                logsFilter,
 		Rules:                     rules,
 		NotificationPayloadFilter: notificationPayloadFilter,
@@ -1230,7 +1238,7 @@ func expandLogsAnomalyAlertTypeDefinition(ctx context.Context, properties *alert
 		AnomalyAlertSettings:      anomalyAlertSettings,
 	}
 
-	properties.AlertDefPropertiesLogsAnomaly.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_ANOMALY.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_ANOMALY.Ptr()
 	return properties, nil
 }
 
@@ -1310,17 +1318,16 @@ func expandLogsRatioThresholdTypeDefinition(ctx context.Context, properties *ale
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsRatioThreshold = &alerts.AlertDefPropertiesLogsRatioThreshold{}
-	properties.AlertDefPropertiesLogsRatioThreshold.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesLogsRatioThreshold.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesLogsRatioThreshold.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsRatioThreshold.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesLogsRatioThreshold.GroupByKeys = groupBy
-	properties.AlertDefPropertiesLogsRatioThreshold.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesLogsRatioThreshold.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesLogsRatioThreshold.EntityLabels = &labels
-	properties.AlertDefPropertiesLogsRatioThreshold.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsRatioThreshold.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(ratioThreshold) {
 		return properties, nil
 	}
@@ -1344,7 +1351,7 @@ func expandLogsRatioThresholdTypeDefinition(ctx context.Context, properties *ale
 	if groupByFor == "" {
 		groupByFor = alerttypes.LogsRatioGroupByForProtoToSchemaMap[alerts.LOGSRATIOGROUPBYFOR_LOGS_RATIO_GROUP_BY_FOR_BOTH_OR_UNSPECIFIED]
 	}
-	properties.AlertDefPropertiesLogsRatioThreshold.LogsRatioThreshold = alerts.LogsRatioThresholdType{
+	properties.LogsRatioThreshold = &alerts.LogsRatioThresholdType{
 		Numerator:                 numeratorLogsFilter,
 		NumeratorAlias:            ratioThresholdModel.NumeratorAlias.ValueStringPointer(),
 		Denominator:               denominatorLogsFilter,
@@ -1355,7 +1362,7 @@ func expandLogsRatioThresholdTypeDefinition(ctx context.Context, properties *ale
 		EvaluationDelayMs:         extractCustomEvaluationDelay(ratioThresholdModel.CustomEvaluationDelay),
 		IgnoreInfinity:            ratioThresholdModel.IgnoreInfinity.ValueBoolPointer(),
 	}
-	properties.AlertDefPropertiesLogsRatioThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_RATIO_THRESHOLD.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_RATIO_THRESHOLD.Ptr()
 	return properties, nil
 }
 
@@ -1471,17 +1478,16 @@ func expandLogsNewValueAlertTypeDefinition(ctx context.Context, properties *aler
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsNewValue = &alerts.AlertDefPropertiesLogsNewValue{}
-	properties.AlertDefPropertiesLogsNewValue.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesLogsNewValue.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesLogsNewValue.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsNewValue.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesLogsNewValue.GroupByKeys = groupBy
-	properties.AlertDefPropertiesLogsNewValue.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesLogsNewValue.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesLogsNewValue.EntityLabels = &labels
-	properties.AlertDefPropertiesLogsNewValue.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsNewValue.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if newValue.IsNull() || newValue.IsUnknown() {
 		return properties, nil
 	}
@@ -1490,12 +1496,12 @@ func expandLogsNewValueAlertTypeDefinition(ctx context.Context, properties *aler
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsNewValue.LogsNewValue = alerts.LogsNewValueType{
+	properties.LogsNewValue = &alerts.LogsNewValueType{
 		LogsFilter:                logsFilter,
 		Rules:                     rules,
 		NotificationPayloadFilter: notificationPayloadFilter,
 	}
-	properties.AlertDefPropertiesLogsNewValue.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_NEW_VALUE.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_NEW_VALUE.Ptr()
 	return properties, nil
 }
 
@@ -1587,17 +1593,16 @@ func expandLogsUniqueCountAlertTypeDefinition(ctx context.Context, properties *a
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsUniqueCount = &alerts.AlertDefPropertiesLogsUniqueCount{}
-	properties.AlertDefPropertiesLogsUniqueCount.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesLogsUniqueCount.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesLogsUniqueCount.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsUniqueCount.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesLogsUniqueCount.GroupByKeys = groupBy
-	properties.AlertDefPropertiesLogsUniqueCount.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesLogsUniqueCount.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesLogsUniqueCount.EntityLabels = &labels
-	properties.AlertDefPropertiesLogsUniqueCount.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsUniqueCount.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(uniqueCount) {
 		return properties, nil
 	}
@@ -1612,14 +1617,14 @@ func expandLogsUniqueCountAlertTypeDefinition(ctx context.Context, properties *a
 		val := strconv.FormatInt(uniqueCountModel.MaxUniqueCountPerGroupByKey.ValueInt64(), 10)
 		maxUniqueCountPerGroupByKey = &val
 	}
-	properties.AlertDefPropertiesLogsUniqueCount.LogsUniqueCount = alerts.LogsUniqueCountType{
+	properties.LogsUniqueCount = &alerts.LogsUniqueCountType{
 		LogsFilter:                  logsFilter,
 		Rules:                       rules,
 		NotificationPayloadFilter:   notificationPayloadFilter,
 		MaxUniqueCountPerGroupByKey: maxUniqueCountPerGroupByKey,
 		UniqueCountKeypath:          uniqueCountModel.UniqueCountKeypath.ValueStringPointer(),
 	}
-	properties.AlertDefPropertiesLogsUniqueCount.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_UNIQUE_COUNT.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_UNIQUE_COUNT.Ptr()
 	return properties, nil
 }
 
@@ -1710,17 +1715,16 @@ func expandLogsTimeRelativeThresholdAlertTypeDefinition(ctx context.Context, pro
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold = &alerts.AlertDefPropertiesLogsTimeRelativeThreshold{}
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.GroupByKeys = groupBy
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.EntityLabels = &labels
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(relativeThreshold) {
 		return properties, nil
 	}
@@ -1734,7 +1738,7 @@ func expandLogsTimeRelativeThresholdAlertTypeDefinition(ctx context.Context, pro
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.LogsTimeRelativeThreshold = alerts.LogsTimeRelativeThresholdType{
+	properties.LogsTimeRelativeThreshold = &alerts.LogsTimeRelativeThresholdType{
 		LogsFilter:                 logsFilter,
 		Rules:                      rules,
 		NotificationPayloadFilter:  notificationPayloadFilter,
@@ -1742,7 +1746,7 @@ func expandLogsTimeRelativeThresholdAlertTypeDefinition(ctx context.Context, pro
 		EvaluationDelayMs:          extractCustomEvaluationDelay(relativeThresholdModel.CustomEvaluationDelay),
 		IgnoreInfinity:             relativeThresholdModel.IgnoreInfinity.ValueBoolPointer(),
 	}
-	properties.AlertDefPropertiesLogsTimeRelativeThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_TIME_RELATIVE_THRESHOLD.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_TIME_RELATIVE_THRESHOLD.Ptr()
 	return properties, nil
 }
 
@@ -1821,17 +1825,16 @@ func expandMetricThresholdAlertTypeDefinition(ctx context.Context, properties *a
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesMetricThreshold = &alerts.AlertDefPropertiesMetricThreshold{}
-	properties.AlertDefPropertiesMetricThreshold.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesMetricThreshold.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesMetricThreshold.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesMetricThreshold.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesMetricThreshold.GroupByKeys = groupBy
-	properties.AlertDefPropertiesMetricThreshold.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesMetricThreshold.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesMetricThreshold.EntityLabels = &labels
-	properties.AlertDefPropertiesMetricThreshold.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesMetricThreshold.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(metricThreshold) {
 		return properties, nil
 	}
@@ -1859,7 +1862,7 @@ func expandMetricThresholdAlertTypeDefinition(ctx context.Context, properties *a
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesMetricThreshold.MetricThreshold = alerts.MetricThresholdType{
+	properties.MetricThreshold = &alerts.MetricThresholdType{
 		MetricFilter:               metricFilter,
 		Rules:                      rules,
 		MissingValues:              missingValues,
@@ -1867,7 +1870,7 @@ func expandMetricThresholdAlertTypeDefinition(ctx context.Context, properties *a
 		NoDataPolicy:               noDataPolicy,
 		EvaluationDelayMs:          extractCustomEvaluationDelay(metricThresholdModel.CustomEvaluationDelay),
 	}
-	properties.AlertDefPropertiesMetricThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_THRESHOLD.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_THRESHOLD.Ptr()
 
 	return properties, nil
 }
@@ -1884,15 +1887,11 @@ func extractMetricThresholdMissingValues(ctx context.Context, values types.Objec
 
 	if replaceWithZero := valuesModel.ReplaceWithZero; !(replaceWithZero.IsNull() || replaceWithZero.IsUnknown()) {
 		return &alerts.MetricMissingValues{
-			MetricMissingValuesReplaceWithZero: &alerts.MetricMissingValuesReplaceWithZero{
-				ReplaceWithZero: replaceWithZero.ValueBool(),
-			},
+			ReplaceWithZero: replaceWithZero.ValueBoolPointer(),
 		}, nil
 	} else if retainMissingValues := valuesModel.MinNonNullValuesPct; !(retainMissingValues.IsNull() || retainMissingValues.IsUnknown()) {
 		return &alerts.MetricMissingValues{
-			MetricMissingValuesMinNonNullValuesPct: &alerts.MetricMissingValuesMinNonNullValuesPct{
-				MinNonNullValuesPct: retainMissingValues.ValueInt64(),
-			},
+			MinNonNullValuesPct: retainMissingValues.ValueInt64Pointer(),
 		}, nil
 	} else {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Invalid Metric Missing Values", "Metric Missing Values is not valid")}
@@ -1990,17 +1989,16 @@ func expandTracingImmediateTypeDefinition(ctx context.Context, properties *alert
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesTracingImmediate = &alerts.AlertDefPropertiesTracingImmediate{}
-	properties.AlertDefPropertiesTracingImmediate.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesTracingImmediate.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesTracingImmediate.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesTracingImmediate.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesTracingImmediate.GroupByKeys = groupBy
-	properties.AlertDefPropertiesTracingImmediate.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesTracingImmediate.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesTracingImmediate.EntityLabels = &labels
-	properties.AlertDefPropertiesTracingImmediate.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesTracingImmediate.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(tracingImmediate) {
 		return properties, nil
 	}
@@ -2014,13 +2012,13 @@ func expandTracingImmediateTypeDefinition(ctx context.Context, properties *alert
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesTracingImmediate.TracingImmediate = alerts.TracingImmediateType{
+	properties.TracingImmediate = &alerts.TracingImmediateType{
 		TracingFilter: &alerts.TracingFilter{
 			SimpleFilter: tracingQuery,
 		},
 		NotificationPayloadFilter: notificationPayloadFilter,
 	}
-	properties.AlertDefPropertiesTracingImmediate.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_TRACING_IMMEDIATE.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_TRACING_IMMEDIATE.Ptr()
 
 	return properties, nil
 }
@@ -2053,17 +2051,16 @@ func expandTracingThresholdTypeDefinition(ctx context.Context, properties *alert
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesTracingThreshold = &alerts.AlertDefPropertiesTracingThreshold{}
-	properties.AlertDefPropertiesTracingThreshold.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesTracingThreshold.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesTracingThreshold.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesTracingThreshold.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesTracingThreshold.GroupByKeys = groupBy
-	properties.AlertDefPropertiesTracingThreshold.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesTracingThreshold.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesTracingThreshold.EntityLabels = &labels
-	properties.AlertDefPropertiesTracingThreshold.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesTracingThreshold.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(tracingThreshold) {
 		return properties, nil
 	}
@@ -2083,14 +2080,14 @@ func expandTracingThresholdTypeDefinition(ctx context.Context, properties *alert
 		return nil, diags
 	}
 
-	properties.AlertDefPropertiesTracingThreshold.TracingThreshold = alerts.TracingThresholdType{
+	properties.TracingThreshold = &alerts.TracingThresholdType{
 		TracingFilter: &alerts.TracingFilter{
 			SimpleFilter: tracingQuery,
 		},
 		NotificationPayloadFilter: notificationPayloadFilter,
 		Rules:                     rules,
 	}
-	properties.AlertDefPropertiesTracingThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_TRACING_THRESHOLD.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_TRACING_THRESHOLD.Ptr()
 
 	return properties, nil
 }
@@ -2295,17 +2292,16 @@ func expandMetricAnomalyAlertTypeDefinition(ctx context.Context, properties *ale
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesMetricAnomaly = &alerts.AlertDefPropertiesMetricAnomaly{}
-	properties.AlertDefPropertiesMetricAnomaly.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesMetricAnomaly.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesMetricAnomaly.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesMetricAnomaly.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesMetricAnomaly.GroupByKeys = groupBy
-	properties.AlertDefPropertiesMetricAnomaly.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesMetricAnomaly.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesMetricAnomaly.EntityLabels = &labels
-	properties.AlertDefPropertiesMetricAnomaly.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesMetricAnomaly.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(metricAnomaly) {
 		return properties, nil
 	}
@@ -2328,13 +2324,13 @@ func expandMetricAnomalyAlertTypeDefinition(ctx context.Context, properties *ale
 		}
 	}
 
-	properties.AlertDefPropertiesMetricAnomaly.MetricAnomaly = alerts.MetricAnomalyType{
+	properties.MetricAnomaly = &alerts.MetricAnomalyType{
 		MetricFilter:         metricFilter,
 		Rules:                rules,
 		EvaluationDelayMs:    extractCustomEvaluationDelay(metricAnomalyModel.CustomEvaluationDelay),
 		AnomalyAlertSettings: anomalyAlertSettings,
 	}
-	properties.AlertDefPropertiesMetricAnomaly.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_ANOMALY.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_ANOMALY.Ptr()
 
 	return properties, nil
 }
@@ -2370,9 +2366,7 @@ func extractMetricAnomalyRules(ctx context.Context, elements types.Set) ([]alert
 				Threshold:  condition.Threshold.ValueFloat64Pointer(),
 				ForOverPct: condition.ForOverPct.ValueInt64Pointer(),
 				OfTheLast: &alerts.MetricTimeWindow{
-					MetricTimeWindowMetricTimeWindowSpecificValue: &alerts.MetricTimeWindowMetricTimeWindowSpecificValue{
-						MetricTimeWindowSpecificValue: alerttypes.MetricTimeWindowValueSchemaToProtoMap[ofTheLast],
-					},
+					MetricTimeWindowSpecificValue: alerttypes.MetricTimeWindowValueSchemaToProtoMap[ofTheLast].Ptr(),
 				},
 				ConditionType:       conditionType.Ptr(),
 				MinNonNullValuesPct: condition.MinNonNullValuesPct.ValueInt64Pointer(),
@@ -2388,31 +2382,23 @@ func extractMetricAnomalyRules(ctx context.Context, elements types.Set) ([]alert
 func expandMetricTimeWindow(metricTimeWindow types.String) *alerts.MetricTimeWindow {
 	if metricTimeWindow.IsNull() || metricTimeWindow.IsUnknown() {
 		return &alerts.MetricTimeWindow{
-			MetricTimeWindowMetricTimeWindowSpecificValue: &alerts.MetricTimeWindowMetricTimeWindowSpecificValue{
-				MetricTimeWindowSpecificValue: alerts.METRICTIMEWINDOWVALUE_METRIC_TIME_WINDOW_VALUE_MINUTES_1_OR_UNSPECIFIED,
-			},
+			MetricTimeWindowSpecificValue: alerts.METRICTIMEWINDOWVALUE_METRIC_TIME_WINDOW_VALUE_MINUTES_1_OR_UNSPECIFIED.Ptr(),
 		}
 	}
 	timeWindowStr := metricTimeWindow.ValueString()
 	if timeWindowStr == "" {
 		timeWindowStr = alerttypes.MetricFilterOperationTypeProtoToSchemaMap[alerts.METRICTIMEWINDOWVALUE_METRIC_TIME_WINDOW_VALUE_MINUTES_1_OR_UNSPECIFIED]
 		return &alerts.MetricTimeWindow{
-			MetricTimeWindowMetricTimeWindowSpecificValue: &alerts.MetricTimeWindowMetricTimeWindowSpecificValue{
-				MetricTimeWindowSpecificValue: alerttypes.MetricTimeWindowValueSchemaToProtoMap[timeWindowStr],
-			},
+			MetricTimeWindowSpecificValue: alerttypes.MetricTimeWindowValueSchemaToProtoMap[timeWindowStr].Ptr(),
 		}
 	} else if timeWindow, ok := alerttypes.MetricTimeWindowValueSchemaToProtoMap[timeWindowStr]; ok {
 		return &alerts.MetricTimeWindow{
-			MetricTimeWindowMetricTimeWindowSpecificValue: &alerts.MetricTimeWindowMetricTimeWindowSpecificValue{
-				MetricTimeWindowSpecificValue: timeWindow,
-			},
+			MetricTimeWindowSpecificValue: timeWindow.Ptr(),
 		}
 
 	} else {
 		return &alerts.MetricTimeWindow{
-			MetricTimeWindowMetricTimeWindowDynamicDuration: &alerts.MetricTimeWindowMetricTimeWindowDynamicDuration{
-				MetricTimeWindowDynamicDuration: timeWindowStr,
-			},
+			MetricTimeWindowDynamicDuration: &timeWindowStr,
 		}
 	}
 }
@@ -2445,17 +2431,16 @@ func expandFlowAlertTypeDefinition(ctx context.Context, properties *alerts.Alert
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesFlow = &alerts.AlertDefPropertiesFlow{}
-	properties.AlertDefPropertiesFlow.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesFlow.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesFlow.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesFlow.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesFlow.GroupByKeys = groupBy
-	properties.AlertDefPropertiesFlow.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesFlow.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesFlow.EntityLabels = &labels
-	properties.AlertDefPropertiesFlow.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesFlow.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(flow) {
 		return properties, nil
 	}
@@ -2465,11 +2450,11 @@ func expandFlowAlertTypeDefinition(ctx context.Context, properties *alerts.Alert
 		return nil, diags
 	}
 
-	properties.AlertDefPropertiesFlow.Flow = alerts.FlowType{
+	properties.Flow = &alerts.FlowType{
 		Stages:             stages,
 		EnforceSuppression: flowModel.EnforceSuppression.ValueBoolPointer(),
 	}
-	properties.AlertDefPropertiesFlow.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_FLOW.Ptr()
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_FLOW.Ptr()
 	return properties, nil
 }
 
@@ -2608,17 +2593,16 @@ func expandSloThresholdAlertTypeDefinition(ctx context.Context, properties *aler
 	if diags.HasError() {
 		return nil, diags
 	}
-	properties.AlertDefPropertiesSloThreshold = &alerts.AlertDefPropertiesSloThreshold{}
-	properties.AlertDefPropertiesSloThreshold.Name = alertResourceModel.Name.ValueStringPointer()
-	properties.AlertDefPropertiesSloThreshold.Description = alertResourceModel.Description.ValueStringPointer()
-	properties.AlertDefPropertiesSloThreshold.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
-	properties.AlertDefPropertiesSloThreshold.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
-	properties.AlertDefPropertiesSloThreshold.GroupByKeys = groupBy
-	properties.AlertDefPropertiesSloThreshold.IncidentsSettings = incidentsSettings
-	properties.AlertDefPropertiesSloThreshold.NotificationGroup = notificationGroup
-	properties.AlertDefPropertiesSloThreshold.EntityLabels = &labels
-	properties.AlertDefPropertiesSloThreshold.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
-	properties.AlertDefPropertiesSloThreshold.ActiveOn = schedule
+	properties.Name = alertResourceModel.Name.ValueStringPointer()
+	properties.Description = alertResourceModel.Description.ValueStringPointer()
+	properties.Enabled = alertResourceModel.Enabled.ValueBoolPointer()
+	properties.Priority = alerttypes.AlertPrioritySchemaToProtoMap[extractAlertPriority(alertResourceModel.Priority)].Ptr()
+	properties.GroupByKeys = groupBy
+	properties.IncidentsSettings = incidentsSettings
+	properties.NotificationGroup = notificationGroup
+	properties.EntityLabels = &labels
+	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
+	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(sloThreshold) {
 		return properties, nil
 	}
@@ -2635,19 +2619,21 @@ func expandSloThresholdAlertTypeDefinition(ctx context.Context, properties *aler
 		if diags.HasError() {
 			return nil, diags
 		}
-		sloThresholdType.SloThresholdTypeErrorBudget = &alerts.SloThresholdTypeErrorBudget{ErrorBudget: *errorBudget, SloDefinition: sloDef}
+		sloThresholdType.ErrorBudget = errorBudget
+		sloThresholdType.SloDefinition = sloDef
 	} else if !utils.ObjIsNullOrUnknown(sloThresholdModel.BurnRate) {
 		burnRate, diags := extractSloBurnRateThreshold(ctx, sloThresholdModel.BurnRate)
 		if diags.HasError() {
 			return nil, diags
 		}
-		sloThresholdType.SloThresholdTypeBurnRate = &alerts.SloThresholdTypeBurnRate{BurnRate: *burnRate, SloDefinition: sloDef}
+		sloThresholdType.BurnRate = burnRate
+		sloThresholdType.SloDefinition = sloDef
 	} else {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Invalid SLO Threshold Type", "SLO Threshold must have either ErrorBudget or BurnRate defined")}
 	}
 
-	properties.AlertDefPropertiesSloThreshold.SloThreshold = sloThresholdType
-	properties.AlertDefPropertiesSloThreshold.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_SLO_THRESHOLD.Ptr()
+	properties.SloThreshold = &sloThresholdType
+	properties.Type = alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_SLO_THRESHOLD.Ptr()
 	return properties, nil
 }
 
@@ -2694,13 +2680,15 @@ func extractSloBurnRateThreshold(ctx context.Context, obj types.Object) (*alerts
 		if diags.HasError() {
 			return nil, diags
 		}
-		burnRate.BurnRateThresholdDual = &alerts.BurnRateThresholdDual{Dual: alerts.BurnRateTypeDual{TimeDuration: timeDuration}, Rules: rules}
+		burnRate.Dual = &alerts.BurnRateTypeDual{TimeDuration: timeDuration}
+		burnRate.Rules = rules
 	} else if !utils.ObjIsNullOrUnknown(model.Single) {
 		timeDuration, diags := extractSloTimeDuration(ctx, model.Single)
 		if diags.HasError() {
 			return nil, diags
 		}
-		burnRate.BurnRateThresholdSingle = &alerts.BurnRateThresholdSingle{Single: alerts.BurnRateTypeSingle{TimeDuration: timeDuration}, Rules: rules}
+		burnRate.Single = &alerts.BurnRateTypeSingle{TimeDuration: timeDuration}
+		burnRate.Rules = rules
 	} else {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Invalid SLO Burn Rate Type", "SLO Burn Rate must have either Dual or Single defined")}
 	}
@@ -2851,223 +2839,223 @@ func flattenAlert(ctx context.Context, alert alerts.AlertDef, currentSchedule *t
 }
 
 func getAlertName(alertDefProperties *alerts.AlertDefProperties) *string {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.Name
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.Name
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.Name
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.Name
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.Name
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.Name
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.Name
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.Name
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.Name
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.Name
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.Name
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.Name
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.Name
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.Name
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.Name
 	} else {
 		return nil
 	}
 }
 
 func getAlertDescription(alertDefProperties *alerts.AlertDefProperties) *string {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.Description
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.Description
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.Description
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.Description
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.Description
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.Description
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.Description
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.Description
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.Description
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.Description
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.Description
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.Description
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.Description
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.Description
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.Description
 	} else {
 		return nil
 	}
 }
 
 func getAlertEnabled(alertDefProperties *alerts.AlertDefProperties) *bool {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.Enabled
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.Enabled
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.Enabled
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.Enabled
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.Enabled
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.Enabled
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.Enabled
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.Enabled
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.Enabled
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.Enabled
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.Enabled
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.Enabled
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.Enabled
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.Enabled
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.Enabled
 	} else {
 		return nil
 	}
 }
 func getAlertIncidentSettings(alertDefProperties *alerts.AlertDefProperties) *alerts.AlertDefIncidentSettings {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.IncidentsSettings
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.IncidentsSettings
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.IncidentsSettings
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.IncidentsSettings
 	} else {
 		return nil
 	}
 }
 
 func getAlertEntityLabels(alertDefProperties *alerts.AlertDefProperties) *map[string]string {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.EntityLabels
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.EntityLabels
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.EntityLabels
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.EntityLabels
 	} else {
 		return nil
 	}
 }
 
 func getAlertNotificationGroup(alertDefProperties *alerts.AlertDefProperties) *alerts.AlertDefNotificationGroup {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.NotificationGroup
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.NotificationGroup
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.NotificationGroup
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.NotificationGroup
 	} else {
 		return nil
 	}
 }
 
 func getAlertPriority(alertDefProperties *alerts.AlertDefProperties) *alerts.AlertDefPriority {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.Priority
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.Priority
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.Priority
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.Priority
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.Priority
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.Priority
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.Priority
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.Priority
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.Priority
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.Priority
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.Priority
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.Priority
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.Priority
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.Priority
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.Priority
 	} else {
 		return alerts.ALERTDEFPRIORITY_ALERT_DEF_PRIORITY_P5_OR_UNSPECIFIED.Ptr()
 	}
@@ -3091,102 +3079,102 @@ func groupByKeysToStateValue(keys []string, alertDefProperties *alerts.AlertDefP
 // plan modifier (unknown when state null, state value when state set). Only for these do we
 // normalize empty group_by to [] instead of null on read.
 func alertTypeUsesGroupByPlanModifier(alertDefProperties *alerts.AlertDefProperties) bool {
-	return alertDefProperties.AlertDefPropertiesSloThreshold != nil ||
-		alertDefProperties.AlertDefPropertiesTracingThreshold != nil ||
-		alertDefProperties.AlertDefPropertiesFlow != nil
+	return alertDefProperties.SloThreshold != nil ||
+		alertDefProperties.TracingThreshold != nil ||
+		alertDefProperties.Flow != nil
 }
 
 func getAlertGroupByKeys(alertDefProperties *alerts.AlertDefProperties) []string {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.GroupByKeys
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.GroupByKeys
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.GroupByKeys
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.GroupByKeys
 	} else {
 		return nil
 	}
 }
 
 func getAlertPhantomMode(alertDefProperties *alerts.AlertDefProperties) *bool {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.PhantomMode
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.PhantomMode
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.PhantomMode
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.PhantomMode
 	} else {
 		return nil
 	}
 }
 
 func getAlertDeleted(alertDefProperties *alerts.AlertDefProperties) *bool {
-	if alertDefProperties.AlertDefPropertiesFlow != nil {
-		return alertDefProperties.AlertDefPropertiesFlow.Deleted
-	} else if alertDefProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesLogsImmediate.Deleted
-	} else if alertDefProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesMetricAnomaly.Deleted
-	} else if alertDefProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesSloThreshold.Deleted
-	} else if alertDefProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesTracingThreshold.Deleted
-	} else if alertDefProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertDefProperties.AlertDefPropertiesLogsUniqueCount.Deleted
-	} else if alertDefProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsThreshold.Deleted
-	} else if alertDefProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesMetricThreshold.Deleted
-	} else if alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsTimeRelativeThreshold.Deleted
-	} else if alertDefProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertDefProperties.AlertDefPropertiesLogsNewValue.Deleted
-	} else if alertDefProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertDefProperties.AlertDefPropertiesLogsRatioThreshold.Deleted
-	} else if alertDefProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertDefProperties.AlertDefPropertiesLogsAnomaly.Deleted
-	} else if alertDefProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertDefProperties.AlertDefPropertiesTracingImmediate.Deleted
+	if alertDefProperties.Flow != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.LogsImmediate != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.MetricAnomaly != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.SloThreshold != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.TracingThreshold != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.LogsUniqueCount != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.LogsThreshold != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.MetricThreshold != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.LogsTimeRelativeThreshold != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.LogsNewValue != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.LogsRatioThreshold != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.LogsAnomaly != nil {
+		return alertDefProperties.Deleted
+	} else if alertDefProperties.TracingImmediate != nil {
+		return alertDefProperties.Deleted
 	} else {
 		return nil
 	}
@@ -3250,11 +3238,11 @@ func flattenAdvancedTargetSettings(ctx context.Context, webhooksSettings []alert
 
 		integration := notification.Integration
 		if integration != nil {
-			if integrationIdType := integration.V3IntegrationTypeIntegrationId; integrationIdType != nil {
-				integrationID := strconv.FormatInt(integrationIdType.IntegrationId, 10)
+			if integration.IntegrationId != nil {
+				integrationID := strconv.FormatInt(*integration.IntegrationId, 10)
 				notificationModel.IntegrationID = types.StringValue(integrationID)
-			} else if integrationRecipientsType := integration.V3IntegrationTypeRecipients; integrationRecipientsType != nil {
-				notificationModel.Recipients = utils.StringSliceToTypeStringSet(integrationRecipientsType.Recipients.Emails)
+			} else if integration.Recipients != nil {
+				notificationModel.Recipients = utils.StringSliceToTypeStringSet(integration.Recipients.Emails)
 			}
 		}
 		notificationsModel = append(notificationsModel, &notificationModel)
@@ -3416,7 +3404,23 @@ func flattenAlertTypeDefinition(ctx context.Context, properties *alerts.AlertDef
 		return types.ObjectNull(alertschema.AlertTypeDefinitionAttr()), nil
 	}
 
-	alertTypeDefinitionModel := alerttypes.AlertTypeDefinitionModel{
+	alertTypeDefinitionModel := emptyAlertTypeDefinitionModel()
+	diags, handled := flattenLogsAlertTypeDefinition(ctx, properties, &alertTypeDefinitionModel)
+	if !handled {
+		diags, handled = flattenNonLogsAlertTypeDefinition(ctx, properties, &alertTypeDefinitionModel)
+	}
+	if !handled {
+		return types.ObjectNull(alertschema.AlertTypeDefinitionAttr()), diag.Diagnostics{diag.NewErrorDiagnostic("Invalid Alert Type Definition", "Alert Type Definition is not valid")}
+	}
+	if diags.HasError() {
+		return types.ObjectNull(alertschema.AlertTypeDefinitionAttr()), diags
+	}
+
+	return types.ObjectValueFrom(ctx, alertschema.AlertTypeDefinitionAttr(), alertTypeDefinitionModel)
+}
+
+func emptyAlertTypeDefinitionModel() alerttypes.AlertTypeDefinitionModel {
+	return alerttypes.AlertTypeDefinitionModel{
 		LogsImmediate:             types.ObjectNull(alertschema.LogsImmediateAttr()),
 		LogsThreshold:             types.ObjectNull(alertschema.LogsThresholdAttr()),
 		LogsAnomaly:               types.ObjectNull(alertschema.LogsAnomalyAttr()),
@@ -3431,42 +3435,72 @@ func flattenAlertTypeDefinition(ctx context.Context, properties *alerts.AlertDef
 		Flow:                      types.ObjectNull(alertschema.FlowAttr()),
 		SloThreshold:              types.ObjectNull(alertschema.SloThresholdAttr()),
 	}
-	var diags diag.Diagnostics
-	if logsImmediate := properties.AlertDefPropertiesLogsImmediate; logsImmediate != nil {
-		alertTypeDefinitionModel.LogsImmediate, diags = flattenLogsImmediate(ctx, &logsImmediate.LogsImmediate)
-	} else if logsThreshold := properties.AlertDefPropertiesLogsThreshold; logsThreshold != nil {
-		alertTypeDefinitionModel.LogsThreshold, diags = flattenLogsThreshold(ctx, &logsThreshold.LogsThreshold)
-	} else if logsAnomaly := properties.AlertDefPropertiesLogsAnomaly; logsAnomaly != nil {
-		alertTypeDefinitionModel.LogsAnomaly, diags = flattenLogsAnomaly(ctx, &logsAnomaly.LogsAnomaly)
-	} else if logsRatioThreshold := properties.AlertDefPropertiesLogsRatioThreshold; logsRatioThreshold != nil {
-		alertTypeDefinitionModel.LogsRatioThreshold, diags = flattenLogsRatioThreshold(ctx, &logsRatioThreshold.LogsRatioThreshold)
-	} else if logsNewValue := properties.AlertDefPropertiesLogsNewValue; logsNewValue != nil {
-		alertTypeDefinitionModel.LogsNewValue, diags = flattenLogsNewValue(ctx, &logsNewValue.LogsNewValue)
-	} else if logsUniqueCount := properties.AlertDefPropertiesLogsUniqueCount; logsUniqueCount != nil {
-		alertTypeDefinitionModel.LogsUniqueCount, diags = flattenLogsUniqueCount(ctx, &logsUniqueCount.LogsUniqueCount)
-	} else if logsTimeRelativeThreshold := properties.AlertDefPropertiesLogsTimeRelativeThreshold; logsTimeRelativeThreshold != nil {
-		alertTypeDefinitionModel.LogsTimeRelativeThreshold, diags = flattenLogsTimeRelativeThreshold(ctx, &logsTimeRelativeThreshold.LogsTimeRelativeThreshold)
-	} else if metricThreshold := properties.AlertDefPropertiesMetricThreshold; metricThreshold != nil {
-		alertTypeDefinitionModel.MetricThreshold, diags = flattenMetricThreshold(ctx, &metricThreshold.MetricThreshold)
-	} else if metricAnomaly := properties.AlertDefPropertiesMetricAnomaly; metricAnomaly != nil {
-		alertTypeDefinitionModel.MetricAnomaly, diags = flattenMetricAnomaly(ctx, &metricAnomaly.MetricAnomaly)
-	} else if tracingImmediate := properties.AlertDefPropertiesTracingImmediate; tracingImmediate != nil {
-		alertTypeDefinitionModel.TracingImmediate, diags = flattenTracingImmediate(ctx, &tracingImmediate.TracingImmediate)
-	} else if tracingThreshold := properties.AlertDefPropertiesTracingThreshold; tracingThreshold != nil {
-		alertTypeDefinitionModel.TracingThreshold, diags = flattenTracingThreshold(ctx, &tracingThreshold.TracingThreshold)
-	} else if flow := properties.AlertDefPropertiesFlow; flow != nil {
-		alertTypeDefinitionModel.Flow, diags = flattenFlow(ctx, &flow.Flow)
-	} else if sloThreshold := properties.AlertDefPropertiesSloThreshold; sloThreshold != nil {
-		alertTypeDefinitionModel.SloThreshold, diags = flattenSloThreshold(ctx, &sloThreshold.SloThreshold)
-	} else {
-		return types.ObjectNull(alertschema.AlertTypeDefinitionAttr()), diag.Diagnostics{diag.NewErrorDiagnostic("Invalid Alert Type Definition", "Alert Type Definition is not valid")}
-	}
+}
 
-	if diags.HasError() {
-		return types.ObjectNull(alertschema.AlertTypeDefinitionAttr()), diags
+func flattenLogsAlertTypeDefinition(ctx context.Context, properties *alerts.AlertDefProperties, model *alerttypes.AlertTypeDefinitionModel) (diag.Diagnostics, bool) {
+	switch {
+	case properties.LogsImmediate != nil:
+		diags := diag.Diagnostics(nil)
+		model.LogsImmediate, diags = flattenLogsImmediate(ctx, properties.LogsImmediate)
+		return diags, true
+	case properties.LogsThreshold != nil:
+		diags := diag.Diagnostics(nil)
+		model.LogsThreshold, diags = flattenLogsThreshold(ctx, properties.LogsThreshold)
+		return diags, true
+	case properties.LogsAnomaly != nil:
+		diags := diag.Diagnostics(nil)
+		model.LogsAnomaly, diags = flattenLogsAnomaly(ctx, properties.LogsAnomaly)
+		return diags, true
+	case properties.LogsRatioThreshold != nil:
+		diags := diag.Diagnostics(nil)
+		model.LogsRatioThreshold, diags = flattenLogsRatioThreshold(ctx, properties.LogsRatioThreshold)
+		return diags, true
+	case properties.LogsNewValue != nil:
+		diags := diag.Diagnostics(nil)
+		model.LogsNewValue, diags = flattenLogsNewValue(ctx, properties.LogsNewValue)
+		return diags, true
+	case properties.LogsUniqueCount != nil:
+		diags := diag.Diagnostics(nil)
+		model.LogsUniqueCount, diags = flattenLogsUniqueCount(ctx, properties.LogsUniqueCount)
+		return diags, true
+	case properties.LogsTimeRelativeThreshold != nil:
+		diags := diag.Diagnostics(nil)
+		model.LogsTimeRelativeThreshold, diags = flattenLogsTimeRelativeThreshold(ctx, properties.LogsTimeRelativeThreshold)
+		return diags, true
+	default:
+		return nil, false
 	}
+}
 
-	return types.ObjectValueFrom(ctx, alertschema.AlertTypeDefinitionAttr(), alertTypeDefinitionModel)
+func flattenNonLogsAlertTypeDefinition(ctx context.Context, properties *alerts.AlertDefProperties, model *alerttypes.AlertTypeDefinitionModel) (diag.Diagnostics, bool) {
+	switch {
+	case properties.MetricThreshold != nil:
+		diags := diag.Diagnostics(nil)
+		model.MetricThreshold, diags = flattenMetricThreshold(ctx, properties.MetricThreshold)
+		return diags, true
+	case properties.MetricAnomaly != nil:
+		diags := diag.Diagnostics(nil)
+		model.MetricAnomaly, diags = flattenMetricAnomaly(ctx, properties.MetricAnomaly)
+		return diags, true
+	case properties.TracingImmediate != nil:
+		diags := diag.Diagnostics(nil)
+		model.TracingImmediate, diags = flattenTracingImmediate(ctx, properties.TracingImmediate)
+		return diags, true
+	case properties.TracingThreshold != nil:
+		diags := diag.Diagnostics(nil)
+		model.TracingThreshold, diags = flattenTracingThreshold(ctx, properties.TracingThreshold)
+		return diags, true
+	case properties.Flow != nil:
+		diags := diag.Diagnostics(nil)
+		model.Flow, diags = flattenFlow(ctx, properties.Flow)
+		return diags, true
+	case properties.SloThreshold != nil:
+		diags := diag.Diagnostics(nil)
+		model.SloThreshold, diags = flattenSloThreshold(ctx, properties.SloThreshold)
+		return diags, true
+	default:
+		return nil, false
+	}
 }
 
 func flattenLogsImmediate(ctx context.Context, immediate *alerts.LogsImmediateType) (types.Object, diag.Diagnostics) {
@@ -4061,32 +4095,32 @@ func flattenAlertSchedule(ctx context.Context, alertProperties alerts.AlertDefPr
 }
 
 func getActiveOn(alertProperties alerts.AlertDefProperties) (*alerts.ActivitySchedule, diag.Diagnostics) {
-	if alertProperties.AlertDefPropertiesFlow != nil {
-		return alertProperties.AlertDefPropertiesFlow.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesLogsAnomaly != nil {
-		return alertProperties.AlertDefPropertiesLogsAnomaly.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesMetricAnomaly != nil {
-		return alertProperties.AlertDefPropertiesMetricAnomaly.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesLogsNewValue != nil {
-		return alertProperties.AlertDefPropertiesLogsNewValue.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesLogsUniqueCount != nil {
-		return alertProperties.AlertDefPropertiesLogsUniqueCount.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesLogsRatioThreshold != nil {
-		return alertProperties.AlertDefPropertiesLogsRatioThreshold.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesLogsTimeRelativeThreshold != nil {
-		return alertProperties.AlertDefPropertiesLogsTimeRelativeThreshold.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesMetricThreshold != nil {
-		return alertProperties.AlertDefPropertiesMetricThreshold.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesTracingThreshold != nil {
-		return alertProperties.AlertDefPropertiesTracingThreshold.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesLogsThreshold != nil {
-		return alertProperties.AlertDefPropertiesLogsThreshold.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesTracingImmediate != nil {
-		return alertProperties.AlertDefPropertiesTracingImmediate.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesLogsImmediate != nil {
-		return alertProperties.AlertDefPropertiesLogsImmediate.ActiveOn, nil
-	} else if alertProperties.AlertDefPropertiesSloThreshold != nil {
-		return alertProperties.AlertDefPropertiesSloThreshold.ActiveOn, nil
+	if alertProperties.Flow != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.LogsAnomaly != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.MetricAnomaly != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.LogsNewValue != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.LogsUniqueCount != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.LogsRatioThreshold != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.LogsTimeRelativeThreshold != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.MetricThreshold != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.TracingThreshold != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.LogsThreshold != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.TracingImmediate != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.LogsImmediate != nil {
+		return alertProperties.ActiveOn, nil
+	} else if alertProperties.SloThreshold != nil {
+		return alertProperties.ActiveOn, nil
 	}
 	return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unsupported Alert Type", "Received an unsupported alert type from the server.")}
 }
@@ -4269,13 +4303,13 @@ func flattenMissingValuesManagement(ctx context.Context, missingValues *alerts.M
 	if missingValues == nil {
 		return types.ObjectNull(alertschema.MissingValuesAttr()), nil
 	}
-	if replaceWithZero := missingValues.MetricMissingValuesReplaceWithZero; replaceWithZero != nil {
+	if replaceWithZero := missingValues.ReplaceWithZero; replaceWithZero != nil {
 		return types.ObjectValueFrom(ctx, alertschema.MissingValuesAttr(), alerttypes.MissingValuesModel{
-			ReplaceWithZero: types.BoolValue(replaceWithZero.ReplaceWithZero),
+			ReplaceWithZero: types.BoolPointerValue(replaceWithZero),
 		})
-	} else if minNonNullValuesPct := missingValues.MetricMissingValuesMinNonNullValuesPct; minNonNullValuesPct != nil {
+	} else if minNonNullValuesPct := missingValues.MinNonNullValuesPct; minNonNullValuesPct != nil {
 		return types.ObjectValueFrom(ctx, alertschema.MissingValuesAttr(), alerttypes.MissingValuesModel{
-			MinNonNullValuesPct: types.Int64Value(minNonNullValuesPct.MinNonNullValuesPct),
+			MinNonNullValuesPct: types.Int64PointerValue(minNonNullValuesPct),
 		})
 	} else {
 		return types.ObjectNull(alertschema.MissingValuesAttr()), diag.Diagnostics{diag.NewErrorDiagnostic("Invalid Missing Values Management", "Missing Values Management strategy not supported")}
@@ -4303,14 +4337,14 @@ func flattenMetricTimeWindow(timeWindow *alerts.MetricTimeWindow) types.String {
 	if timeWindow == nil {
 		return types.StringValue(alerttypes.MetricFilterOperationTypeProtoToSchemaMap[alerts.METRICTIMEWINDOWVALUE_METRIC_TIME_WINDOW_VALUE_MINUTES_1_OR_UNSPECIFIED])
 	}
-	if specificValue := timeWindow.MetricTimeWindowMetricTimeWindowSpecificValue; specificValue != nil {
-		metricTimeWindowSpecificValue := specificValue.MetricTimeWindowSpecificValue
+	if specificValue := timeWindow.MetricTimeWindowSpecificValue; specificValue != nil {
+		metricTimeWindowSpecificValue := *specificValue
 		if metricTimeWindowSpecificValue == "" {
 			metricTimeWindowSpecificValue = alerts.METRICTIMEWINDOWVALUE_METRIC_TIME_WINDOW_VALUE_MINUTES_1_OR_UNSPECIFIED
 		}
 		return types.StringValue(alerttypes.MetricFilterOperationTypeProtoToSchemaMap[metricTimeWindowSpecificValue])
-	} else if dynamicDuration := timeWindow.MetricTimeWindowMetricTimeWindowDynamicDuration; dynamicDuration != nil {
-		return types.StringValue(dynamicDuration.MetricTimeWindowDynamicDuration)
+	} else if dynamicDuration := timeWindow.MetricTimeWindowDynamicDuration; dynamicDuration != nil {
+		return types.StringPointerValue(dynamicDuration)
 	} else {
 		return types.StringValue(alerttypes.MetricFilterOperationTypeProtoToSchemaMap[alerts.METRICTIMEWINDOWVALUE_METRIC_TIME_WINDOW_VALUE_MINUTES_1_OR_UNSPECIFIED])
 	}
@@ -4743,15 +4777,15 @@ func flattenSloThreshold(ctx context.Context, slo *alerts.SloThresholdType) (typ
 		BurnRate:      types.ObjectNull(alertschema.SloBurnRateAttr()),
 	}
 
-	if burnRate := slo.SloThresholdTypeBurnRate; burnRate != nil {
-		burnRate, diags := flattenSloBurnRate(ctx, &burnRate.BurnRate)
+	if burnRate := slo.BurnRate; burnRate != nil {
+		burnRate, diags := flattenSloBurnRate(ctx, burnRate)
 		if diags.HasError() {
 			return types.ObjectNull(alertschema.SloThresholdAttr()), diags
 		}
 		sloModel.BurnRate = burnRate
 
-	} else if errorBudget := slo.SloThresholdTypeErrorBudget; errorBudget != nil {
-		errBudget, diags := flattenSloErrorBudget(ctx, &errorBudget.ErrorBudget)
+	} else if errorBudget := slo.ErrorBudget; errorBudget != nil {
+		errBudget, diags := flattenSloErrorBudget(ctx, errorBudget)
 		if diags.HasError() {
 			return types.ObjectNull(alertschema.SloThresholdAttr()), diags
 		}
@@ -4762,23 +4796,10 @@ func flattenSloThreshold(ctx context.Context, slo *alerts.SloThresholdType) (typ
 }
 
 func getSloId(slo *alerts.SloThresholdType) *string {
-	if errorBudget := slo.SloThresholdTypeErrorBudget; errorBudget != nil {
-		if errorBudget.SloDefinition != nil {
-			return errorBudget.SloDefinition.SloId
-
-		} else {
-			return nil
-		}
-	} else if burnRate := slo.SloThresholdTypeBurnRate; burnRate != nil {
-		if burnRate.SloDefinition != nil {
-			return burnRate.SloDefinition.SloId
-
-		} else {
-			return nil
-		}
-	} else {
-		return nil
+	if slo.SloDefinition != nil {
+		return slo.SloDefinition.SloId
 	}
+	return nil
 }
 
 func flattenSloErrorBudget(ctx context.Context, errBudget *alerts.ErrorBudgetThreshold) (types.Object, diag.Diagnostics) {
@@ -4802,15 +4823,15 @@ func flattenSloBurnRate(ctx context.Context, burnRate *alerts.BurnRateThreshold)
 		Single: types.ObjectNull(alertschema.SloDurationWrapperAttr()),
 	}
 
-	if dual := burnRate.BurnRateThresholdDual; dual != nil {
-		td, diags := flattenSloTimeDuration(ctx, dual.Dual.TimeDuration)
+	if dual := burnRate.Dual; dual != nil {
+		td, diags := flattenSloTimeDuration(ctx, dual.TimeDuration)
 		if diags.HasError() {
 			return types.ObjectNull(alertschema.SloBurnRateAttr()), diags
 		}
 		burnRateModel.Dual = td
 
-	} else if single := burnRate.BurnRateThresholdSingle; single != nil {
-		td, diags := flattenSloTimeDuration(ctx, single.Single.TimeDuration)
+	} else if single := burnRate.Single; single != nil {
+		td, diags := flattenSloTimeDuration(ctx, single.TimeDuration)
 		if diags.HasError() {
 			return types.ObjectNull(alertschema.SloBurnRateAttr()), diags
 		}
@@ -4822,13 +4843,7 @@ func flattenSloBurnRate(ctx context.Context, burnRate *alerts.BurnRateThreshold)
 }
 
 func getBurnRateThresholdRules(slo *alerts.BurnRateThreshold) []alerts.SloThresholdRule {
-	if dual := slo.BurnRateThresholdDual; dual != nil {
-		return dual.Rules
-	} else if single := slo.BurnRateThresholdSingle; single != nil {
-		return single.Rules
-	} else {
-		return []alerts.SloThresholdRule{}
-	}
+	return slo.Rules
 }
 
 func flattenSloThresholdRules(ctx context.Context, rules []alerts.SloThresholdRule) (types.List, diag.Diagnostics) {

--- a/internal/provider/alerts/resource_coralogix_alerts_scheduler.go
+++ b/internal/provider/alerts/resource_coralogix_alerts_scheduler.go
@@ -406,6 +406,7 @@ func mergeScheduleFromPlan(ctx context.Context, stateModel *AlertsSchedulerResou
 	if utils.ObjIsNullOrUnknown(stateModel.Schedule) || utils.ObjIsNullOrUnknown(plan.Schedule) {
 		return nil
 	}
+
 	var stateSchedule ScheduleModel
 	if diags := stateModel.Schedule.As(ctx, &stateSchedule, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return diags
@@ -414,117 +415,144 @@ func mergeScheduleFromPlan(ctx context.Context, stateModel *AlertsSchedulerResou
 	if diags := plan.Schedule.As(ctx, &planSchedule, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return diags
 	}
-	// Recurring.dynamic.time_frame
-	if !(stateSchedule.Recurring.IsNull() || stateSchedule.Recurring.IsUnknown()) &&
-		!(planSchedule.Recurring.IsNull() || planSchedule.Recurring.IsUnknown()) {
-		var stateRecurring RecurringModel
-		if diags := stateSchedule.Recurring.As(ctx, &stateRecurring, basetypes.ObjectAsOptions{}); diags.HasError() {
-			return diags
-		}
-		var planRecurring RecurringModel
-		if diags := planSchedule.Recurring.As(ctx, &planRecurring, basetypes.ObjectAsOptions{}); diags.HasError() {
-			return diags
-		}
-		if !(stateRecurring.Dynamic.IsNull() || stateRecurring.Dynamic.IsUnknown()) &&
-			!(planRecurring.Dynamic.IsNull() || planRecurring.Dynamic.IsUnknown()) {
-			var stateDynamic DynamicModel
-			if diags := stateRecurring.Dynamic.As(ctx, &stateDynamic, basetypes.ObjectAsOptions{}); diags.HasError() {
-				return diags
-			}
-			var planDynamic DynamicModel
-			if diags := planRecurring.Dynamic.As(ctx, &planDynamic, basetypes.ObjectAsOptions{}); diags.HasError() {
-				return diags
-			}
-			if !(stateDynamic.TimeFrame.IsNull() || stateDynamic.TimeFrame.IsUnknown()) &&
-				!(planDynamic.TimeFrame.IsNull() || planDynamic.TimeFrame.IsUnknown()) {
-				var stateTF TimeFrameModel
-				if diags := stateDynamic.TimeFrame.As(ctx, &stateTF, basetypes.ObjectAsOptions{}); diags.HasError() {
-					return diags
-				}
-				var planTF TimeFrameModel
-				if diags := planDynamic.TimeFrame.As(ctx, &planTF, basetypes.ObjectAsOptions{}); diags.HasError() {
-					return diags
-				}
-				// Use plan's start_time when semantically equal so state matches plan.
-				if !planTF.StartTime.IsNull() && !planTF.StartTime.IsUnknown() &&
-					startTimeSemanticallyEqual(planTF.StartTime.ValueString(), stateTF.StartTime.ValueString()) {
-					stateTF.StartTime = planTF.StartTime
-				}
-				// Use plan's time_zone when equivalent (e.g. plan "UTC" vs state "UTC+0").
-				if !planTF.TimeZone.IsNull() && !planTF.TimeZone.IsUnknown() &&
-					timeZoneEquivalent(planTF.TimeZone.ValueString(), stateTF.TimeZone.ValueString()) {
-					stateTF.TimeZone = planTF.TimeZone
-				}
-				newTF, diags := types.ObjectValueFrom(ctx, timeFrameModelAttr(), stateTF)
-				if diags.HasError() {
-					return diags
-				}
-				stateDynamic.TimeFrame = newTF
-				newDynamic, diags := types.ObjectValueFrom(ctx, dynamicModelAttr(), stateDynamic)
-				if diags.HasError() {
-					return diags
-				}
-				stateRecurring.Dynamic = newDynamic
-				newRecurring, diags := types.ObjectValueFrom(ctx, recurringModelAttr(), stateRecurring)
-				if diags.HasError() {
-					return diags
-				}
-				stateSchedule.Recurring = newRecurring
-				newSchedule, diags := types.ObjectValueFrom(ctx, scheduleModelAttr(), stateSchedule)
-				if diags.HasError() {
-					return diags
-				}
-				stateModel.Schedule = newSchedule
-			}
-		}
+
+	recurringChanged, diags := mergeRecurringScheduleFromPlan(ctx, &stateSchedule, planSchedule)
+	if diags.HasError() {
+		return diags
 	}
-	// One_time.time_frame (same idea if we ever need it)
-	if !(stateSchedule.OneTime.IsNull() || stateSchedule.OneTime.IsUnknown()) &&
-		!(planSchedule.OneTime.IsNull() || planSchedule.OneTime.IsUnknown()) {
-		var stateOneTime OneTimeModel
-		if diags := stateSchedule.OneTime.As(ctx, &stateOneTime, basetypes.ObjectAsOptions{}); diags.HasError() {
-			return diags
-		}
-		var planOneTime OneTimeModel
-		if diags := planSchedule.OneTime.As(ctx, &planOneTime, basetypes.ObjectAsOptions{}); diags.HasError() {
-			return diags
-		}
-		if !(stateOneTime.TimeFrame.IsNull() || stateOneTime.TimeFrame.IsUnknown()) &&
-			!(planOneTime.TimeFrame.IsNull() || planOneTime.TimeFrame.IsUnknown()) {
-			var stateTF TimeFrameModel
-			if diags := stateOneTime.TimeFrame.As(ctx, &stateTF, basetypes.ObjectAsOptions{}); diags.HasError() {
-				return diags
-			}
-			var planTF TimeFrameModel
-			if diags := planOneTime.TimeFrame.As(ctx, &planTF, basetypes.ObjectAsOptions{}); diags.HasError() {
-				return diags
-			}
-			if !planTF.StartTime.IsNull() && !planTF.StartTime.IsUnknown() &&
-				startTimeSemanticallyEqual(planTF.StartTime.ValueString(), stateTF.StartTime.ValueString()) {
-				stateTF.StartTime = planTF.StartTime
-			}
-			if !planTF.TimeZone.IsNull() && !planTF.TimeZone.IsUnknown() &&
-				timeZoneEquivalent(planTF.TimeZone.ValueString(), stateTF.TimeZone.ValueString()) {
-				stateTF.TimeZone = planTF.TimeZone
-			}
-			newTF, diags := types.ObjectValueFrom(ctx, timeFrameModelAttr(), stateTF)
-			if diags.HasError() {
-				return diags
-			}
-			stateOneTime.TimeFrame = newTF
-			newOneTime, diags := types.ObjectValueFrom(ctx, oneTimeModelAttr(), stateOneTime)
-			if diags.HasError() {
-				return diags
-			}
-			stateSchedule.OneTime = newOneTime
-			newSchedule, diags := types.ObjectValueFrom(ctx, scheduleModelAttr(), stateSchedule)
-			if diags.HasError() {
-				return diags
-			}
-			stateModel.Schedule = newSchedule
-		}
+	oneTimeChanged, diags := mergeOneTimeScheduleFromPlan(ctx, &stateSchedule, planSchedule)
+	if diags.HasError() {
+		return diags
 	}
+	if !recurringChanged && !oneTimeChanged {
+		return nil
+	}
+
+	newSchedule, diags := types.ObjectValueFrom(ctx, scheduleModelAttr(), stateSchedule)
+	if diags.HasError() {
+		return diags
+	}
+	stateModel.Schedule = newSchedule
 	return nil
+}
+
+func mergeRecurringScheduleFromPlan(ctx context.Context, stateSchedule *ScheduleModel, planSchedule ScheduleModel) (bool, diag.Diagnostics) {
+	if utils.ObjIsNullOrUnknown(stateSchedule.Recurring) || utils.ObjIsNullOrUnknown(planSchedule.Recurring) {
+		return false, nil
+	}
+
+	var stateRecurring RecurringModel
+	if diags := stateSchedule.Recurring.As(ctx, &stateRecurring, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return false, diags
+	}
+	var planRecurring RecurringModel
+	if diags := planSchedule.Recurring.As(ctx, &planRecurring, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return false, diags
+	}
+	if utils.ObjIsNullOrUnknown(stateRecurring.Dynamic) || utils.ObjIsNullOrUnknown(planRecurring.Dynamic) {
+		return false, nil
+	}
+
+	var stateDynamic DynamicModel
+	if diags := stateRecurring.Dynamic.As(ctx, &stateDynamic, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return false, diags
+	}
+	var planDynamic DynamicModel
+	if diags := planRecurring.Dynamic.As(ctx, &planDynamic, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return false, diags
+	}
+
+	newTimeFrame, changed, diags := mergeTimeFrameFromPlan(ctx, stateDynamic.TimeFrame, planDynamic.TimeFrame)
+	if diags.HasError() || !changed {
+		return changed, diags
+	}
+
+	stateDynamic.TimeFrame = newTimeFrame
+	newDynamic, diags := types.ObjectValueFrom(ctx, dynamicModelAttr(), stateDynamic)
+	if diags.HasError() {
+		return false, diags
+	}
+	stateRecurring.Dynamic = newDynamic
+	newRecurring, diags := types.ObjectValueFrom(ctx, recurringModelAttr(), stateRecurring)
+	if diags.HasError() {
+		return false, diags
+	}
+	stateSchedule.Recurring = newRecurring
+	return true, nil
+}
+
+func mergeOneTimeScheduleFromPlan(ctx context.Context, stateSchedule *ScheduleModel, planSchedule ScheduleModel) (bool, diag.Diagnostics) {
+	if utils.ObjIsNullOrUnknown(stateSchedule.OneTime) || utils.ObjIsNullOrUnknown(planSchedule.OneTime) {
+		return false, nil
+	}
+
+	var stateOneTime OneTimeModel
+	if diags := stateSchedule.OneTime.As(ctx, &stateOneTime, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return false, diags
+	}
+	var planOneTime OneTimeModel
+	if diags := planSchedule.OneTime.As(ctx, &planOneTime, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return false, diags
+	}
+
+	newTimeFrame, changed, diags := mergeTimeFrameFromPlan(ctx, stateOneTime.TimeFrame, planOneTime.TimeFrame)
+	if diags.HasError() || !changed {
+		return changed, diags
+	}
+
+	stateOneTime.TimeFrame = newTimeFrame
+	newOneTime, diags := types.ObjectValueFrom(ctx, oneTimeModelAttr(), stateOneTime)
+	if diags.HasError() {
+		return false, diags
+	}
+	stateSchedule.OneTime = newOneTime
+	return true, nil
+}
+
+func mergeTimeFrameFromPlan(ctx context.Context, stateTimeFrame types.Object, planTimeFrame types.Object) (types.Object, bool, diag.Diagnostics) {
+	if utils.ObjIsNullOrUnknown(stateTimeFrame) || utils.ObjIsNullOrUnknown(planTimeFrame) {
+		return stateTimeFrame, false, nil
+	}
+
+	var stateTF TimeFrameModel
+	if diags := stateTimeFrame.As(ctx, &stateTF, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return stateTimeFrame, false, diags
+	}
+	var planTF TimeFrameModel
+	if diags := planTimeFrame.As(ctx, &planTF, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return stateTimeFrame, false, diags
+	}
+
+	changed := mergeStartTimeFromPlan(&stateTF, planTF)
+	changed = mergeTimeZoneFromPlan(&stateTF, planTF) || changed
+	if !changed {
+		return stateTimeFrame, false, nil
+	}
+
+	newTimeFrame, diags := types.ObjectValueFrom(ctx, timeFrameModelAttr(), stateTF)
+	return newTimeFrame, !diags.HasError(), diags
+}
+
+func mergeStartTimeFromPlan(stateTF *TimeFrameModel, planTF TimeFrameModel) bool {
+	if planTF.StartTime.IsNull() || planTF.StartTime.IsUnknown() {
+		return false
+	}
+	if !startTimeSemanticallyEqual(planTF.StartTime.ValueString(), stateTF.StartTime.ValueString()) {
+		return false
+	}
+	stateTF.StartTime = planTF.StartTime
+	return true
+}
+
+func mergeTimeZoneFromPlan(stateTF *TimeFrameModel, planTF TimeFrameModel) bool {
+	if planTF.TimeZone.IsNull() || planTF.TimeZone.IsUnknown() {
+		return false
+	}
+	if !timeZoneEquivalent(planTF.TimeZone.ValueString(), stateTF.TimeZone.ValueString()) {
+		return false
+	}
+	stateTF.TimeZone = planTF.TimeZone
+	return true
 }
 
 func timeFrameAttributes() map[string]schema.Attribute {
@@ -678,18 +706,18 @@ func flattenFilter(ctx context.Context, filter *alertscheduler.AlertSchedulerRul
 	}
 
 	var filterModel FilterModel
-	if filter.AlertSchedulerRuleProtobufV1FilterAlertMetaLabels != nil {
-		metaLabels, diags := flattenAlertsSchedulerMetaLabels(ctx, filter.AlertSchedulerRuleProtobufV1FilterAlertMetaLabels.AlertMetaLabels.GetValue())
+	if filter.AlertMetaLabels != nil {
+		metaLabels, diags := flattenAlertsSchedulerMetaLabels(ctx, filter.AlertMetaLabels.GetValue())
 		if diags.HasError() {
 			return types.ObjectNull(filterModelAttr()), diags
 		}
 		filterModel.MetaLabels = metaLabels
 		filterModel.AlertsUniqueIDs = types.SetNull(types.StringType)
-		filterModel.WhatExpression = types.StringValue(filter.AlertSchedulerRuleProtobufV1FilterAlertMetaLabels.GetWhatExpression())
-	} else if filter.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds != nil {
-		filterModel.AlertsUniqueIDs = utils.StringSliceToTypeStringSet(filter.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds.AlertUniqueIds.GetValue())
+		filterModel.WhatExpression = types.StringValue(filter.GetWhatExpression())
+	} else if filter.AlertUniqueIds != nil {
+		filterModel.AlertsUniqueIDs = utils.StringSliceToTypeStringSet(filter.AlertUniqueIds.GetValue())
 		filterModel.MetaLabels = types.SetNull(types.ObjectType{AttrTypes: labelModelAttr()})
-		filterModel.WhatExpression = types.StringValue(filter.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds.GetWhatExpression())
+		filterModel.WhatExpression = types.StringValue(filter.GetWhatExpression())
 	} else {
 		return types.ObjectNull(filterModelAttr()), diag.Diagnostics{diag.NewErrorDiagnostic("error flatten filter", "unknown filter type")}
 	}
@@ -715,17 +743,17 @@ func flattenSchedule(ctx context.Context, schedule *alertscheduler.Schedule) (ty
 	}
 
 	var scheduleModel ScheduleModel
-	if schedule.ScheduleOneTime != nil {
-		scheduleModel.Operation = types.StringValue(protoToSchemaScheduleOperation[schedule.ScheduleOneTime.GetScheduleOperation()])
-		oneTime, diags := flattenOneTime(ctx, &schedule.ScheduleOneTime.OneTime)
+	if schedule.OneTime != nil {
+		scheduleModel.Operation = types.StringValue(protoToSchemaScheduleOperation[schedule.GetScheduleOperation()])
+		oneTime, diags := flattenOneTime(ctx, schedule.OneTime)
 		if diags.HasError() {
 			return types.ObjectNull(scheduleModelAttr()), diags
 		}
 		scheduleModel.OneTime = oneTime
 		scheduleModel.Recurring = types.ObjectNull(recurringModelAttr())
-	} else if schedule.ScheduleRecurring != nil {
-		scheduleModel.Operation = types.StringValue(protoToSchemaScheduleOperation[schedule.ScheduleRecurring.GetScheduleOperation()])
-		recurring, diags := flattenRecurring(ctx, &schedule.ScheduleRecurring.Recurring)
+	} else if schedule.Recurring != nil {
+		scheduleModel.Operation = types.StringValue(protoToSchemaScheduleOperation[schedule.GetScheduleOperation()])
+		recurring, diags := flattenRecurring(ctx, schedule.Recurring)
 		if diags.HasError() {
 			return types.ObjectNull(scheduleModelAttr()), diags
 		}
@@ -744,14 +772,14 @@ func flattenRecurring(ctx context.Context, recurring *alertscheduler.Recurring) 
 	}
 
 	var recurringModel RecurringModel
-	if recurring.RecurringSchedule != nil {
-		dynamic, diags := flattenDynamic(ctx, &recurring.RecurringSchedule.Schedule)
+	if recurring.Schedule != nil {
+		dynamic, diags := flattenDynamic(ctx, recurring.Schedule)
 		if diags.HasError() {
 			return types.ObjectNull(recurringModelAttr()), diags
 		}
 		recurringModel.Dynamic = dynamic
 		recurringModel.AlwaysActive = types.BoolNull()
-	} else if recurring.RecurringAlwaysActive != nil {
+	} else if recurring.AlwaysActive != nil {
 		recurringModel.Dynamic = types.ObjectNull(dynamicModelAttr())
 		recurringModel.AlwaysActive = types.BoolValue(true)
 	} else {
@@ -775,27 +803,27 @@ func flattenDynamic(ctx context.Context, dynamic *alertscheduler.RecurringDynami
 	var repeatEvery int32
 	var terminationDate string
 
-	if dynamic.RecurringDynamicDaily != nil {
-		timeFrame, diags = flattenAlertsSchedulerTimeFrame(ctx, dynamic.RecurringDynamicDaily.Timeframe)
+	if dynamic.Daily != nil {
+		timeFrame, diags = flattenAlertsSchedulerTimeFrame(ctx, dynamic.Timeframe)
 		if diags.HasError() {
 			return types.ObjectNull(dynamicModelAttr()), diags
 		}
-		repeatEvery = dynamic.RecurringDynamicDaily.GetRepeatEvery()
-		terminationDate = dynamic.RecurringDynamicDaily.GetTerminationDate()
-	} else if dynamic.RecurringDynamicWeekly != nil {
-		timeFrame, diags = flattenAlertsSchedulerTimeFrame(ctx, dynamic.RecurringDynamicWeekly.Timeframe)
+		repeatEvery = dynamic.GetRepeatEvery()
+		terminationDate = dynamic.GetTerminationDate()
+	} else if dynamic.Weekly != nil {
+		timeFrame, diags = flattenAlertsSchedulerTimeFrame(ctx, dynamic.Timeframe)
 		if diags.HasError() {
 			return types.ObjectNull(dynamicModelAttr()), diags
 		}
-		repeatEvery = dynamic.RecurringDynamicWeekly.GetRepeatEvery()
-		terminationDate = dynamic.RecurringDynamicWeekly.GetTerminationDate()
-	} else if dynamic.RecurringDynamicMonthly != nil {
-		timeFrame, diags = flattenAlertsSchedulerTimeFrame(ctx, dynamic.RecurringDynamicMonthly.Timeframe)
+		repeatEvery = dynamic.GetRepeatEvery()
+		terminationDate = dynamic.GetTerminationDate()
+	} else if dynamic.Monthly != nil {
+		timeFrame, diags = flattenAlertsSchedulerTimeFrame(ctx, dynamic.Timeframe)
 		if diags.HasError() {
 			return types.ObjectNull(dynamicModelAttr()), diags
 		}
-		repeatEvery = dynamic.RecurringDynamicMonthly.GetRepeatEvery()
-		terminationDate = dynamic.RecurringDynamicMonthly.GetTerminationDate()
+		repeatEvery = dynamic.GetRepeatEvery()
+		terminationDate = dynamic.GetTerminationDate()
 	} else {
 		return types.ObjectNull(dynamicModelAttr()), nil
 	}
@@ -816,20 +844,20 @@ func flattenFrequency(ctx context.Context, dynamic *alertscheduler.RecurringDyna
 	}
 
 	var frequencyModel FrequencyModel
-	if dynamic.RecurringDynamicDaily != nil {
+	if dynamic.Daily != nil {
 		frequencyModel.Daily = types.ObjectNull(map[string]attr.Type{})
 		frequencyModel.Weekly = types.ObjectNull(weeklyModelAttr())
 		frequencyModel.Monthly = types.ObjectNull(monthlyModelAttr())
-	} else if dynamic.RecurringDynamicWeekly != nil {
-		weekly, diags := flattenWeekly(ctx, &dynamic.RecurringDynamicWeekly.Weekly)
+	} else if dynamic.Weekly != nil {
+		weekly, diags := flattenWeekly(ctx, dynamic.Weekly)
 		if diags.HasError() {
 			return types.ObjectNull(frequencyModelAttr()), diags
 		}
 		frequencyModel.Weekly = weekly
 		frequencyModel.Daily = types.ObjectNull(map[string]attr.Type{})
 		frequencyModel.Monthly = types.ObjectNull(monthlyModelAttr())
-	} else if dynamic.RecurringDynamicMonthly != nil {
-		monthly, diags := flattenMonthly(ctx, &dynamic.RecurringDynamicMonthly.Monthly)
+	} else if dynamic.Monthly != nil {
+		monthly, diags := flattenMonthly(ctx, dynamic.Monthly)
 		if diags.HasError() {
 			return types.ObjectNull(frequencyModelAttr()), diags
 		}
@@ -895,17 +923,17 @@ func flattenAlertsSchedulerTimeFrame(ctx context.Context, timeFrame *alertschedu
 	}
 
 	var timeFrameModel TimeFrameModel
-	if timeFrame.TimeframeEndTime != nil {
+	if timeFrame.EndTime != nil {
 		// Normalize start_time to the format the API uses (no Z) so state is consistent after apply.
-		timeFrameModel.StartTime = types.StringValue(normalizeStartTimeFromAPI(timeFrame.TimeframeEndTime.GetStartTime()))
-		timeFrameModel.TimeZone = types.StringValue(timeFrame.TimeframeEndTime.GetTimezone())
-		timeFrameModel.EndTime = types.StringValue(timeFrame.TimeframeEndTime.GetEndTime())
+		timeFrameModel.StartTime = types.StringValue(normalizeStartTimeFromAPI(timeFrame.GetStartTime()))
+		timeFrameModel.TimeZone = types.StringValue(timeFrame.GetTimezone())
+		timeFrameModel.EndTime = types.StringPointerValue(timeFrame.EndTime)
 		timeFrameModel.Duration = types.ObjectNull(durationModelAttr())
-	} else if timeFrame.TimeframeDuration != nil {
-		timeFrameModel.StartTime = types.StringValue(normalizeStartTimeFromAPI(timeFrame.TimeframeDuration.GetStartTime()))
-		timeFrameModel.TimeZone = types.StringValue(timeFrame.TimeframeDuration.GetTimezone())
+	} else if timeFrame.Duration != nil {
+		timeFrameModel.StartTime = types.StringValue(normalizeStartTimeFromAPI(timeFrame.GetStartTime()))
+		timeFrameModel.TimeZone = types.StringValue(timeFrame.GetTimezone())
 		var diags diag.Diagnostics
-		timeFrameModel.Duration, diags = flattenAlertsSchedulerDuration(ctx, &timeFrame.TimeframeDuration.Duration)
+		timeFrameModel.Duration, diags = flattenAlertsSchedulerDuration(ctx, timeFrame.Duration)
 		if diags.HasError() {
 			return types.ObjectNull(timeFrameModelAttr()), diags
 		}
@@ -1087,11 +1115,9 @@ func extractFilter(ctx context.Context, filter types.Object) (*alertscheduler.Al
 			return nil, diags
 		}
 		return &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
-			AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
-				WhatExpression: alertscheduler.PtrString(whatExpression),
-				AlertUniqueIds: alertscheduler.AlertUniqueIds{
-					Value: ids,
-				},
+			WhatExpression: alertscheduler.PtrString(whatExpression),
+			AlertUniqueIds: &alertscheduler.AlertUniqueIds{
+				Value: ids,
 			},
 		}, nil
 	} else if !(filterModel.MetaLabels.IsNull() || filterModel.MetaLabels.IsUnknown()) {
@@ -1100,21 +1126,17 @@ func extractFilter(ctx context.Context, filter types.Object) (*alertscheduler.Al
 			return nil, diags
 		}
 		return &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
-			AlertSchedulerRuleProtobufV1FilterAlertMetaLabels: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertMetaLabels{
-				WhatExpression: alertscheduler.PtrString(whatExpression),
-				AlertMetaLabels: alertscheduler.MetaLabels{
-					Value: metaLabels,
-				},
+			WhatExpression: alertscheduler.PtrString(whatExpression),
+			AlertMetaLabels: &alertscheduler.MetaLabels{
+				Value: metaLabels,
 			},
 		}, nil
 	}
 
 	return &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
-		AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
-			WhatExpression: alertscheduler.PtrString(whatExpression),
-			AlertUniqueIds: alertscheduler.AlertUniqueIds{
-				Value: nil,
-			},
+		WhatExpression: alertscheduler.PtrString(whatExpression),
+		AlertUniqueIds: &alertscheduler.AlertUniqueIds{
+			Value: nil,
 		},
 	}, nil
 }
@@ -1137,10 +1159,8 @@ func extractSchedule(ctx context.Context, schedule types.Object) (*alertschedule
 			return nil, diags
 		}
 		return &alertscheduler.Schedule{
-			ScheduleOneTime: &alertscheduler.ScheduleOneTime{
-				OneTime:           *oneTime,
-				ScheduleOperation: &operation,
-			},
+			OneTime:           oneTime,
+			ScheduleOperation: &operation,
 		}, nil
 	} else if !(scheduleModel.Recurring.IsNull() || scheduleModel.Recurring.IsUnknown()) {
 		recurring, diags := extractRecurring(ctx, scheduleModel.Recurring)
@@ -1148,10 +1168,8 @@ func extractSchedule(ctx context.Context, schedule types.Object) (*alertschedule
 			return nil, diags
 		}
 		return &alertscheduler.Schedule{
-			ScheduleRecurring: &alertscheduler.ScheduleRecurring{
-				Recurring:         *recurring,
-				ScheduleOperation: &operation,
-			},
+			Recurring:         recurring,
+			ScheduleOperation: &operation,
 		}, nil
 	}
 
@@ -1201,19 +1219,15 @@ func extractTimeFrame(ctx context.Context, timeFrame types.Object) (*alertschedu
 			return nil, diags
 		}
 		return &alertscheduler.Timeframe{
-			TimeframeDuration: &alertscheduler.TimeframeDuration{
-				StartTime: alertscheduler.PtrString(startTime),
-				Timezone:  alertscheduler.PtrString(timezone),
-				Duration:  *duration,
-			},
+			StartTime: alertscheduler.PtrString(startTime),
+			Timezone:  alertscheduler.PtrString(timezone),
+			Duration:  duration,
 		}, nil
 	} else if !(timeFrameModel.EndTime.IsNull() || timeFrameModel.EndTime.IsUnknown()) {
 		return &alertscheduler.Timeframe{
-			TimeframeEndTime: &alertscheduler.TimeframeEndTime{
-				StartTime: alertscheduler.PtrString(startTime),
-				Timezone:  alertscheduler.PtrString(timezone),
-				EndTime:   timeFrameModel.EndTime.ValueString(),
-			},
+			StartTime: alertscheduler.PtrString(startTime),
+			Timezone:  alertscheduler.PtrString(timezone),
+			EndTime:   timeFrameModel.EndTime.ValueStringPointer(),
 		}, nil
 	}
 
@@ -1251,18 +1265,14 @@ func extractRecurring(ctx context.Context, recurring types.Object) (*alertschedu
 			return nil, diags
 		}
 		return &alertscheduler.Recurring{
-			RecurringSchedule: &alertscheduler.RecurringSchedule{
-				Schedule: *dynamic,
-			},
+			Schedule: dynamic,
 		}, nil
 	}
 
 	// Handle always_active - permanent suppression rule
 	if !recurringModel.AlwaysActive.IsNull() && !recurringModel.AlwaysActive.IsUnknown() && recurringModel.AlwaysActive.ValueBool() {
 		return &alertscheduler.Recurring{
-			RecurringAlwaysActive: &alertscheduler.RecurringAlwaysActive{
-				AlwaysActive: map[string]interface{}{},
-			},
+			AlwaysActive: map[string]interface{}{},
 		}, nil
 	}
 
@@ -1301,12 +1311,10 @@ func expandFrequency(ctx context.Context, frequency types.Object, timeFrame *ale
 
 	if daily := frequencyModel.Daily; !(daily.IsNull() || daily.IsUnknown()) {
 		return &alertscheduler.RecurringDynamic{
-			RecurringDynamicDaily: &alertscheduler.RecurringDynamicDaily{
-				Daily:           make(map[string]interface{}),
-				Timeframe:       timeFrame,
-				RepeatEvery:     &repeatEvery,
-				TerminationDate: terminationDate,
-			},
+			Daily:           make(map[string]interface{}),
+			Timeframe:       timeFrame,
+			RepeatEvery:     &repeatEvery,
+			TerminationDate: terminationDate,
 		}, nil
 	} else if weekly := frequencyModel.Weekly; !(weekly.IsNull() || weekly.IsUnknown()) {
 		var weeklyModel WeeklyModel
@@ -1324,14 +1332,12 @@ func expandFrequency(ctx context.Context, frequency types.Object, timeFrame *ale
 		}
 
 		return &alertscheduler.RecurringDynamic{
-			RecurringDynamicWeekly: &alertscheduler.RecurringDynamicWeekly{
-				Weekly: alertscheduler.Weekly{
-					DaysOfWeek: daysValues,
-				},
-				Timeframe:       timeFrame,
-				RepeatEvery:     &repeatEvery,
-				TerminationDate: terminationDate,
+			Weekly: &alertscheduler.Weekly{
+				DaysOfWeek: daysValues,
 			},
+			Timeframe:       timeFrame,
+			RepeatEvery:     &repeatEvery,
+			TerminationDate: terminationDate,
 		}, nil
 	} else if monthly := frequencyModel.Monthly; !(monthly.IsNull() || monthly.IsUnknown()) {
 		var monthlyModel MonthlyModel
@@ -1345,14 +1351,12 @@ func expandFrequency(ctx context.Context, frequency types.Object, timeFrame *ale
 		}
 
 		return &alertscheduler.RecurringDynamic{
-			RecurringDynamicMonthly: &alertscheduler.RecurringDynamicMonthly{
-				Monthly: alertscheduler.Monthly{
-					DaysOfMonth: days,
-				},
-				Timeframe:       timeFrame,
-				RepeatEvery:     &repeatEvery,
-				TerminationDate: terminationDate,
+			Monthly: &alertscheduler.Monthly{
+				DaysOfMonth: days,
 			},
+			Timeframe:       timeFrame,
+			RepeatEvery:     &repeatEvery,
+			TerminationDate: terminationDate,
 		}, nil
 	}
 

--- a/internal/provider/alerts/resource_coralogix_alerts_scheduler_test.go
+++ b/internal/provider/alerts/resource_coralogix_alerts_scheduler_test.go
@@ -138,10 +138,8 @@ func TestFlattenFilterTreatsNilOrEmptyAlertIDsAsAllAlerts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filter := &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
-				AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
-					WhatExpression: alertscheduler.PtrString("source logs | filter true"),
-					AlertUniqueIds: alertscheduler.AlertUniqueIds{Value: tt.ids},
-				},
+				WhatExpression: alertscheduler.PtrString("source logs | filter true"),
+				AlertUniqueIds: &alertscheduler.AlertUniqueIds{Value: tt.ids},
 			}
 
 			got, diags := flattenFilter(ctx, filter)
@@ -170,10 +168,8 @@ func TestFlattenFilterTreatsNilOrEmptyAlertIDsAsAllAlerts(t *testing.T) {
 func TestFlattenFilterPreservesDirectAlertIDs(t *testing.T) {
 	ctx := context.Background()
 	filter := &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
-		AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
-			WhatExpression: alertscheduler.PtrString("source logs | filter true"),
-			AlertUniqueIds: alertscheduler.AlertUniqueIds{Value: []string{"alert-id-1", "alert-id-2"}},
-		},
+		WhatExpression: alertscheduler.PtrString("source logs | filter true"),
+		AlertUniqueIds: &alertscheduler.AlertUniqueIds{Value: []string{"alert-id-1", "alert-id-2"}},
 	}
 
 	got, diags := flattenFilter(ctx, filter)
@@ -211,10 +207,10 @@ func TestExtractFilterOmitsAlertIDsForAllAlerts(t *testing.T) {
 	if diags.HasError() {
 		t.Fatalf("extractFilter returned diagnostics: %v", diags)
 	}
-	if got.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds == nil {
+	if got.AlertUniqueIds == nil {
 		t.Fatal("extractFilter did not produce alert unique IDs filter for all-alert config")
 	}
-	if ids := got.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds.AlertUniqueIds.Value; ids != nil {
+	if ids := got.AlertUniqueIds.Value; ids != nil {
 		t.Fatalf("all-alert config should extract nil alert IDs, got %#v", ids)
 	}
 }

--- a/internal/provider/data_source_coralogix_global_router_test.go
+++ b/internal/provider/data_source_coralogix_global_router_test.go
@@ -24,7 +24,6 @@ import (
 var globalRouterDataSourceName = "data." + globalRouterResourceName
 
 func TestAccCoralogixDataSourceGlobalRouter_basic(t *testing.T) {
-	t.Skip("Skipping test due to a breaking change in BE")
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -42,8 +41,6 @@ func TestAccCoralogixDataSourceGlobalRouter_basic(t *testing.T) {
 }
 
 func TestAccCoralogixDataSourceGlobalRouterByName(t *testing.T) {
-	t.Skip("Skipping test due to a breaking change in BE")
-
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/data_source_coralogix_global_router_test.go
+++ b/internal/provider/data_source_coralogix_global_router_test.go
@@ -24,6 +24,7 @@ import (
 var globalRouterDataSourceName = "data." + globalRouterResourceName
 
 func TestAccCoralogixDataSourceGlobalRouter_basic(t *testing.T) {
+	t.Skip("Skipping test due to a breaking change in BE")
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -41,6 +42,8 @@ func TestAccCoralogixDataSourceGlobalRouter_basic(t *testing.T) {
 }
 
 func TestAccCoralogixDataSourceGlobalRouterByName(t *testing.T) {
+	t.Skip("Skipping test due to a breaking change in BE")
+
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -529,7 +529,7 @@ func flattenGetTCOPoliciesLogsList(ctx context.Context, getResp *tcoPolicys.GetC
 }
 
 func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPolicyLogsModel, diag.Diagnostics) {
-	logsPolicy := policy.PolicyLogRules
+	logsPolicy := policy
 
 	logRules := logsPolicy.LogRules
 	applications, diags := flattenTCOPolicyRule(ctx, logsPolicy.ApplicationRule)

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_traces.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_traces.go
@@ -565,7 +565,7 @@ func flattenGetTCOTracesPoliciesList(ctx context.Context, resp *tcoPolicys.GetCo
 
 func flattenTCOTracesPolicy(ctx context.Context, policy *tcoPolicys.Policy) (*TCOPolicyTracesModel, diag.Diagnostics) {
 
-	spanPolicy := policy.PolicySpanRules
+	spanPolicy := policy
 
 	traceRules := spanPolicy.SpanRules
 	applications, diags := flattenTCOPolicyRule(ctx, spanPolicy.ApplicationRule)

--- a/internal/provider/enrichment_rules/resource_coralogix_data_enrichments.go
+++ b/internal/provider/enrichment_rules/resource_coralogix_data_enrichments.go
@@ -633,11 +633,11 @@ func extractCustomEnrichmentsDataCreate(plan *DataEnrichmentsModel) *cess.Create
 		return &cess.CreateCustomEnrichmentRequest{
 			Name:        plan.Custom.CustomEnrichmentDataModel.Name.ValueString(),
 			Description: plan.Custom.CustomEnrichmentDataModel.Description.ValueString(),
-			File: cess.FileTextualAsFile(&cess.FileTextual{
+			File: cess.File{
 				Extension: &ext,
 				Name:      plan.Custom.CustomEnrichmentDataModel.Name.ValueStringPointer(),
-				Textual:   plan.Custom.CustomEnrichmentDataModel.Contents.ValueString(),
-			}),
+				Textual:   plan.Custom.CustomEnrichmentDataModel.Contents.ValueStringPointer(),
+			},
 		}
 	}
 	return nil
@@ -651,11 +651,9 @@ func extractCustomEnrichmentsDataUpdate(plan *DataEnrichmentsModel) *cess.Update
 			Name:               plan.Custom.CustomEnrichmentDataModel.Name.ValueString(),
 			Description:        plan.Custom.CustomEnrichmentDataModel.Description.ValueString(),
 			File: cess.File{
-				FileTextual: &cess.FileTextual{
-					Extension: &ext,
-					Name:      plan.Custom.CustomEnrichmentDataModel.Name.ValueStringPointer(),
-					Textual:   plan.Custom.CustomEnrichmentDataModel.Contents.ValueString(),
-				},
+				Extension: &ext,
+				Name:      plan.Custom.CustomEnrichmentDataModel.Name.ValueStringPointer(),
+				Textual:   plan.Custom.CustomEnrichmentDataModel.Contents.ValueStringPointer(),
 			},
 		}
 	}
@@ -668,10 +666,8 @@ func extractDataEnrichments(plan *DataEnrichmentsModel) []ess.EnrichmentRequestM
 	if plan.Aws != nil {
 		for _, f := range plan.Aws.Fields {
 			enrichmentType := ess.EnrichmentType{
-				EnrichmentTypeAws: &ess.EnrichmentTypeAws{
-					Aws: ess.AwsType{
-						ResourceType: f.Resource.ValueStringPointer(),
-					},
+				Aws: &ess.AwsType{
+					ResourceType: f.Resource.ValueStringPointer(),
 				},
 			}
 			requestModels = append(requestModels, ess.EnrichmentRequestModel{
@@ -685,13 +681,11 @@ func extractDataEnrichments(plan *DataEnrichmentsModel) []ess.EnrichmentRequestM
 
 	if plan.GeoIp != nil {
 		enrichmentType := ess.EnrichmentType{
-			EnrichmentTypeGeoIp: &ess.EnrichmentTypeGeoIp{
-				GeoIp: *ess.NewGeoIpType(),
-			},
+			GeoIp: ess.NewGeoIpType(),
 		}
 		for _, f := range plan.GeoIp.Fields {
 			if !(f.Asn.IsNull() || f.Asn.IsUnknown()) {
-				enrichmentType.EnrichmentTypeGeoIp.GeoIp.WithAsn = f.Asn.ValueBoolPointer()
+				enrichmentType.GeoIp.WithAsn = f.Asn.ValueBoolPointer()
 			}
 			requestModels = append(requestModels, ess.EnrichmentRequestModel{
 				EnrichedFieldName: f.EnrichedFieldName.ValueStringPointer(),
@@ -704,9 +698,7 @@ func extractDataEnrichments(plan *DataEnrichmentsModel) []ess.EnrichmentRequestM
 
 	if plan.SuspiciousIp != nil {
 		enrichmentType := ess.EnrichmentType{
-			EnrichmentTypeSuspiciousIp: &ess.EnrichmentTypeSuspiciousIp{
-				SuspiciousIp: map[string]any{},
-			},
+			SuspiciousIp: map[string]any{},
 		}
 		for _, f := range plan.SuspiciousIp.Fields {
 			requestModels = append(requestModels, ess.EnrichmentRequestModel{
@@ -723,10 +715,8 @@ func extractDataEnrichments(plan *DataEnrichmentsModel) []ess.EnrichmentRequestM
 		for _, f := range plan.Custom.Fields {
 
 			enrichmentType := ess.EnrichmentType{
-				EnrichmentTypeCustomEnrichment: &ess.EnrichmentTypeCustomEnrichment{
-					CustomEnrichment: ess.CustomEnrichmentType{
-						Id: id,
-					},
+				CustomEnrichment: &ess.CustomEnrichmentType{
+					Id: id,
 				},
 			}
 			requestModels = append(requestModels, ess.EnrichmentRequestModel{
@@ -766,7 +756,7 @@ func flattenDataEnrichments(enrichments []ess.Enrichment, uploadResp *cess.Custo
 	}
 
 	for _, e := range enrichments {
-		if e.EnrichmentType.EnrichmentTypeAws != nil {
+		if e.EnrichmentType.Aws != nil {
 			if model.Aws == nil {
 				model.Aws = &AwsEnrichmentFieldsModel{}
 			}
@@ -774,11 +764,11 @@ func flattenDataEnrichments(enrichments []ess.Enrichment, uploadResp *cess.Custo
 				EnrichedFieldName: types.StringPointerValue(e.EnrichedFieldName),
 				SelectedColumns:   utils.StringSliceToTypeStringSet(e.SelectedColumns),
 				Name:              types.StringValue(e.FieldName),
-				Resource:          types.StringPointerValue(e.EnrichmentType.EnrichmentTypeAws.Aws.ResourceType),
+				Resource:          types.StringPointerValue(e.EnrichmentType.Aws.ResourceType),
 				ID:                types.Int64Value(e.Id),
 			})
 			id = append(id, AWS_TYPE)
-		} else if e.EnrichmentType.EnrichmentTypeGeoIp != nil {
+		} else if e.EnrichmentType.GeoIp != nil {
 			if model.GeoIp == nil {
 				model.GeoIp = &GeoIpEnrichmentFieldsModel{}
 			}
@@ -787,10 +777,10 @@ func flattenDataEnrichments(enrichments []ess.Enrichment, uploadResp *cess.Custo
 				SelectedColumns:   utils.StringSliceToTypeStringSet(e.SelectedColumns),
 				Name:              types.StringValue(e.FieldName),
 				ID:                types.Int64Value(e.Id),
-				Asn:               types.BoolPointerValue(e.EnrichmentType.EnrichmentTypeGeoIp.GeoIp.WithAsn),
+				Asn:               types.BoolPointerValue(e.EnrichmentType.GeoIp.WithAsn),
 			})
 			id = append(id, GEOIP_TYPE)
-		} else if e.EnrichmentType.EnrichmentTypeSuspiciousIp != nil {
+		} else if e.EnrichmentType.SuspiciousIp != nil {
 			if model.SuspiciousIp == nil {
 				model.SuspiciousIp = &EnrichmentFieldsModel{}
 			}
@@ -801,7 +791,7 @@ func flattenDataEnrichments(enrichments []ess.Enrichment, uploadResp *cess.Custo
 				ID:                types.Int64Value(e.Id),
 			})
 			id = append(id, SUSIP_TYPE)
-		} else if e.EnrichmentType.EnrichmentTypeCustomEnrichment != nil {
+		} else if e.EnrichmentType.CustomEnrichment != nil {
 			if model.Custom == nil {
 				model.Custom = &CustomEnrichmentFieldsModel{}
 			}
@@ -832,16 +822,16 @@ func ExtractIdsFromEnrichment(fields []CoralogixEnrichment) []uint32 {
 func FilterEnrichmentByTypes(enrichments []ess.Enrichment, t string) []ess.Enrichment {
 	results := make([]ess.Enrichment, 0)
 	for _, e := range enrichments {
-		if t == AWS_TYPE && e.EnrichmentType.EnrichmentTypeAws != nil {
+		if t == AWS_TYPE && e.EnrichmentType.Aws != nil {
 			results = append(results, e)
 		}
-		if t == GEOIP_TYPE && e.EnrichmentType.EnrichmentTypeGeoIp != nil {
+		if t == GEOIP_TYPE && e.EnrichmentType.GeoIp != nil {
 			results = append(results, e)
 		}
-		if t == SUSIP_TYPE && e.EnrichmentType.EnrichmentTypeSuspiciousIp != nil {
+		if t == SUSIP_TYPE && e.EnrichmentType.SuspiciousIp != nil {
 			results = append(results, e)
 		}
-		if t == CUSTOM_TYPE && e.EnrichmentType.EnrichmentTypeCustomEnrichment != nil {
+		if t == CUSTOM_TYPE && e.EnrichmentType.CustomEnrichment != nil {
 			results = append(results, e)
 		}
 	}

--- a/internal/provider/integrations/resource_coralogix_integration.go
+++ b/internal/provider/integrations/resource_coralogix_integration.go
@@ -133,9 +133,9 @@ func (r *IntegrationResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	if testResult.Result.TestIntegrationResultFailure != nil {
+	if testResult.Result.Failure != nil {
 		// TODO after the data structure is fixed, change to print the error message
-		newDiags := diag.Diagnostics{diag.NewErrorDiagnostic("Invalid integration configuration", fmt.Sprintf("API responded with an error: %v", testResult.Result.TestIntegrationResultFailure))}
+		newDiags := diag.Diagnostics{diag.NewErrorDiagnostic("Invalid integration configuration", fmt.Sprintf("API responded with an error: %v", testResult.Result.Failure))}
 		resp.Diagnostics.Append(newDiags...)
 		return
 	}
@@ -189,14 +189,8 @@ func KeysFromPlan(ctx context.Context, plan *IntegrationResourceModel) ([]string
 	parameters, diags := dynamicToParameters(plan.Parameters)
 	keys := make([]string, len(parameters))
 	for i, parameter := range parameters {
-		if parameter.ParameterStringList != nil {
-			keys[i] = *parameter.ParameterStringList.Key
-		} else if parameter.ParameterBooleanValue != nil {
-			keys[i] = *parameter.ParameterBooleanValue.Key
-		} else if parameter.ParameterStringValue != nil {
-			keys[i] = *parameter.ParameterStringValue.Key
-		} else if parameter.ParameterNumericValue != nil {
-			keys[i] = *parameter.ParameterNumericValue.Key
+		if parameter.Key != nil {
+			keys[i] = *parameter.Key
 		}
 	}
 	return keys, diags
@@ -247,21 +241,15 @@ func dynamicToParameters(planParameters types.Dynamic) ([]integrations.Parameter
 			param := integrations.Parameter{}
 			switch v := value.(type) {
 			case types.String:
-				param.ParameterStringValue = &integrations.ParameterStringValue{
-					StringValue: v.ValueString(),
-					Key:         &key,
-				}
+				param.StringValue = v.ValueStringPointer()
+				param.Key = &key
 			case types.Number:
 				f, _ := v.ValueBigFloat().Float64()
-				param.ParameterNumericValue = &integrations.ParameterNumericValue{
-					NumericValue: f,
-					Key:          &key,
-				}
+				param.NumericValue = &f
+				param.Key = &key
 			case types.Bool:
-				param.ParameterBooleanValue = &integrations.ParameterBooleanValue{
-					BooleanValue: v.ValueBool(),
-					Key:          &key,
-				}
+				param.BooleanValue = v.ValueBoolPointer()
+				param.Key = &key
 			case types.List:
 				stringlist, diags := collectionToParameters(v.Elements())
 				if diags.HasError() {
@@ -269,7 +257,7 @@ func dynamicToParameters(planParameters types.Dynamic) ([]integrations.Parameter
 				}
 
 				stringlist.Key = &key
-				param.ParameterStringList = stringlist
+				param = *stringlist
 			case types.Tuple:
 				stringlist, diags := collectionToParameters(v.Elements())
 
@@ -278,7 +266,7 @@ func dynamicToParameters(planParameters types.Dynamic) ([]integrations.Parameter
 				}
 
 				stringlist.Key = &key
-				param.ParameterStringList = stringlist
+				param = *stringlist
 			default:
 				return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Invalid parameter type", fmt.Sprintf("Invalid parameter type %v: %v", v, p))}
 			}
@@ -298,7 +286,7 @@ func hasKnownParameters(parameters types.Dynamic) bool {
 	return !parameters.IsUnderlyingValueNull() && !parameters.IsUnderlyingValueUnknown()
 }
 
-func collectionToParameters(elements []attr.Value) (*integrations.ParameterStringList, diag.Diagnostics) {
+func collectionToParameters(elements []attr.Value) (*integrations.Parameter, diag.Diagnostics) {
 	strings := make([]string, len(elements))
 	for i, value := range elements {
 		switch value := value.(type) {
@@ -310,8 +298,8 @@ func collectionToParameters(elements []attr.Value) (*integrations.ParameterStrin
 			return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Invalid parameter type", fmt.Sprintf("Invalid parameter type %v: %v", value, elements))}
 		}
 	}
-	return &integrations.ParameterStringList{
-		StringList: integrations.StringList{
+	return &integrations.Parameter{
+		StringList: &integrations.StringList{
 			Values: strings,
 		},
 	}, nil
@@ -337,47 +325,53 @@ func parametersToDynamic(parameters []integrations.Parameter, keys []string) (ty
 	obj := make(map[string]attr.Value, len(parameters))
 	t := make(map[string]attr.Type, len(parameters))
 	for _, parameter := range parameters {
-
-		if parameter.ParameterStringList != nil && includeParameter(keys, parameter.ParameterStringList.Key) {
-			v := parameter.ParameterStringList
-			values := make([]attr.Value, len(v.StringList.Values))
-			assignedTypes := make([]attr.Type, len(v.StringList.Values))
-			for i, value := range v.StringList.Values {
-				values[i] = types.StringValue(value)
-				assignedTypes[i] = types.StringType
-			}
-			parameters, diags := types.TupleValue(assignedTypes, values)
-			if diags.HasError() {
-				return types.Dynamic{}, diags
-			}
-			obj[*parameter.ParameterStringList.Key] = parameters
-			t[*parameter.ParameterStringList.Key] = types.TupleType{ElemTypes: assignedTypes}
-
-		} else if parameter.ParameterBooleanValue != nil && includeParameter(keys, parameter.ParameterBooleanValue.Key) {
-			obj[*parameter.ParameterBooleanValue.Key] = types.BoolValue(parameter.ParameterBooleanValue.BooleanValue)
-			t[*parameter.ParameterBooleanValue.Key] = types.BoolType
-
-		} else if parameter.ParameterStringValue != nil && includeParameter(keys, parameter.ParameterStringValue.Key) {
-			obj[*parameter.ParameterStringValue.Key] = types.StringValue(parameter.ParameterStringValue.StringValue)
-			t[*parameter.ParameterStringValue.Key] = types.StringType
-
-		} else if parameter.ParameterNumericValue != nil && includeParameter(keys, parameter.ParameterNumericValue.Key) {
-			obj[*parameter.ParameterNumericValue.Key] = types.NumberValue(big.NewFloat(parameter.ParameterNumericValue.NumericValue))
-			t[*parameter.ParameterNumericValue.Key] = types.NumberType
-
-		} else if parameter.ParameterApiKey != nil && includeParameter(keys, parameter.ParameterApiKey.Key) {
-			obj[*parameter.ParameterApiKey.Key] = types.StringPointerValue(parameter.ParameterApiKey.ApiKey.Value)
-			t[*parameter.ParameterApiKey.Key] = types.StringType
-
-		} else if parameter.ParameterSensitiveData != nil && includeParameter(keys, parameter.ParameterSensitiveData.Key) {
-			obj[*parameter.ParameterSensitiveData.Key] = types.StringValue("<redacted>")
-			t[*parameter.ParameterSensitiveData.Key] = types.StringType
-		} else {
-			log.Printf("[WARN] Invalid parameter type: %v", utils.FormatJSON(parameter))
+		if !includeParameter(keys, parameter.Key) {
+			continue
 		}
+
+		value, valueType, diags, ok := parameterToAttr(parameter)
+		if diags.HasError() {
+			return types.Dynamic{}, diags
+		}
+		if !ok {
+			log.Printf("[WARN] Invalid parameter type: %v", utils.FormatJSON(parameter))
+			continue
+		}
+
+		obj[*parameter.Key] = value
+		t[*parameter.Key] = valueType
 	}
 	val, e := types.ObjectValue(t, obj)
 	return types.DynamicValue(val), e
+}
+
+func parameterToAttr(parameter integrations.Parameter) (attr.Value, attr.Type, diag.Diagnostics, bool) {
+	if parameter.StringList != nil {
+		values := make([]attr.Value, len(parameter.StringList.Values))
+		assignedTypes := make([]attr.Type, len(parameter.StringList.Values))
+		for i, value := range parameter.StringList.Values {
+			values[i] = types.StringValue(value)
+			assignedTypes[i] = types.StringType
+		}
+		parameters, diags := types.TupleValue(assignedTypes, values)
+		return parameters, types.TupleType{ElemTypes: assignedTypes}, diags, true
+	}
+	if parameter.BooleanValue != nil {
+		return types.BoolPointerValue(parameter.BooleanValue), types.BoolType, nil, true
+	}
+	if parameter.StringValue != nil {
+		return types.StringPointerValue(parameter.StringValue), types.StringType, nil, true
+	}
+	if parameter.NumericValue != nil {
+		return types.NumberValue(big.NewFloat(*parameter.NumericValue)), types.NumberType, nil, true
+	}
+	if parameter.ApiKey != nil {
+		return types.StringPointerValue(parameter.ApiKey.Value), types.StringType, nil, true
+	}
+	if parameter.SensitiveData != nil {
+		return types.StringValue("<redacted>"), types.StringType, nil, true
+	}
+	return nil, nil, nil, false
 }
 
 func includeParameter(keys []string, key *string) bool {
@@ -453,9 +447,9 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	if testResult.Result.TestIntegrationResultFailure != nil {
+	if testResult.Result.Failure != nil {
 		// TODO after the data structure is fixed, change to print the error message
-		newDiags := diag.Diagnostics{diag.NewErrorDiagnostic("Invalid integration configuration", fmt.Sprintf("API responded with an error: %v", testResult.Result.TestIntegrationResultFailure))}
+		newDiags := diag.Diagnostics{diag.NewErrorDiagnostic("Invalid integration configuration", fmt.Sprintf("API responded with an error: %v", testResult.Result.Failure))}
 		resp.Diagnostics.Append(newDiags...)
 		return
 	}

--- a/internal/provider/integrations/resource_coralogix_integration_test.go
+++ b/internal/provider/integrations/resource_coralogix_integration_test.go
@@ -72,16 +72,12 @@ func TestIntegrationDetailWithNilKeysIncludesBackendParameters(t *testing.T) {
 			DefinitionVersion: &definitionVersion,
 			Parameters: []cxsdk.Parameter{
 				{
-					ParameterStringValue: &cxsdk.ParameterStringValue{
-						Key:         &applicationNameKey,
-						StringValue: "svc-as-code",
-					},
+					Key:         &applicationNameKey,
+					StringValue: cxsdk.PtrString("svc-as-code"),
 				},
 				{
-					ParameterBooleanValue: &cxsdk.ParameterBooleanValue{
-						Key:          &enabledKey,
-						BooleanValue: true,
-					},
+					Key:          &enabledKey,
+					BooleanValue: cxsdk.PtrBool(true),
 				},
 			},
 		},

--- a/internal/provider/integrations/resource_coralogix_webhook.go
+++ b/internal/provider/integrations/resource_coralogix_webhook.go
@@ -919,37 +919,27 @@ func (r WebhookResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 func expandWebhookType(ctx context.Context, plan *WebhookResourceModel) (*webhooks.OutgoingWebhookInputData, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	data := webhooks.OutgoingWebhookInputData{}
+	var data *webhooks.OutgoingWebhookInputData
 	if plan.CustomWebhook != nil {
-		data.OutgoingWebhookInputDataGenericWebhook, diags = expandGenericWebhook(ctx, plan.CustomWebhook)
-		data.OutgoingWebhookInputDataGenericWebhook.Name = plan.Name.ValueStringPointer()
+		data, diags = expandGenericWebhook(ctx, plan.CustomWebhook)
 	} else if plan.Slack != nil {
-		data.OutgoingWebhookInputDataSlack, diags = expandSlack(ctx, plan.Slack)
-		data.OutgoingWebhookInputDataSlack.Name = plan.Name.ValueStringPointer()
+		data, diags = expandSlack(ctx, plan.Slack)
 	} else if plan.PagerDuty != nil {
-		data.OutgoingWebhookInputDataPagerDuty = expandPagerDuty(plan.PagerDuty)
-		data.OutgoingWebhookInputDataPagerDuty.Name = plan.Name.ValueStringPointer()
+		data = expandPagerDuty(plan.PagerDuty)
 	} else if plan.SendLog != nil {
-		data.OutgoingWebhookInputDataSendLog = expandSendLog(plan.SendLog)
-		data.OutgoingWebhookInputDataSendLog.Name = plan.Name.ValueStringPointer()
+		data = expandSendLog(plan.SendLog)
 	} else if plan.EmailGroup != nil {
-		data.OutgoingWebhookInputDataEmailGroup, diags = expandEmailGroup(ctx, plan.EmailGroup)
-		data.OutgoingWebhookInputDataEmailGroup.Name = plan.Name.ValueStringPointer()
+		data, diags = expandEmailGroup(ctx, plan.EmailGroup)
 	} else if plan.MsTeamsWorkflow != nil {
-		data.OutgoingWebhookInputDataMsTeamsWorkflow = expandMicrosoftTeamsWorkflow(plan.MsTeamsWorkflow)
-		data.OutgoingWebhookInputDataMsTeamsWorkflow.Name = plan.Name.ValueStringPointer()
+		data = expandMicrosoftTeamsWorkflow(plan.MsTeamsWorkflow)
 	} else if plan.Jira != nil {
-		data.OutgoingWebhookInputDataJira = expandJira(plan.Jira)
-		data.OutgoingWebhookInputDataJira.Name = plan.Name.ValueStringPointer()
+		data = expandJira(plan.Jira)
 	} else if plan.Opsgenie != nil {
-		data.OutgoingWebhookInputDataOpsgenie = expandOpsgenie(plan.Opsgenie)
-		data.OutgoingWebhookInputDataOpsgenie.Name = plan.Name.ValueStringPointer()
+		data = expandOpsgenie(plan.Opsgenie)
 	} else if plan.Demisto != nil {
-		data.OutgoingWebhookInputDataDemisto = expandDemisto(plan.Demisto)
-		data.OutgoingWebhookInputDataDemisto.Name = plan.Name.ValueStringPointer()
+		data = expandDemisto(plan.Demisto)
 	} else if plan.EventBridge != nil {
-		data.OutgoingWebhookInputDataAwsEventBridge = expandEventBridge(plan.EventBridge)
-		data.OutgoingWebhookInputDataAwsEventBridge.Name = plan.Name.ValueStringPointer()
+		data = expandEventBridge(plan.EventBridge)
 	} else {
 		diags.AddError("Error expanding webhook type", "Unknown webhook type")
 	}
@@ -958,14 +948,15 @@ func expandWebhookType(ctx context.Context, plan *WebhookResourceModel) (*webhoo
 		return nil, diags
 	}
 
-	return &data, nil
+	data.Name = plan.Name.ValueStringPointer()
+	return data, nil
 }
 
-func expandEventBridge(bridge *EventBridgeModel) *webhooks.OutgoingWebhookInputDataAwsEventBridge {
+func expandEventBridge(bridge *EventBridgeModel) *webhooks.OutgoingWebhookInputData {
 	ty := webhooks.WEBHOOKTYPE_AWS_EVENT_BRIDGE
-	return &webhooks.OutgoingWebhookInputDataAwsEventBridge{
+	return &webhooks.OutgoingWebhookInputData{
 		Type: &ty,
-		AwsEventBridge: webhooks.AwsEventBridgeConfig{
+		AwsEventBridge: &webhooks.AwsEventBridgeConfig{
 			EventBusArn: bridge.EventBusARN.ValueStringPointer(),
 			Detail:      bridge.Detail.ValueStringPointer(),
 			DetailType:  bridge.DetailType.ValueStringPointer(),
@@ -975,16 +966,16 @@ func expandEventBridge(bridge *EventBridgeModel) *webhooks.OutgoingWebhookInputD
 	}
 }
 
-func expandMicrosoftTeamsWorkflow(microsoftTeams *MsTeamsWorkflowModel) *webhooks.OutgoingWebhookInputDataMsTeamsWorkflow {
+func expandMicrosoftTeamsWorkflow(microsoftTeams *MsTeamsWorkflowModel) *webhooks.OutgoingWebhookInputData {
 	ty := webhooks.WEBHOOKTYPE_MS_TEAMS_WORKFLOW
-	return &webhooks.OutgoingWebhookInputDataMsTeamsWorkflow{
+	return &webhooks.OutgoingWebhookInputData{
 		MsTeamsWorkflow: map[string]any{},
 		Type:            &ty,
 		Url:             utils.StringNullIfUnknown(microsoftTeams.URL),
 	}
 }
 
-func expandSlack(ctx context.Context, slack *SlackModel) (*webhooks.OutgoingWebhookInputDataSlack, diag.Diagnostics) {
+func expandSlack(ctx context.Context, slack *SlackModel) (*webhooks.OutgoingWebhookInputData, diag.Diagnostics) {
 	digests, diags := expandDigests(ctx, slack.NotifyAbout)
 	if diags.HasError() {
 		return nil, diags
@@ -1000,9 +991,9 @@ func expandSlack(ctx context.Context, slack *SlackModel) (*webhooks.OutgoingWebh
 		url = planUrl.ValueStringPointer()
 	}
 	ty := webhooks.WEBHOOKTYPE_SLACK
-	return &webhooks.OutgoingWebhookInputDataSlack{
+	return &webhooks.OutgoingWebhookInputData{
 		Url: url,
-		Slack: webhooks.SlackConfig{
+		Slack: &webhooks.SlackConfig{
 			Digests:     digests,
 			Attachments: attachments,
 		},
@@ -1062,7 +1053,7 @@ func expandDigest(digest webhooks.DigestType) webhooks.Digest {
 	}
 }
 
-func expandGenericWebhook(ctx context.Context, genericWebhook *CustomWebhookModel) (*webhooks.OutgoingWebhookInputDataGenericWebhook, diag.Diagnostics) {
+func expandGenericWebhook(ctx context.Context, genericWebhook *CustomWebhookModel) (*webhooks.OutgoingWebhookInputData, diag.Diagnostics) {
 	headers, diags := utils.TypeMapToStringMap(ctx, genericWebhook.Headers)
 	if diags.HasError() {
 		return nil, diags
@@ -1075,10 +1066,10 @@ func expandGenericWebhook(ctx context.Context, genericWebhook *CustomWebhookMode
 	method := webhooksSchemaToProtoMethod[genericWebhook.Method.ValueString()]
 	uuid := utils.UuidCreateIfNull(genericWebhook.UUID)
 	ty := webhooks.WEBHOOKTYPE_GENERIC
-	return &webhooks.OutgoingWebhookInputDataGenericWebhook{
+	return &webhooks.OutgoingWebhookInputData{
 		Type: &ty,
 		Url:  url,
-		GenericWebhook: webhooks.GenericWebhookConfig{
+		GenericWebhook: &webhooks.GenericWebhookConfig{
 			Uuid:    &uuid,
 			Method:  &method,
 			Headers: &headers,
@@ -1087,50 +1078,50 @@ func expandGenericWebhook(ctx context.Context, genericWebhook *CustomWebhookMode
 	}, nil
 }
 
-func expandPagerDuty(pagerDuty *PagerDutyModel) *webhooks.OutgoingWebhookInputDataPagerDuty {
+func expandPagerDuty(pagerDuty *PagerDutyModel) *webhooks.OutgoingWebhookInputData {
 	ty := webhooks.WEBHOOKTYPE_PAGERDUTY
-	return &webhooks.OutgoingWebhookInputDataPagerDuty{
+	return &webhooks.OutgoingWebhookInputData{
 		Type: &ty,
-		PagerDuty: webhooks.PagerDutyConfig{
+		PagerDuty: &webhooks.PagerDutyConfig{
 			ServiceKey: pagerDuty.ServiceKey.ValueStringPointer(),
 		},
 	}
 }
 
-func expandSendLog(sendLog *SendLogModel) *webhooks.OutgoingWebhookInputDataSendLog {
+func expandSendLog(sendLog *SendLogModel) *webhooks.OutgoingWebhookInputData {
 	uuid := utils.UuidCreateIfNull(sendLog.UUID)
 
 	ty := webhooks.WEBHOOKTYPE_SEND_LOG
-	return &webhooks.OutgoingWebhookInputDataSendLog{
+	return &webhooks.OutgoingWebhookInputData{
 		Type: &ty,
-		SendLog: webhooks.SendLogConfig{
+		SendLog: &webhooks.SendLogConfig{
 			Payload: sendLog.Payload.ValueStringPointer(),
 			Uuid:    &uuid,
 		},
 	}
 }
 
-func expandEmailGroup(ctx context.Context, emailGroup *EmailGroupModel) (*webhooks.OutgoingWebhookInputDataEmailGroup, diag.Diagnostics) {
+func expandEmailGroup(ctx context.Context, emailGroup *EmailGroupModel) (*webhooks.OutgoingWebhookInputData, diag.Diagnostics) {
 	emailAddresses, diags := utils.TypeStringElementsToStringSlice(ctx, emailGroup.Emails.Elements())
 	if diags.HasError() {
 		return nil, diags
 	}
 
 	ty := webhooks.WEBHOOKTYPE_EMAIL_GROUP
-	return &webhooks.OutgoingWebhookInputDataEmailGroup{
+	return &webhooks.OutgoingWebhookInputData{
 		Type: &ty,
-		EmailGroup: webhooks.EmailGroupConfig{
+		EmailGroup: &webhooks.EmailGroupConfig{
 			EmailAddresses: emailAddresses,
 		},
 	}, nil
 }
 
-func expandJira(jira *JiraModel) *webhooks.OutgoingWebhookInputDataJira {
+func expandJira(jira *JiraModel) *webhooks.OutgoingWebhookInputData {
 	ty := webhooks.WEBHOOKTYPE_JIRA
-	return &webhooks.OutgoingWebhookInputDataJira{
+	return &webhooks.OutgoingWebhookInputData{
 		Type: &ty,
 		Url:  utils.StringNullIfUnknown(jira.URL),
-		Jira: webhooks.JiraConfig{
+		Jira: &webhooks.JiraConfig{
 			ApiToken:   jira.ApiKey.ValueStringPointer(),
 			Email:      jira.Email.ValueStringPointer(),
 			ProjectKey: jira.ProjectID.ValueStringPointer(),
@@ -1138,21 +1129,21 @@ func expandJira(jira *JiraModel) *webhooks.OutgoingWebhookInputDataJira {
 	}
 }
 
-func expandOpsgenie(opsgenie *OpsgenieModel) *webhooks.OutgoingWebhookInputDataOpsgenie {
+func expandOpsgenie(opsgenie *OpsgenieModel) *webhooks.OutgoingWebhookInputData {
 	ty := webhooks.WEBHOOKTYPE_OPSGENIE
-	return &webhooks.OutgoingWebhookInputDataOpsgenie{
+	return &webhooks.OutgoingWebhookInputData{
 		Opsgenie: map[string]any{},
 		Type:     &ty,
 		Url:      utils.StringNullIfUnknown(opsgenie.URL)}
 }
 
-func expandDemisto(demisto *DemistoModel) *webhooks.OutgoingWebhookInputDataDemisto {
+func expandDemisto(demisto *DemistoModel) *webhooks.OutgoingWebhookInputData {
 	uuid := utils.UuidCreateIfNull(demisto.UUID)
 	ty := webhooks.WEBHOOKTYPE_DEMISTO
-	return &webhooks.OutgoingWebhookInputDataDemisto{
+	return &webhooks.OutgoingWebhookInputData{
 		Type: &ty,
 		Url:  utils.StringNullIfUnknown(demisto.URL),
-		Demisto: webhooks.DemistoConfig{
+		Demisto: &webhooks.DemistoConfig{
 			Uuid:    &uuid,
 			Payload: demisto.Payload.ValueStringPointer(),
 		},
@@ -1173,35 +1164,35 @@ func flattenWebhook(ctx context.Context, webhook *webhooks.OutgoingWebhook) (*We
 
 	var diags diag.Diagnostics
 
-	if webhook.OutgoingWebhookAwsEventBridge != nil {
-		result.EventBridge, result.ID, result.ExternalID, result.Name = flattenEventBridge(webhook.OutgoingWebhookAwsEventBridge)
-	} else if webhook.OutgoingWebhookDemisto != nil {
-		result.Demisto, result.ID, result.ExternalID, result.Name = flattenDemisto(webhook.OutgoingWebhookDemisto)
-	} else if webhook.OutgoingWebhookEmailGroup != nil {
-		result.EmailGroup, result.ID, result.ExternalID, result.Name = flattenEmailGroup(webhook.OutgoingWebhookEmailGroup)
-	} else if webhook.OutgoingWebhookGenericWebhook != nil {
-		result.CustomWebhook, result.ID, result.ExternalID, result.Name, diags = flattenGenericWebhook(ctx, webhook.OutgoingWebhookGenericWebhook)
-	} else if webhook.OutgoingWebhookJira != nil {
-		result.Jira, result.ID, result.ExternalID, result.Name = flattenJira(webhook.OutgoingWebhookJira)
-	} else if webhook.OutgoingWebhookMicrosoftTeams != nil {
-		result.MsTeams, result.ID, result.ExternalID, result.Name = flattenMicrosoftTeams(webhook.OutgoingWebhookMicrosoftTeams)
-	} else if webhook.OutgoingWebhookMsTeamsWorkflow != nil {
-		result.MsTeamsWorkflow, result.ID, result.ExternalID, result.Name = flattenMsTeamsWorkflow(webhook.OutgoingWebhookMsTeamsWorkflow)
-	} else if webhook.OutgoingWebhookOpsgenie != nil {
-		result.Opsgenie, result.ID, result.ExternalID, result.Name = flattenOpsgenie(webhook.OutgoingWebhookOpsgenie)
-	} else if webhook.OutgoingWebhookPagerDuty != nil {
-		result.PagerDuty, result.ID, result.ExternalID, result.Name = flattenPagerDuty(webhook.OutgoingWebhookPagerDuty)
-	} else if webhook.OutgoingWebhookSendLog != nil {
-		result.SendLog, result.ID, result.ExternalID, result.Name = flattenSendLog(webhook.OutgoingWebhookSendLog)
-	} else if webhook.OutgoingWebhookSlack != nil {
-		result.Slack, result.ID, result.ExternalID, result.Name, diags = flattenSlack(ctx, webhook.OutgoingWebhookSlack)
+	if webhook.AwsEventBridge != nil {
+		result.EventBridge, result.ID, result.ExternalID, result.Name = flattenEventBridge(webhook)
+	} else if webhook.Demisto != nil {
+		result.Demisto, result.ID, result.ExternalID, result.Name = flattenDemisto(webhook)
+	} else if webhook.EmailGroup != nil {
+		result.EmailGroup, result.ID, result.ExternalID, result.Name = flattenEmailGroup(webhook)
+	} else if webhook.GenericWebhook != nil {
+		result.CustomWebhook, result.ID, result.ExternalID, result.Name, diags = flattenGenericWebhook(ctx, webhook)
+	} else if webhook.Jira != nil {
+		result.Jira, result.ID, result.ExternalID, result.Name = flattenJira(webhook)
+	} else if webhook.MicrosoftTeams != nil {
+		result.MsTeams, result.ID, result.ExternalID, result.Name = flattenMicrosoftTeams(webhook)
+	} else if webhook.MsTeamsWorkflow != nil {
+		result.MsTeamsWorkflow, result.ID, result.ExternalID, result.Name = flattenMsTeamsWorkflow(webhook)
+	} else if webhook.Opsgenie != nil {
+		result.Opsgenie, result.ID, result.ExternalID, result.Name = flattenOpsgenie(webhook)
+	} else if webhook.PagerDuty != nil {
+		result.PagerDuty, result.ID, result.ExternalID, result.Name = flattenPagerDuty(webhook)
+	} else if webhook.SendLog != nil {
+		result.SendLog, result.ID, result.ExternalID, result.Name = flattenSendLog(webhook)
+	} else if webhook.Slack != nil {
+		result.Slack, result.ID, result.ExternalID, result.Name, diags = flattenSlack(ctx, webhook)
 	} else {
 		diags.AddError("Error flattening webhook", fmt.Sprintf("Unknown webhook type: %v", *webhook))
 	}
 	return result, diags
 }
 
-func flattenGenericWebhook(ctx context.Context, genericWebhook *webhooks.OutgoingWebhookGenericWebhook) (*CustomWebhookModel, types.String, types.String, types.String, diag.Diagnostics) {
+func flattenGenericWebhook(ctx context.Context, genericWebhook *webhooks.OutgoingWebhook) (*CustomWebhookModel, types.String, types.String, types.String, diag.Diagnostics) {
 	headers, diags := types.MapValueFrom(ctx, types.StringType, genericWebhook.GenericWebhook.Headers)
 	return &CustomWebhookModel{
 		UUID:    types.StringPointerValue(genericWebhook.GenericWebhook.Uuid),
@@ -1212,7 +1203,7 @@ func flattenGenericWebhook(ctx context.Context, genericWebhook *webhooks.Outgoin
 	}, types.StringPointerValue(genericWebhook.Id), utils.Int64ToStringValue(genericWebhook.ExternalId), types.StringPointerValue(genericWebhook.Name), diags
 }
 
-func flattenSlack(ctx context.Context, slack *webhooks.OutgoingWebhookSlack) (*SlackModel, types.String, types.String, types.String, diag.Diagnostics) {
+func flattenSlack(ctx context.Context, slack *webhooks.OutgoingWebhook) (*SlackModel, types.String, types.String, types.String, diag.Diagnostics) {
 	digests, diags := flattenDigests(ctx, slack.Slack.Digests)
 	if diags.HasError() {
 		return nil, types.StringNull(), types.StringNull(), types.StringNull(), diags
@@ -1272,13 +1263,13 @@ func flattenDigest(digest *webhooks.Digest) types.String {
 	return types.StringValue(webhooksProtoToSchemaSlackConfigDigestType[digest.GetType()])
 }
 
-func flattenPagerDuty(pagerDuty *webhooks.OutgoingWebhookPagerDuty) (*PagerDutyModel, types.String, types.String, types.String) {
+func flattenPagerDuty(pagerDuty *webhooks.OutgoingWebhook) (*PagerDutyModel, types.String, types.String, types.String) {
 	return &PagerDutyModel{
 		ServiceKey: types.StringPointerValue(pagerDuty.PagerDuty.ServiceKey),
 	}, types.StringPointerValue(pagerDuty.Id), utils.Int64ToStringValue(pagerDuty.ExternalId), types.StringPointerValue(pagerDuty.Name)
 }
 
-func flattenSendLog(sendLog *webhooks.OutgoingWebhookSendLog) (*SendLogModel, types.String, types.String, types.String) {
+func flattenSendLog(sendLog *webhooks.OutgoingWebhook) (*SendLogModel, types.String, types.String, types.String) {
 	return &SendLogModel{
 		UUID:    types.StringPointerValue(sendLog.SendLog.Uuid),
 		Payload: types.StringPointerValue(sendLog.SendLog.Payload),
@@ -1286,26 +1277,26 @@ func flattenSendLog(sendLog *webhooks.OutgoingWebhookSendLog) (*SendLogModel, ty
 	}, types.StringPointerValue(sendLog.Id), utils.Int64ToStringValue(sendLog.ExternalId), types.StringPointerValue(sendLog.Name)
 }
 
-func flattenEmailGroup(emailGroup *webhooks.OutgoingWebhookEmailGroup) (*EmailGroupModel, types.String, types.String, types.String) {
+func flattenEmailGroup(emailGroup *webhooks.OutgoingWebhook) (*EmailGroupModel, types.String, types.String, types.String) {
 	return &EmailGroupModel{
 		Emails: utils.StringSliceToTypeStringList(emailGroup.EmailGroup.EmailAddresses),
 	}, types.StringPointerValue(emailGroup.Id), utils.Int64ToStringValue(emailGroup.ExternalId), types.StringPointerValue(emailGroup.Name)
 }
 
-func flattenMsTeamsWorkflow(msteamswf *webhooks.OutgoingWebhookMsTeamsWorkflow) (*MsTeamsWorkflowModel, types.String, types.String, types.String) {
+func flattenMsTeamsWorkflow(msteamswf *webhooks.OutgoingWebhook) (*MsTeamsWorkflowModel, types.String, types.String, types.String) {
 	return &MsTeamsWorkflowModel{
 		URL: types.StringPointerValue(msteamswf.Url),
 	}, types.StringPointerValue(msteamswf.Id), utils.Int64ToStringValue(msteamswf.ExternalId), types.StringPointerValue(msteamswf.Name)
 }
 
 // Legacy webhook, is converted to MS Teams Workflow webhook
-func flattenMicrosoftTeams(msteams *webhooks.OutgoingWebhookMicrosoftTeams) (*MsTeamsWorkflowModel, types.String, types.String, types.String) {
+func flattenMicrosoftTeams(msteams *webhooks.OutgoingWebhook) (*MsTeamsWorkflowModel, types.String, types.String, types.String) {
 	return &MsTeamsWorkflowModel{
 		URL: types.StringPointerValue(msteams.Url),
 	}, types.StringPointerValue(msteams.Id), utils.Int64ToStringValue(msteams.ExternalId), types.StringPointerValue(msteams.Name)
 }
 
-func flattenJira(jira *webhooks.OutgoingWebhookJira) (*JiraModel, types.String, types.String, types.String) {
+func flattenJira(jira *webhooks.OutgoingWebhook) (*JiraModel, types.String, types.String, types.String) {
 	return &JiraModel{
 		ApiKey:    types.StringPointerValue(jira.Jira.ApiToken),
 		Email:     types.StringPointerValue(jira.Jira.Email),
@@ -1314,13 +1305,13 @@ func flattenJira(jira *webhooks.OutgoingWebhookJira) (*JiraModel, types.String, 
 	}, types.StringPointerValue(jira.Id), utils.Int64ToStringValue(jira.ExternalId), types.StringPointerValue(jira.Name)
 }
 
-func flattenOpsgenie(opsgenie *webhooks.OutgoingWebhookOpsgenie) (*OpsgenieModel, types.String, types.String, types.String) {
+func flattenOpsgenie(opsgenie *webhooks.OutgoingWebhook) (*OpsgenieModel, types.String, types.String, types.String) {
 	return &OpsgenieModel{
 		URL: types.StringPointerValue(opsgenie.Url),
 	}, types.StringPointerValue(opsgenie.Id), utils.Int64ToStringValue(opsgenie.ExternalId), types.StringPointerValue(opsgenie.Name)
 }
 
-func flattenDemisto(demisto *webhooks.OutgoingWebhookDemisto) (*DemistoModel, types.String, types.String, types.String) {
+func flattenDemisto(demisto *webhooks.OutgoingWebhook) (*DemistoModel, types.String, types.String, types.String) {
 	return &DemistoModel{
 		UUID:    types.StringPointerValue(demisto.Demisto.Uuid),
 		Payload: types.StringPointerValue(demisto.Demisto.Payload),
@@ -1328,7 +1319,7 @@ func flattenDemisto(demisto *webhooks.OutgoingWebhookDemisto) (*DemistoModel, ty
 	}, types.StringPointerValue(demisto.Id), utils.Int64ToStringValue(demisto.ExternalId), types.StringPointerValue(demisto.Name)
 }
 
-func flattenEventBridge(bridge *webhooks.OutgoingWebhookAwsEventBridge) (*EventBridgeModel, types.String, types.String, types.String) {
+func flattenEventBridge(bridge *webhooks.OutgoingWebhook) (*EventBridgeModel, types.String, types.String, types.String) {
 	return &EventBridgeModel{
 		EventBusARN: types.StringPointerValue(bridge.AwsEventBridge.EventBusArn),
 		Detail:      types.StringPointerValue(bridge.AwsEventBridge.Detail),

--- a/internal/provider/logs/data_source_coralogix_archive_logs.go
+++ b/internal/provider/logs/data_source_coralogix_archive_logs.go
@@ -91,7 +91,7 @@ func (d *ArchiveLogsDataSource) Read(ctx context.Context, req datasource.ReadReq
 		}
 		return
 	}
-	data = flattenArchiveLogs(result.Target.V2TargetS3, id)
+	data = flattenArchiveLogs(result.Target.S3, result.Target.ArchiveSpec, id)
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/logs/resource_coralogix_archive_logs.go
+++ b/internal/provider/logs/resource_coralogix_archive_logs.go
@@ -164,7 +164,7 @@ func (r *ArchiveLogsResource) Create(ctx context.Context, req resource.CreateReq
 	resp.Diagnostics.Append(diags...)
 }
 
-func flattenArchiveLogs(targetS3 *archiveLogs.S3TargetSpec, archiveSpec *archiveLogs.ArchiveSpec, id string) *ArchiveLogsResourceModel {
+func flattenArchiveLogs(targetS3 *archiveLogs.S3TargetSpec, archiveSpec archiveLogs.ArchiveSpec, id string) *ArchiveLogsResourceModel {
 	if targetS3 == nil {
 		return nil
 	}

--- a/internal/provider/logs/resource_coralogix_archive_logs.go
+++ b/internal/provider/logs/resource_coralogix_archive_logs.go
@@ -154,7 +154,7 @@ func (r *ArchiveLogsResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	plan = flattenArchiveLogs(result.Target.V2TargetS3, RESOURCE_ID_ARCHIVE_LOGS)
+	plan = flattenArchiveLogs(result.Target.S3, result.Target.ArchiveSpec, RESOURCE_ID_ARCHIVE_LOGS)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -164,24 +164,24 @@ func (r *ArchiveLogsResource) Create(ctx context.Context, req resource.CreateReq
 	resp.Diagnostics.Append(diags...)
 }
 
-func flattenArchiveLogs(targetS3 *archiveLogs.V2TargetS3, id string) *ArchiveLogsResourceModel {
+func flattenArchiveLogs(targetS3 *archiveLogs.S3TargetSpec, archiveSpec *archiveLogs.ArchiveSpec, id string) *ArchiveLogsResourceModel {
 	if targetS3 == nil {
 		return nil
 	}
 	return &ArchiveLogsResourceModel{
 		ID:                types.StringValue(id),
-		Active:            types.BoolValue(targetS3.ArchiveSpec.GetIsActive()),
-		Bucket:            types.StringValue(targetS3.GetS3().Bucket),
-		Region:            types.StringPointerValue(targetS3.GetS3().Region),
-		ArchivingFormatId: types.StringValue(targetS3.ArchiveSpec.GetArchivingFormatId()),
-		EnableTags:        types.BoolValue(targetS3.ArchiveSpec.GetEnableTags()),
+		Active:            types.BoolValue(archiveSpec.GetIsActive()),
+		Bucket:            types.StringValue(targetS3.Bucket),
+		Region:            types.StringPointerValue(targetS3.Region),
+		ArchivingFormatId: types.StringValue(archiveSpec.GetArchivingFormatId()),
+		EnableTags:        types.BoolValue(archiveSpec.GetEnableTags()),
 	}
 }
 
 func extractArchiveLogs(plan ArchiveLogsResourceModel) archiveLogs.SetTargetResponse {
 	return archiveLogs.SetTargetResponse{
 		IsActive: plan.Active.ValueBool(),
-		S3: &archiveLogs.S3TargetSpec{
+		S3: archiveLogs.S3TargetSpec{
 			Bucket: plan.Bucket.ValueString(),
 			Region: utils.TypeStringToStringPointer(plan.Region),
 		},
@@ -215,7 +215,7 @@ func (r *ArchiveLogsResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	state = flattenArchiveLogs(result.Target.V2TargetS3, id)
+	state = flattenArchiveLogs(result.Target.S3, result.Target.ArchiveSpec, id)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -251,7 +251,7 @@ func (r *ArchiveLogsResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	plan = flattenArchiveLogs(result.Target.V2TargetS3, plan.ID.ValueString())
+	plan = flattenArchiveLogs(result.Target.S3, result.Target.ArchiveSpec, plan.ID.ValueString())
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/metrics/resource_coralogix_archive_metrics.go
+++ b/internal/provider/metrics/resource_coralogix_archive_metrics.go
@@ -202,7 +202,7 @@ func (r *ArchiveMetricsResource) Create(ctx context.Context, req resource.Create
 	}
 	_, httpResponse, err := r.client.
 		MetricsConfiguratorPublicServiceConfigureTenant(ctx).
-		MetricsConfiguratorPublicServiceConfigureTenantRequest(*rq).
+		ConfigureTenantRequest(*rq).
 		Execute()
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating coralogix_archive_metrics",
@@ -285,7 +285,7 @@ func (r *ArchiveMetricsResource) Update(ctx context.Context, req resource.Update
 	}
 	_, httpResponse, err := r.client.
 		MetricsConfiguratorPublicServiceConfigureTenant(ctx).
-		MetricsConfiguratorPublicServiceConfigureTenantRequest(*rq).
+		ConfigureTenantRequest(*rq).
 		Execute()
 	if err != nil {
 		resp.Diagnostics.AddError("Error update coralogix_archive_metrics",
@@ -341,15 +341,15 @@ func flattenRetentionPolicy(ctx context.Context, policy *ams.RetentionPolicyRequ
 }
 
 func flattenStorageConfig(ctx context.Context, metricConfig *ams.TenantConfigV2) (*ArchiveMetricsResourceModel, diag.Diagnostics) {
-	if c := metricConfig.TenantConfigV2Ibm; c != nil {
-		retentionPolicy, diags := flattenRetentionPolicy(ctx, c.RetentionPolicy)
+	if metricConfig.Ibm != nil {
+		retentionPolicy, diags := flattenRetentionPolicy(ctx, metricConfig.RetentionPolicy)
 		if diags.HasError() {
 			return nil, diags
 		}
 
 		ibmConfig := &IBMConfigModel{
-			Endpoint: types.StringPointerValue(c.Ibm.Endpoint),
-			Crn:      types.StringPointerValue(c.Ibm.Crn),
+			Endpoint: types.StringPointerValue(metricConfig.Ibm.Endpoint),
+			Crn:      types.StringPointerValue(metricConfig.Ibm.Crn),
 		}
 		ibmConfigObject, diags := types.ObjectValueFrom(ctx, ibmConfigModelAttr(), ibmConfig)
 		if diags.HasError() {
@@ -357,29 +357,29 @@ func flattenStorageConfig(ctx context.Context, metricConfig *ams.TenantConfigV2)
 		}
 
 		return &ArchiveMetricsResourceModel{
-			TenantID:        types.Int64PointerValue(c.TenantId),
-			Prefix:          types.StringPointerValue(c.Prefix),
+			TenantID:        types.Int64PointerValue(metricConfig.TenantId),
+			Prefix:          types.StringPointerValue(metricConfig.Prefix),
 			RetentionPolicy: retentionPolicy,
 			IBM:             ibmConfigObject,
 			S3:              types.ObjectNull(s3ConfigModelAttr()),
 		}, diags
-	} else if c := metricConfig.TenantConfigV2S3; c != nil {
-		retentionPolicy, diags := flattenRetentionPolicy(ctx, c.RetentionPolicy)
+	} else if metricConfig.S3 != nil {
+		retentionPolicy, diags := flattenRetentionPolicy(ctx, metricConfig.RetentionPolicy)
 		if diags.HasError() {
 			return nil, diags
 		}
 
 		s3Config := &S3ConfigModel{
-			Bucket: types.StringPointerValue(c.S3.Bucket),
-			Region: types.StringPointerValue(c.S3.Region),
+			Bucket: types.StringPointerValue(metricConfig.S3.Bucket),
+			Region: types.StringPointerValue(metricConfig.S3.Region),
 		}
 		s3ConfigObject, diags := types.ObjectValueFrom(ctx, s3ConfigModelAttr(), s3Config)
 		if diags.HasError() {
 			return nil, diags
 		}
 		return &ArchiveMetricsResourceModel{
-			TenantID:        types.Int64PointerValue(c.TenantId),
-			Prefix:          types.StringPointerValue(c.Prefix),
+			TenantID:        types.Int64PointerValue(metricConfig.TenantId),
+			Prefix:          types.StringPointerValue(metricConfig.Prefix),
 			S3:              s3ConfigObject,
 			RetentionPolicy: retentionPolicy,
 			IBM:             types.ObjectNull(ibmConfigModelAttr()),
@@ -411,8 +411,8 @@ func s3ConfigModelAttr() map[string]attr.Type {
 	}
 }
 
-func extractArchiveMetrics(ctx context.Context, plan ArchiveMetricsResourceModel) (*ams.MetricsConfiguratorPublicServiceConfigureTenantRequest, diag.Diagnostics) {
-	tenantConfig := ams.MetricsConfiguratorPublicServiceConfigureTenantRequest{}
+func extractArchiveMetrics(ctx context.Context, plan ArchiveMetricsResourceModel) (*ams.ConfigureTenantRequest, diag.Diagnostics) {
+	tenantConfig := ams.ConfigureTenantRequest{}
 	retentionPolicy, diags := extractRetentionPolicies(ctx, plan.RetentionPolicy)
 	if diags.HasError() {
 		return nil, diags
@@ -423,26 +423,22 @@ func extractArchiveMetrics(ctx context.Context, plan ArchiveMetricsResourceModel
 		if diags.HasError() {
 			return nil, diags
 		}
-		tenantConfig.ConfigureTenantRequestIbm = &ams.ConfigureTenantRequestIbm{
-			Ibm: ams.IbmConfigV2{
-				Endpoint: ibmConfig.Endpoint.ValueStringPointer(),
-				Crn:      ibmConfig.Crn.ValueStringPointer(),
-			},
+		tenantConfig.Ibm = &ams.IbmConfigV2{
+			Endpoint: ibmConfig.Endpoint.ValueStringPointer(),
+			Crn:      ibmConfig.Crn.ValueStringPointer(),
 		}
-		tenantConfig.ConfigureTenantRequestIbm.RetentionPolicy = retentionPolicy
+		tenantConfig.RetentionPolicy = retentionPolicy
 	} else if !plan.S3.IsNull() {
 		var s3Config S3ConfigModel
 		diags := plan.S3.As(ctx, &s3Config, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, diags
 		}
-		tenantConfig.ConfigureTenantRequestS3 = &ams.ConfigureTenantRequestS3{
-			S3: ams.S3Config{
-				Bucket: s3Config.Bucket.ValueStringPointer(),
-				Region: s3Config.Region.ValueStringPointer(),
-			},
+		tenantConfig.S3 = &ams.S3Config{
+			Bucket: s3Config.Bucket.ValueStringPointer(),
+			Region: s3Config.Region.ValueStringPointer(),
 		}
-		tenantConfig.ConfigureTenantRequestS3.RetentionPolicy = retentionPolicy
+		tenantConfig.RetentionPolicy = retentionPolicy
 	}
 	return &tenantConfig, nil
 }

--- a/internal/provider/notifications/resource_coralogix_preset.go
+++ b/internal/provider/notifications/resource_coralogix_preset.go
@@ -474,9 +474,7 @@ func extractConditionType(ctx context.Context, conditionType types.Object) (*pre
 			return nil, diags
 		}
 		return &presets.NotificationCenterConditionType{
-			NotificationCenterConditionTypeMatchEntityType: &presets.NotificationCenterConditionTypeMatchEntityType{
-				MatchEntityType: map[string]any{},
-			},
+			MatchEntityType: map[string]any{},
 		}, nil
 	} else if matchEntityTypeAndSubType := condition.MatchEntityTypeAndSubType; !(matchEntityTypeAndSubType.IsNull() || matchEntityTypeAndSubType.IsUnknown()) {
 		var matchEntityTypeAndSubTypeModel MatchEntityTypeAndSubTypeModel
@@ -484,10 +482,8 @@ func extractConditionType(ctx context.Context, conditionType types.Object) (*pre
 			return nil, diags
 		}
 		return &presets.NotificationCenterConditionType{
-			NotificationCenterConditionTypeMatchEntityTypeAndSubType: &presets.NotificationCenterConditionTypeMatchEntityTypeAndSubType{
-				MatchEntityTypeAndSubType: presets.MatchEntityTypeAndSubTypeCondition{
-					EntitySubType: matchEntityTypeAndSubTypeModel.EntitySubType.ValueStringPointer(),
-				},
+			MatchEntityTypeAndSubType: &presets.MatchEntityTypeAndSubTypeCondition{
+				EntitySubType: matchEntityTypeAndSubTypeModel.EntitySubType.ValueStringPointer(),
 			},
 		}, nil
 	}
@@ -653,16 +649,16 @@ func flattenConditionType(ctx context.Context, condition *presets.NotificationCe
 	presetCondition.MatchEntityTypeAndSubType = types.ObjectNull(matchEntityTypeAndSubTypeAttr())
 	presetCondition.MatchEntityType = types.ObjectNull(matchEntityTypeTypeAttr())
 
-	if matchEntityType := condition.NotificationCenterConditionTypeMatchEntityType; matchEntityType != nil {
+	if condition.MatchEntityType != nil {
 		matchEntityType, diags := types.ObjectValueFrom(ctx, matchEntityTypeTypeAttr(), MatchEntityTypeModel{})
 		if diags.HasError() {
 			return types.ObjectNull(conditionTypeAttr()), diags
 		}
 		presetCondition.MatchEntityType = matchEntityType
 
-	} else if matchEntityTypeAndSubType := condition.NotificationCenterConditionTypeMatchEntityTypeAndSubType; matchEntityTypeAndSubType != nil {
+	} else if matchEntityTypeAndSubType := condition.MatchEntityTypeAndSubType; matchEntityTypeAndSubType != nil {
 		matchEntityTypeAndSubType, diags := types.ObjectValueFrom(ctx, matchEntityTypeAndSubTypeAttr(), MatchEntityTypeAndSubTypeModel{
-			EntitySubType: types.StringPointerValue(matchEntityTypeAndSubType.GetMatchEntityTypeAndSubType().EntitySubType),
+			EntitySubType: types.StringPointerValue(matchEntityTypeAndSubType.EntitySubType),
 		})
 		if diags.HasError() {
 			return types.ObjectNull(conditionTypeAttr()), diags

--- a/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
+++ b/internal/provider/parsing_rules/resource_coralogix_parsing_rules.go
@@ -543,17 +543,13 @@ func extractRuleMatchers(apps []types.String, subs []types.String, sevs []types.
 	ruleMatchers := make([]prgs.RuleMatcher, len(apps)+len(subs)+len(sevs))
 	for i, a := range apps {
 		ruleMatchers[i] = prgs.RuleMatcher{
-			RuleMatcherApplicationName: &prgs.RuleMatcherApplicationName{
-				ApplicationName: prgs.ApplicationNameConstraint{Value: a.ValueStringPointer()},
-			},
+			ApplicationName: &prgs.ApplicationNameConstraint{Value: a.ValueStringPointer()},
 		}
 	}
 
 	for i, s := range subs {
 		ruleMatchers[len(apps)+i] = prgs.RuleMatcher{
-			RuleMatcherSubsystemName: &prgs.RuleMatcherSubsystemName{
-				SubsystemName: prgs.SubsystemNameConstraint{Value: s.ValueStringPointer()},
-			},
+			SubsystemName: &prgs.SubsystemNameConstraint{Value: s.ValueStringPointer()},
 		}
 	}
 
@@ -561,9 +557,7 @@ func extractRuleMatchers(apps []types.String, subs []types.String, sevs []types.
 		if !(s.IsNull() && s.IsUnknown()) {
 			val := rulesSchemaSeverityToApiSeverity[s.ValueString()]
 			ruleMatchers[len(apps)+len(subs)+i] = prgs.RuleMatcher{
-				RuleMatcherSeverity: &prgs.RuleMatcherSeverity{
-					Severity: prgs.SeverityConstraint{Value: &val},
-				},
+				Severity: &prgs.SeverityConstraint{Value: &val},
 			}
 		}
 	}
@@ -788,20 +782,16 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 				var params prgs.RuleParameters
 				if r.BlockMatchingLogs.ValueBool() {
 					params = prgs.RuleParameters{
-						RuleParametersBlockParameters: &prgs.RuleParametersBlockParameters{
-							BlockParameters: prgs.BlockParameters{
-								KeepBlockedLogs: r.KeepBlockedLogs.ValueBoolPointer(),
-								Rule:            r.RegularExpression.ValueStringPointer(),
-							},
+						BlockParameters: &prgs.BlockParameters{
+							KeepBlockedLogs: r.KeepBlockedLogs.ValueBoolPointer(),
+							Rule:            r.RegularExpression.ValueStringPointer(),
 						},
 					}
 				} else {
 					params = prgs.RuleParameters{
-						RuleParametersAllowParameters: &prgs.RuleParametersAllowParameters{
-							AllowParameters: prgs.AllowParameters{
-								KeepBlockedLogs: r.KeepBlockedLogs.ValueBoolPointer(),
-								Rule:            r.RegularExpression.ValueStringPointer(),
-							},
+						AllowParameters: &prgs.AllowParameters{
+							KeepBlockedLogs: r.KeepBlockedLogs.ValueBoolPointer(),
+							Rule:            r.RegularExpression.ValueStringPointer(),
 						},
 					}
 				}
@@ -824,12 +814,10 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 					Order:       &order,
 					SourceField: &defaultSourceFieldName,
 					Parameters: &prgs.RuleParameters{
-						RuleParametersJsonExtractParameters: &prgs.RuleParametersJsonExtractParameters{
-							JsonExtractParameters: prgs.JsonExtractParameters{
-								DestinationFieldText: r.DestinationFieldText.ValueStringPointer(),
-								DestinationFieldType: &destinationField,
-								Rule:                 r.JsonKey.ValueStringPointer(),
-							},
+						JsonExtractParameters: &prgs.JsonExtractParameters{
+							DestinationFieldText: r.DestinationFieldText.ValueStringPointer(),
+							DestinationFieldType: &destinationField,
+							Rule:                 r.JsonKey.ValueStringPointer(),
 						},
 					},
 				})
@@ -842,12 +830,10 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 					Order:       &order,
 					SourceField: r.SourceField.ValueStringPointer(),
 					Parameters: &prgs.RuleParameters{
-						RuleParametersReplaceParameters: &prgs.RuleParametersReplaceParameters{
-							ReplaceParameters: prgs.ReplaceParameters{
-								DestinationField: r.DestinationField.ValueStringPointer(),
-								ReplaceNewVal:    r.ReplacementString.ValueStringPointer(),
-								Rule:             r.RegularExpression.ValueStringPointer(),
-							},
+						ReplaceParameters: &prgs.ReplaceParameters{
+							DestinationField: r.DestinationField.ValueStringPointer(),
+							ReplaceNewVal:    r.ReplacementString.ValueStringPointer(),
+							Rule:             r.RegularExpression.ValueStringPointer(),
 						},
 					},
 				})
@@ -862,11 +848,9 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 					Order:       &order,
 					SourceField: r.SourceField.ValueStringPointer(),
 					Parameters: &prgs.RuleParameters{
-						RuleParametersExtractTimestampParameters: &prgs.RuleParametersExtractTimestampParameters{
-							ExtractTimestampParameters: prgs.ExtractTimestampParameters{
-								Format:   r.TimeFormat.ValueStringPointer(),
-								Standard: &fmtStd,
-							},
+						ExtractTimestampParameters: &prgs.ExtractTimestampParameters{
+							Format:   r.TimeFormat.ValueStringPointer(),
+							Standard: &fmtStd,
 						},
 					},
 				})
@@ -880,10 +864,8 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 					Order:       &order,
 					SourceField: &defaultSourceFieldName,
 					Parameters: &prgs.RuleParameters{
-						RuleParametersRemoveFieldsParameters: &prgs.RuleParametersRemoveFieldsParameters{
-							RemoveFieldsParameters: prgs.RemoveFieldsParameters{
-								Fields: utils.TypeStringSliceToStringSlice(r.ExcludedFields),
-							},
+						RemoveFieldsParameters: &prgs.RemoveFieldsParameters{
+							Fields: utils.TypeStringSliceToStringSlice(r.ExcludedFields),
 						},
 					},
 				})
@@ -898,11 +880,9 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 					Order:       &order,
 					SourceField: r.SourceField.ValueStringPointer(),
 					Parameters: &prgs.RuleParameters{
-						RuleParametersJsonStringifyParameters: &prgs.RuleParametersJsonStringifyParameters{
-							JsonStringifyParameters: prgs.JsonStringifyParameters{
-								DeleteSource:     &deleteSource,
-								DestinationField: r.DestinationField.ValueStringPointer(),
-							},
+						JsonStringifyParameters: &prgs.JsonStringifyParameters{
+							DeleteSource:     &deleteSource,
+							DestinationField: r.DestinationField.ValueStringPointer(),
 						},
 					},
 				})
@@ -916,10 +896,8 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 					Order:       &order,
 					SourceField: r.SourceField.ValueStringPointer(),
 					Parameters: &prgs.RuleParameters{
-						RuleParametersExtractParameters: &prgs.RuleParametersExtractParameters{
-							ExtractParameters: prgs.ExtractParameters{
-								Rule: r.RegularExpression.ValueStringPointer(),
-							},
+						ExtractParameters: &prgs.ExtractParameters{
+							Rule: r.RegularExpression.ValueStringPointer(),
 						},
 					},
 				})
@@ -936,13 +914,11 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 					Order:       &order,
 					SourceField: r.SourceField.ValueStringPointer(),
 					Parameters: &prgs.RuleParameters{
-						RuleParametersJsonParseParameters: &prgs.RuleParametersJsonParseParameters{
-							JsonParseParameters: prgs.JsonParseParameters{
-								DeleteSource:     &deleteSource,
-								DestinationField: r.DestinationField.ValueStringPointer(),
-								EscapedValue:     &escapeValue,
-								OverrideDest:     &overrideDestination,
-							},
+						JsonParseParameters: &prgs.JsonParseParameters{
+							DeleteSource:     &deleteSource,
+							DestinationField: r.DestinationField.ValueStringPointer(),
+							EscapedValue:     &escapeValue,
+							OverrideDest:     &overrideDestination,
 						},
 					},
 				})
@@ -956,11 +932,9 @@ func extractRuleSubGroups(subgroups []RuleSubgroupsModel) []prgs.CreateRuleGroup
 					Order:       &order,
 					SourceField: r.SourceField.ValueStringPointer(),
 					Parameters: &prgs.RuleParameters{
-						RuleParametersParseParameters: &prgs.RuleParametersParseParameters{
-							ParseParameters: prgs.ParseParameters{
-								DestinationField: r.DestinationField.ValueStringPointer(),
-								Rule:             r.RegularExpression.ValueStringPointer(),
-							},
+						ParseParameters: &prgs.ParseParameters{
+							DestinationField: r.DestinationField.ValueStringPointer(),
+							Rule:             r.RegularExpression.ValueStringPointer(),
 						},
 					},
 				})
@@ -977,15 +951,15 @@ func flattenParsingRuleMatcher(ruleMatchers []prgs.RuleMatcher) ([]string, []str
 	severities := make([]string, 0)
 	for _, ruleMatcher := range ruleMatchers {
 
-		if ruleMatcher.RuleMatcherApplicationName != nil {
-			applications = append(applications, *ruleMatcher.RuleMatcherApplicationName.ApplicationName.Value)
+		if ruleMatcher.ApplicationName != nil {
+			applications = append(applications, *ruleMatcher.ApplicationName.Value)
 		}
-		if ruleMatcher.RuleMatcherSubsystemName != nil {
-			subsystems = append(subsystems, *ruleMatcher.RuleMatcherSubsystemName.SubsystemName.Value)
+		if ruleMatcher.SubsystemName != nil {
+			subsystems = append(subsystems, *ruleMatcher.SubsystemName.Value)
 
 		}
-		if ruleMatcher.RuleMatcherSeverity != nil {
-			severities = append(severities, rulesApiSeverityToSchemaSeverity[*ruleMatcher.RuleMatcherSeverity.Severity.Value])
+		if ruleMatcher.Severity != nil {
+			severities = append(severities, rulesApiSeverityToSchemaSeverity[*ruleMatcher.Severity.Value])
 
 		}
 	}
@@ -1007,7 +981,7 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 		for _, rule := range groups.Rules {
 			params := rule.Parameters
 
-			if p := params.RuleParametersAllowParameters; p != nil {
+			if p := params.AllowParameters; p != nil {
 				rules = append(rules, RuleSubgroupModel{
 					Block: &BlockModel{
 						ID:                types.StringPointerValue(rule.Id),
@@ -1016,13 +990,13 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Active:            types.BoolPointerValue(rule.Enabled),
 						Order:             types.Int64PointerValue(rule.Order),
 						SourceField:       types.StringPointerValue(rule.SourceField),
-						RegularExpression: types.StringPointerValue(p.AllowParameters.Rule),
-						KeepBlockedLogs:   types.BoolPointerValue(p.AllowParameters.KeepBlockedLogs),
+						RegularExpression: types.StringPointerValue(p.Rule),
+						KeepBlockedLogs:   types.BoolPointerValue(p.KeepBlockedLogs),
 						BlockMatchingLogs: types.BoolValue(false),
 					},
 				})
 			}
-			if p := params.RuleParametersBlockParameters; p != nil {
+			if p := params.BlockParameters; p != nil {
 				rules = append(rules, RuleSubgroupModel{
 					Block: &BlockModel{
 						ID:                types.StringPointerValue(rule.Id),
@@ -1031,13 +1005,13 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Active:            types.BoolPointerValue(rule.Enabled),
 						Order:             types.Int64PointerValue(rule.Order),
 						SourceField:       types.StringPointerValue(rule.SourceField),
-						RegularExpression: types.StringPointerValue(p.BlockParameters.Rule),
-						KeepBlockedLogs:   types.BoolPointerValue(p.BlockParameters.KeepBlockedLogs),
+						RegularExpression: types.StringPointerValue(p.Rule),
+						KeepBlockedLogs:   types.BoolPointerValue(p.KeepBlockedLogs),
 						BlockMatchingLogs: types.BoolValue(true),
 					},
 				})
 			}
-			if p := params.RuleParametersExtractParameters; p != nil {
+			if p := params.ExtractParameters; p != nil {
 				rules = append(rules, RuleSubgroupModel{
 					Extract: &ExtractModel{
 						ID:                types.StringPointerValue(rule.Id),
@@ -1046,13 +1020,13 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Active:            types.BoolPointerValue(rule.Enabled),
 						Order:             types.Int64PointerValue(rule.Order),
 						SourceField:       types.StringPointerValue(rule.SourceField),
-						RegularExpression: types.StringPointerValue(p.ExtractParameters.Rule),
+						RegularExpression: types.StringPointerValue(p.Rule),
 					},
 				})
 
 			}
-			if p := params.RuleParametersExtractTimestampParameters; p != nil {
-				fmtStd := rulesApiFormatStandardToSchemaFormatStandard[*p.ExtractTimestampParameters.Standard]
+			if p := params.ExtractTimestampParameters; p != nil {
+				fmtStd := rulesApiFormatStandardToSchemaFormatStandard[*p.Standard]
 				rules = append(rules, RuleSubgroupModel{
 					ExtractTimestamp: &ExtractTimestampModel{
 						ID:                  types.StringPointerValue(rule.Id),
@@ -1062,12 +1036,12 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Order:               types.Int64PointerValue(rule.Order),
 						SourceField:         types.StringPointerValue(rule.SourceField),
 						FieldFormatStandard: types.StringValue(fmtStd),
-						TimeFormat:          types.StringPointerValue(p.ExtractTimestampParameters.Format),
+						TimeFormat:          types.StringPointerValue(p.Format),
 					},
 				})
 			}
-			if p := params.RuleParametersJsonExtractParameters; p != nil {
-				destinationField := rulesApiDestinationFieldToSchemaDestinationField[*p.JsonExtractParameters.DestinationFieldType]
+			if p := params.JsonExtractParameters; p != nil {
+				destinationField := rulesApiDestinationFieldToSchemaDestinationField[*p.DestinationFieldType]
 				rules = append(rules, RuleSubgroupModel{
 					JsonExtract: &JsonExtractModel{
 						ID:                   types.StringPointerValue(rule.Id),
@@ -1076,14 +1050,14 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Active:               types.BoolPointerValue(rule.Enabled),
 						Order:                types.Int64PointerValue(rule.Order),
 						DestinationField:     types.StringValue(destinationField),
-						DestinationFieldText: types.StringPointerValue(p.JsonExtractParameters.DestinationFieldText),
-						JsonKey:              types.StringPointerValue(p.JsonExtractParameters.Rule),
+						DestinationFieldText: types.StringPointerValue(p.DestinationFieldText),
+						JsonKey:              types.StringPointerValue(p.Rule),
 					},
 				})
 			}
-			if p := params.RuleParametersJsonParseParameters; p != nil {
-				keepSourceField := !*p.JsonParseParameters.DeleteSource
-				keepDestinationField := !*p.JsonParseParameters.OverrideDest
+			if p := params.JsonParseParameters; p != nil {
+				keepSourceField := !*p.DeleteSource
+				keepDestinationField := !*p.OverrideDest
 
 				rules = append(rules, RuleSubgroupModel{
 					ParseJsonField: &ParseJsonFieldModel{
@@ -1093,14 +1067,14 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Active:               types.BoolPointerValue(rule.Enabled),
 						Order:                types.Int64PointerValue(rule.Order),
 						SourceField:          types.StringPointerValue(rule.SourceField),
-						DestinationField:     types.StringPointerValue(p.JsonParseParameters.DestinationField),
+						DestinationField:     types.StringPointerValue(p.DestinationField),
 						KeepSourceField:      types.BoolValue(keepSourceField),
 						KeepDestinationField: types.BoolValue(keepDestinationField),
 					},
 				})
 			}
-			if p := params.RuleParametersJsonStringifyParameters; p != nil {
-				keepSourceField := !*params.RuleParametersJsonStringifyParameters.JsonStringifyParameters.DeleteSource
+			if p := params.JsonStringifyParameters; p != nil {
+				keepSourceField := !*p.DeleteSource
 				rules = append(rules, RuleSubgroupModel{
 					JsonStringify: &JsonStringifyModel{
 						ID:               types.StringPointerValue(rule.Id),
@@ -1109,12 +1083,12 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Active:           types.BoolPointerValue(rule.Enabled),
 						Order:            types.Int64PointerValue(rule.Order),
 						SourceField:      types.StringPointerValue(rule.SourceField),
-						DestinationField: types.StringPointerValue(p.JsonStringifyParameters.DestinationField),
+						DestinationField: types.StringPointerValue(p.DestinationField),
 						KeepSourceField:  types.BoolValue(keepSourceField),
 					},
 				})
 			}
-			if p := params.RuleParametersParseParameters; p != nil {
+			if p := params.ParseParameters; p != nil {
 				rules = append(rules, RuleSubgroupModel{
 					Parse: &ParseModel{
 						ID:                types.StringPointerValue(rule.Id),
@@ -1123,12 +1097,12 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Active:            types.BoolPointerValue(rule.Enabled),
 						Order:             types.Int64PointerValue(rule.Order),
 						SourceField:       types.StringPointerValue(rule.SourceField),
-						DestinationField:  types.StringPointerValue(p.ParseParameters.DestinationField),
-						RegularExpression: types.StringPointerValue(p.ParseParameters.Rule),
+						DestinationField:  types.StringPointerValue(p.DestinationField),
+						RegularExpression: types.StringPointerValue(p.Rule),
 					},
 				})
 			}
-			if p := params.RuleParametersRemoveFieldsParameters; p != nil {
+			if p := params.RemoveFieldsParameters; p != nil {
 				rules = append(rules, RuleSubgroupModel{
 					RemoveFields: &RemoveFieldsModel{
 						ID:             types.StringPointerValue(rule.Id),
@@ -1136,11 +1110,11 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Description:    types.StringPointerValue(rule.Description),
 						Active:         types.BoolPointerValue(rule.Enabled),
 						Order:          types.Int64PointerValue(rule.Order),
-						ExcludedFields: utils.StringSliceToTypeStringSlice(p.RemoveFieldsParameters.Fields),
+						ExcludedFields: utils.StringSliceToTypeStringSlice(p.Fields),
 					},
 				})
 			}
-			if p := params.RuleParametersReplaceParameters; p != nil {
+			if p := params.ReplaceParameters; p != nil {
 				rules = append(rules, RuleSubgroupModel{
 					Replace: &ReplaceModel{
 						ID:                types.StringPointerValue(rule.Id),
@@ -1149,9 +1123,9 @@ func flattenRuleSubGroups(subgroups []prgs.RuleSubgroup) []RuleSubgroupsModel {
 						Active:            types.BoolPointerValue(rule.Enabled),
 						Order:             types.Int64PointerValue(rule.Order),
 						SourceField:       types.StringPointerValue(rule.SourceField),
-						DestinationField:  types.StringPointerValue(p.ReplaceParameters.DestinationField),
-						RegularExpression: types.StringPointerValue(p.ReplaceParameters.Rule),
-						ReplacementString: types.StringPointerValue(p.ReplaceParameters.ReplaceNewVal),
+						DestinationField:  types.StringPointerValue(p.DestinationField),
+						RegularExpression: types.StringPointerValue(p.Rule),
+						ReplacementString: types.StringPointerValue(p.ReplaceNewVal),
 					},
 				})
 			}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -61,3 +61,13 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatalf("CORALOGIX_ENV or CORALOGIX_DOMAIN must be set for acceptance tests")
 	}
 }
+
+func testAccRequiredEnvVarsPreCheck(t *testing.T, envVars ...string) {
+	testAccPreCheck(t)
+
+	for _, envVar := range envVars {
+		if os.Getenv(envVar) == "" {
+			t.Fatalf("%s must be set for acceptance tests", envVar)
+		}
+	}
+}

--- a/internal/provider/recording_rules/resource_coralogix_recording_rules_groups_set.go
+++ b/internal/provider/recording_rules/resource_coralogix_recording_rules_groups_set.go
@@ -766,7 +766,7 @@ func expandRecordingRuleGroup(ctx context.Context, group RecordingRuleGroupModel
 	}
 
 	return &recRuless.InRuleGroup{
-		Name:     group.Name.ValueStringPointer(),
+		Name:     group.Name.ValueString(),
 		Interval: interval,
 		Limit:    limit,
 		Rules:    rules,
@@ -803,8 +803,8 @@ func expandRecordingRule(ctx context.Context, rule RecordingRuleModel) (*recRule
 	}
 
 	return &recRuless.InRule{
-		Record: rule.Record.ValueStringPointer(),
-		Expr:   rule.Expr.ValueStringPointer(),
+		Record: rule.Record.ValueString(),
+		Expr:   rule.Expr.ValueString(),
 		Labels: &labels,
 	}, nil
 }
@@ -830,7 +830,7 @@ func (v recordingRulesGroupYamlContentValidator) ValidateString(_ context.Contex
 	}
 
 	for i, group := range set.Groups {
-		if group.Name == nil || *group.Name == "" {
+		if group.Name == "" {
 			resp.Diagnostics.AddError("error on validating yaml_content", fmt.Sprintf("groups[%d] name can not be empty", i))
 		}
 	}

--- a/internal/provider/resource_coralogix_alert_test.go
+++ b/internal/provider/resource_coralogix_alert_test.go
@@ -338,6 +338,8 @@ func TestAccCoralogixResourceAlert_custom_evaluation_delay_omitted_and_explicit(
 }
 
 func TestAccCoralogixResourceAlert_logs_less_than_with_routing(t *testing.T) {
+	t.Skip("Skipping test due to a breaking change in BE")
+
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -4234,6 +4236,8 @@ func testAccCoralogixResourceAlertWebhooksSettingsNoNotifications() string {
 }
 
 func TestAccCoralogixResourceAlert_group_by_keys_deletion(t *testing.T) {
+	t.Skip("Skipping test due to a breaking change in BE")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -4365,6 +4369,8 @@ func testAccCoralogixResourceAlertGroupByKeysPhantom() string {
 }
 
 func TestAccCoralogixResourceAlert_destinations_deletion(t *testing.T) {
+	t.Skip("Skipping test due to a breaking change in BE")
+
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/resource_coralogix_alert_test.go
+++ b/internal/provider/resource_coralogix_alert_test.go
@@ -1613,11 +1613,11 @@ func testAccGetAlertCustomEvaluationDelay(s *terraform.State, resourceName strin
 
 	alertDef := resp.GetAlertDef()
 	properties := alertDef.GetAlertDefProperties()
-	if properties.AlertDefPropertiesLogsThreshold == nil {
+	if properties.LogsThreshold == nil {
 		return 0, false, fmt.Errorf("alert %q is not a logs threshold alert", resourceName)
 	}
 
-	delay, ok := properties.AlertDefPropertiesLogsThreshold.LogsThreshold.GetEvaluationDelayMsOk()
+	delay, ok := properties.LogsThreshold.GetEvaluationDelayMsOk()
 	if !ok {
 		return 0, false, nil
 	}

--- a/internal/provider/resource_coralogix_alert_test.go
+++ b/internal/provider/resource_coralogix_alert_test.go
@@ -338,11 +338,16 @@ func TestAccCoralogixResourceAlert_custom_evaluation_delay_omitted_and_explicit(
 }
 
 func TestAccCoralogixResourceAlert_logs_less_than_with_routing(t *testing.T) {
-	t.Skip("Skipping test due to a breaking change in BE")
-
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccRequiredEnvVarsPreCheck(
+				t,
+				"SLACK_INTEGRATION_ID",
+				"SLACK_INTEGRATION_CHANNEL",
+				"SLACK_INTEGRATION_CHANNEL_UPDATED",
+			)
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckAlertDestroy,
 		Steps: []resource.TestStep{
@@ -2095,15 +2100,15 @@ func testAccCoralogixResourceAlertLogsLessThanWithRoutingUpdated(name string) st
       fields = [
         {
           field_name = "integrationId"
-          value      = "luigis-testing-grounds"
+          value      = "%[2]v"
         },
         {
           field_name = "fallbackChannel"
-          value      = "luigis-testing-grounds"
+          value      = "%[3]v"
         },
         {
           field_name = "channel"
-          value      = "luigis-testing-grounds"
+          value      = "%[3]v"
         }
       ]
     }
@@ -2227,7 +2232,7 @@ func testAccCoralogixResourceAlertLogsLessThanWithRoutingUpdated(name string) st
     }
   }
 }
-`, name)
+`, name, slackIntegrationId, slackIntegrationChannelUpdated)
 }
 
 func testAccCoralogixResourceAlertLogsLessThanWithRouter(name string) string {
@@ -2241,15 +2246,15 @@ func testAccCoralogixResourceAlertLogsLessThanWithRouter(name string) string {
       fields = [
         {
           field_name = "integrationId"
-          value      = "luigis-testing-grounds"
+          value      = "%[2]v"
         },
         {
           field_name = "fallbackChannel"
-          value      = "luigis-testing-grounds"
+          value      = "%[3]v"
         },
         {
           field_name = "channel"
-          value      = "luigis-testing-grounds"
+          value      = "%[3]v"
         }
       ]
     }
@@ -2379,7 +2384,7 @@ func testAccCoralogixResourceAlertLogsLessThanWithRouter(name string) string {
       ]
     }
   }
-}`, name)
+}`, name, slackIntegrationId, slackIntegrationChannel)
 }
 
 func testAccCoralogixResourceAlertLogsLessThanUpdated() string {
@@ -4236,8 +4241,6 @@ func testAccCoralogixResourceAlertWebhooksSettingsNoNotifications() string {
 }
 
 func TestAccCoralogixResourceAlert_group_by_keys_deletion(t *testing.T) {
-	t.Skip("Skipping test due to a breaking change in BE")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -4369,11 +4372,15 @@ func testAccCoralogixResourceAlertGroupByKeysPhantom() string {
 }
 
 func TestAccCoralogixResourceAlert_destinations_deletion(t *testing.T) {
-	t.Skip("Skipping test due to a breaking change in BE")
-
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccRequiredEnvVarsPreCheck(
+				t,
+				"SLACK_INTEGRATION_ID",
+				"SLACK_INTEGRATION_CHANNEL",
+			)
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckAlertDestroy,
 		Steps: []resource.TestStep{
@@ -4412,9 +4419,9 @@ func testAccCoralogixResourceAlertDestinationsFixtures(name string) string {
     description      = "slack connector example"
     connector_config = {
       fields = [
-        { field_name = "integrationId",   value = "luigis-testing-grounds" },
-        { field_name = "fallbackChannel", value = "luigis-testing-grounds" },
-        { field_name = "channel",         value = "luigis-testing-grounds" }
+        { field_name = "integrationId",   value = "%[2]v" },
+        { field_name = "fallbackChannel", value = "%[3]v" },
+        { field_name = "channel",         value = "%[3]v" }
       ]
     }
   }
@@ -4442,7 +4449,7 @@ func testAccCoralogixResourceAlertDestinationsFixtures(name string) string {
       }
     ]
   }
-`, name)
+`, name, slackIntegrationId, slackIntegrationChannel)
 }
 
 func testAccCoralogixResourceAlertDestinationsSet(name string) string {

--- a/internal/provider/resource_coralogix_alerts_scheduler_test.go
+++ b/internal/provider/resource_coralogix_alerts_scheduler_test.go
@@ -283,19 +283,13 @@ func testAccBackendAlertsScheduler(name string, alertIDs []string) alertschedule
 		Description: alertscheduler.PtrString("Imported parity scheduler"),
 		Enabled:     alertscheduler.PtrBool(true),
 		Filter: &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
-			AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
-				WhatExpression: alertscheduler.PtrString("source logs | filter true"),
-				AlertUniqueIds: alertscheduler.AlertUniqueIds{Value: alertIDs},
-			},
+			WhatExpression: alertscheduler.PtrString("source logs | filter true"),
+			AlertUniqueIds: &alertscheduler.AlertUniqueIds{Value: alertIDs},
 		},
 		Schedule: &alertscheduler.Schedule{
-			ScheduleRecurring: &alertscheduler.ScheduleRecurring{
-				ScheduleOperation: &operation,
-				Recurring: alertscheduler.Recurring{
-					RecurringAlwaysActive: &alertscheduler.RecurringAlwaysActive{
-						AlwaysActive: map[string]interface{}{},
-					},
-				},
+			ScheduleOperation: &operation,
+			Recurring: &alertscheduler.Recurring{
+				AlwaysActive: map[string]interface{}{},
 			},
 		},
 	}

--- a/internal/provider/resource_coralogix_connector_test.go
+++ b/internal/provider/resource_coralogix_connector_test.go
@@ -76,6 +76,8 @@ func TestAccCoralogixResourceGenericHttpsConnector(t *testing.T) {
 }
 
 func TestAccCoralogixResourceSlackConnector(t *testing.T) {
+	t.Skip("Skipping test due to a breaking change in BE")
+
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -174,6 +176,7 @@ func TestAccCoralogixResourcePagerdutyConnector(t *testing.T) {
 }
 
 func TestAccCoralogixResourcePagerdutyIncidentsConnector(t *testing.T) {
+	t.Skip("Skipping test due to a breaking change in BE")
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/resource_coralogix_connector_test.go
+++ b/internal/provider/resource_coralogix_connector_test.go
@@ -76,11 +76,16 @@ func TestAccCoralogixResourceGenericHttpsConnector(t *testing.T) {
 }
 
 func TestAccCoralogixResourceSlackConnector(t *testing.T) {
-	t.Skip("Skipping test due to a breaking change in BE")
-
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccRequiredEnvVarsPreCheck(
+				t,
+				"SLACK_INTEGRATION_ID",
+				"SLACK_INTEGRATION_CHANNEL",
+				"SLACK_INTEGRATION_CHANNEL_UPDATED",
+			)
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -92,15 +97,15 @@ func TestAccCoralogixResourceSlackConnector(t *testing.T) {
 					resource.TestCheckResourceAttr(connectorResourceName, "description", "test connector"),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "integrationId",
-						"value":      "luigis-testing-grounds",
+						"value":      slackIntegrationId,
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "channel",
-						"value":      "luigis-testing-grounds",
+						"value":      slackIntegrationChannel,
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "fallbackChannel",
-						"value":      "luigis-testing-grounds",
+						"value":      slackIntegrationChannel,
 					}),
 				),
 			},
@@ -118,15 +123,15 @@ func TestAccCoralogixResourceSlackConnector(t *testing.T) {
 					resource.TestCheckResourceAttr(connectorResourceName, "description", "test connector"),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "integrationId",
-						"value":      "luigis-testing-grounds-updated",
+						"value":      slackIntegrationId,
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "channel",
-						"value":      "luigis-testing-grounds-updated",
+						"value":      slackIntegrationChannelUpdated,
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "fallbackChannel",
-						"value":      "luigis-testing-grounds-updated",
+						"value":      slackIntegrationChannelUpdated,
 					}),
 				),
 			},
@@ -137,7 +142,12 @@ func TestAccCoralogixResourceSlackConnector(t *testing.T) {
 func TestAccCoralogixResourcePagerdutyConnector(t *testing.T) {
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccRequiredEnvVarsPreCheck(
+				t,
+				"PD_INTEGRATION_ID",
+			)
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -149,7 +159,7 @@ func TestAccCoralogixResourcePagerdutyConnector(t *testing.T) {
 					resource.TestCheckResourceAttr(connectorResourceName, "description", "test pagerduty connector"),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "integrationKey",
-						"value":      "integration-key-example",
+						"value":      pagerDutyIntegrationId,
 					}),
 				),
 			},
@@ -167,7 +177,7 @@ func TestAccCoralogixResourcePagerdutyConnector(t *testing.T) {
 					resource.TestCheckResourceAttr(connectorResourceName, "description", "test pagerduty connector updated"),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "integrationKey",
-						"value":      "integration-key-example",
+						"value":      pagerDutyIntegrationId,
 					}),
 				),
 			},
@@ -176,10 +186,9 @@ func TestAccCoralogixResourcePagerdutyConnector(t *testing.T) {
 }
 
 func TestAccCoralogixResourcePagerdutyIncidentsConnector(t *testing.T) {
-	t.Skip("Skipping test due to a breaking change in BE")
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccRequiredEnvVarsPreCheck(t, "PD_INTEGRATION_ID") },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -191,7 +200,7 @@ func TestAccCoralogixResourcePagerdutyIncidentsConnector(t *testing.T) {
 					resource.TestCheckResourceAttr(connectorResourceName, "description", "test pagerduty incidents connector"),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "integrationId",
-						"value":      "integration-id-example",
+						"value":      pagerDutyIntegrationId,
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
 						"field_name": "service",
@@ -303,19 +312,19 @@ func testAccResourceCoralogixSlackConnector(name string) string {
      fields = [
        {
          field_name = "integrationId"
-         value      = "luigis-testing-grounds"
+         value      = "%[2]v"
        },
 	   {
 	   	  field_name = "channel"
-		  value      = "luigis-testing-grounds"
+		  value      = "%[3]v"
 	   },
 	   {
 	   	  field_name = "fallbackChannel"
-		  value      = "luigis-testing-grounds"
+		  value      = "%[3]v"
 	   },
      ]
    }
- }`, name)
+ }`, name, slackIntegrationId, slackIntegrationChannel)
 }
 
 func testAccResourceCoralogixSlackConnectorUpdate(name string) string {
@@ -328,19 +337,19 @@ func testAccResourceCoralogixSlackConnectorUpdate(name string) string {
      fields = [
        {
          field_name = "integrationId"
-         value      = "luigis-testing-grounds-updated"
+         value      = "%[2]v"
        },
 	   {
 	   	  field_name = "channel"
-		  value      = "luigis-testing-grounds-updated"
+		  value      = "%[3]v"
 	   },
 	   {
 	   	  field_name = "fallbackChannel"
-		  value      = "luigis-testing-grounds-updated"
+		  value      = "%[3]v"
 	   },
      ]
    }
- }`, name)
+ }`, name, slackIntegrationId, slackIntegrationChannelUpdated)
 }
 
 func testAccResourceCoralogixPagerdutyConnector(name string) string {
@@ -353,11 +362,11 @@ func testAccResourceCoralogixPagerdutyConnector(name string) string {
      fields = [
        {
          field_name = "integrationKey"
-         value      = "integration-key-example"
+         value      = "%[2]v"
        }
      ]
    }
- }`, name)
+ }`, name, pagerDutyIntegrationId)
 }
 
 func testAccResourceCoralogixPagerdutyConnectorUpdate(name string) string {
@@ -370,11 +379,11 @@ func testAccResourceCoralogixPagerdutyConnectorUpdate(name string) string {
      fields = [
        {
          field_name = "integrationKey"
-         value      = "integration-key-example"
+         value      = "%[2]v"
        }
      ]
    }
- }`, name)
+ }`, name, pagerDutyIntegrationId)
 }
 
 func testAccResourceCoralogixPagerdutyIncidentsConnector(name string) string {
@@ -387,7 +396,7 @@ func testAccResourceCoralogixPagerdutyIncidentsConnector(name string) string {
      fields = [
        {
          field_name = "integrationId"
-         value      = "integration-id-example"
+         value      = "%[2]v"
        },
        {
          field_name = "service"
@@ -395,7 +404,7 @@ func testAccResourceCoralogixPagerdutyIncidentsConnector(name string) string {
        }
      ]
    }
- }`, name)
+ }`, name, pagerDutyIntegrationId)
 }
 
 func testAccResourceCoralogixEmailConnector(name string) string {

--- a/internal/provider/resource_coralogix_global_router_test.go
+++ b/internal/provider/resource_coralogix_global_router_test.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -24,12 +25,23 @@ import (
 
 const globalRouterResourceName = "coralogix_global_router.example"
 
-func TestAccCoralogixResourceGlobalRouter(t *testing.T) {
-	t.Skip("Skipping test due to a breaking change in BE")
+var slackIntegrationId = os.Getenv("SLACK_INTEGRATION_ID")
+var slackIntegrationChannel = os.Getenv("SLACK_INTEGRATION_CHANNEL")
+var slackIntegrationChannelUpdated = os.Getenv("SLACK_INTEGRATION_CHANNEL_UPDATED")
+var pagerDutyIntegrationId = os.Getenv("PD_INTEGRATION_ID")
 
+func TestAccCoralogixResourceGlobalRouter(t *testing.T) {
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccRequiredEnvVarsPreCheck(
+				t,
+				"SLACK_INTEGRATION_ID",
+				"SLACK_INTEGRATION_CHANNEL",
+				"SLACK_INTEGRATION_CHANNEL_UPDATED",
+				"PD_INTEGRATION_ID",
+			)
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -127,15 +139,15 @@ func testAccResourceCoralogixGlobalRouter(name string) string {
         fields = [
           {
             field_name = "integrationId"
-            value      = "luigis-testing-grounds"
+            value      = "%[2]v"
           },
           {
             field_name = "fallbackChannel"
-            value      = "luigis-testing-grounds"
+            value      = "%[3]v"
           },
           {
             field_name = "channel"
-            value      = "luigis-testing-grounds"
+            value      = "%[3]v"
           }
         ]
       }
@@ -150,7 +162,7 @@ func testAccResourceCoralogixGlobalRouter(name string) string {
         fields = [
           {
             field_name = "integrationKey"
-            value      = "integrationKey-eample"
+            value      = "%[4]v"
           }
         ]
       }
@@ -298,7 +310,7 @@ func testAccResourceCoralogixGlobalRouter(name string) string {
         }
       ]
     }
-  `, name)
+  `, name, slackIntegrationId, slackIntegrationChannel, pagerDutyIntegrationId)
 }
 
 func testAccResourceCoralogixGlobalRouterUpdate(name string) string {
@@ -331,15 +343,15 @@ func testAccResourceCoralogixGlobalRouterUpdate(name string) string {
         fields = [
           {
             field_name = "integrationId"
-            value      = "luigis-testing-grounds"
+            value      = "%[2]v"
           },
           {
             field_name = "fallbackChannel"
-            value      = "luigis-testing-grounds"
+            value      = "%[3]v"
           },
           {
             field_name = "channel"
-            value      = "luigis-testing-grounds"
+            value      = "%[3]v"
           }
         ]
       }
@@ -354,7 +366,7 @@ func testAccResourceCoralogixGlobalRouterUpdate(name string) string {
         fields = [
           {
             field_name = "integrationKey"
-            value      = "integrationKey-eample"
+            value      = "%[4]v"
           }
         ]
       }
@@ -494,5 +506,5 @@ func testAccResourceCoralogixGlobalRouterUpdate(name string) string {
         }
       ]
     }
-  `, name)
+  `, name, slackIntegrationId, slackIntegrationChannelUpdated, pagerDutyIntegrationId)
 }

--- a/internal/provider/resource_coralogix_global_router_test.go
+++ b/internal/provider/resource_coralogix_global_router_test.go
@@ -25,6 +25,8 @@ import (
 const globalRouterResourceName = "coralogix_global_router.example"
 
 func TestAccCoralogixResourceGlobalRouter(t *testing.T) {
+	t.Skip("Skipping test due to a breaking change in BE")
+
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/resource_coralogix_recording_rules_groups_set_test.go
+++ b/internal/provider/resource_coralogix_recording_rules_groups_set_test.go
@@ -239,7 +239,7 @@ func testAccCheckRecordingRulesGroupDestroy(s *terraform.State) error {
 
 		resp, _, err := client.RuleGroupSetsFetch(ctx, rs.Primary.ID).Execute()
 		if err == nil {
-			if resp != nil && *resp.Id == rs.Primary.ID {
+			if resp != nil && resp.Id == rs.Primary.ID {
 				return fmt.Errorf("coralogix_recording_rules_groups_set still exists: %s", rs.Primary.ID)
 			}
 		}

--- a/internal/provider/slo_mgmt/resource_coralogix_slo_v2.go
+++ b/internal/provider/slo_mgmt/resource_coralogix_slo_v2.go
@@ -287,12 +287,9 @@ func (r *SLOV2Resource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics = diags
 		return
 	}
-	rq := slos.SlosServiceReplaceSloRequest{
-		SloRequestBasedMetricSli: slo.SloRequestBasedMetricSli,
-		SloWindowBasedMetricSli:  slo.SloWindowBasedMetricSli,
-	}
+	rq := extractSLOV2Payload(slo)
 
-	result, httpResponse, err := r.client.SlosServiceCreateSlo(ctx).SlosServiceReplaceSloRequest(rq).Execute()
+	result, httpResponse, err := r.client.SlosServiceCreateSlo(ctx).Slo1(rq).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating coralogix_slo_v2",
 			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Create", rq),
@@ -363,14 +360,11 @@ func (r *SLOV2Resource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	rq := slos.SlosServiceReplaceSloRequest{
-		SloRequestBasedMetricSli: slo.SloRequestBasedMetricSli,
-		SloWindowBasedMetricSli:  slo.SloWindowBasedMetricSli,
-	}
+	rq := extractSLOV2Payload(slo)
 
 	result, httpResponse, err := r.client.
 		SlosServiceReplaceSlo(ctx).
-		SlosServiceReplaceSloRequest(rq).
+		Slo1(rq).
 		Execute()
 
 	if err != nil {
@@ -419,7 +413,6 @@ func (r *SLOV2Resource) Delete(ctx context.Context, req resource.DeleteRequest, 
 }
 
 func extractSLOV2(ctx context.Context, plan *SLOV2ResourceModel) (*slos.Slo, diag.Diagnostics) {
-	slo := &slos.Slo{}
 	name := plan.Name.ValueStringPointer()
 	description := plan.Description.ValueStringPointer()
 	targetThresholdPct := plan.TargetThresholdPercentage.ValueFloat32()
@@ -438,6 +431,14 @@ func extractSLOV2(ctx context.Context, plan *SLOV2ResourceModel) (*slos.Slo, dia
 	if diags.HasError() {
 		return nil, diags
 	}
+	slo := &slos.Slo{
+		Description:               description,
+		Id:                        id,
+		Labels:                    &labels,
+		Name:                      name,
+		SloTimeFrame:              timeFrame,
+		TargetThresholdPercentage: &targetThresholdPct,
+	}
 
 	var sliModel SLIModel
 	if diags := plan.SLI.As(ctx, &sliModel, basetypes.ObjectAsOptions{}); diags.HasError() {
@@ -446,17 +447,17 @@ func extractSLOV2(ctx context.Context, plan *SLOV2ResourceModel) (*slos.Slo, dia
 
 	if reqBased := sliModel.RequestBasedMetricSli; !(reqBased.IsNull() || reqBased.IsUnknown()) {
 
-		sli, diags := extractRequestBasedSLI(ctx, id, &labels, name, description, targetThresholdPct, timeFrame, reqBased)
+		sli, diags := extractRequestBasedSLI(ctx, reqBased)
 		if diags.HasError() {
 			return nil, diags
 		}
-		slo.SloRequestBasedMetricSli = sli
+		slo.RequestBasedMetricSli = sli
 	} else if winBased := sliModel.WindowBasedMetricSli; !(winBased.IsNull() || winBased.IsUnknown()) {
-		sli, diags := extractWindowBasedSLI(ctx, id, &labels, name, description, targetThresholdPct, timeFrame, winBased)
+		sli, diags := extractWindowBasedSLI(ctx, winBased)
 		if diags.HasError() {
 			return nil, diags
 		}
-		slo.SloWindowBasedMetricSli = sli
+		slo.WindowBasedMetricSli = sli
 	} else {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic(
 			"Invalid SLI configuration",
@@ -467,7 +468,20 @@ func extractSLOV2(ctx context.Context, plan *SLOV2ResourceModel) (*slos.Slo, dia
 	return slo, nil
 }
 
-func extractRequestBasedSLI(ctx context.Context, id *string, labels *map[string]string, name *string, description *string, targetThresholdPct float32, timeFrame *slos.SloTimeFrame, reqBased types.Object) (*slos.SloRequestBasedMetricSli, diag.Diagnostics) {
+func extractSLOV2Payload(slo *slos.Slo) slos.Slo1 {
+	return slos.Slo1{
+		Description:               slo.Description,
+		Id:                        slo.Id,
+		Labels:                    slo.Labels,
+		Name:                      slo.Name,
+		RequestBasedMetricSli:     slo.RequestBasedMetricSli,
+		SloTimeFrame:              slo.SloTimeFrame,
+		TargetThresholdPercentage: slo.TargetThresholdPercentage,
+		WindowBasedMetricSli:      slo.WindowBasedMetricSli,
+	}
+}
+
+func extractRequestBasedSLI(ctx context.Context, reqBased types.Object) (*slos.RequestBasedMetricSli, diag.Diagnostics) {
 	var requestBasedModel RequestBasedMetricSliModel
 	diags := reqBased.As(ctx, &requestBasedModel, basetypes.ObjectAsOptions{})
 	if diags.HasError() {
@@ -486,25 +500,17 @@ func extractRequestBasedSLI(ctx context.Context, id *string, labels *map[string]
 		return nil, diags
 	}
 
-	return &slos.SloRequestBasedMetricSli{
-		RequestBasedMetricSli: slos.RequestBasedMetricSli{
-			GoodEvents: &slos.Metric{
-				Query: goodModel.Query.ValueStringPointer(),
-			},
-			TotalEvents: &slos.Metric{
-				Query: totalModel.Query.ValueStringPointer(),
-			},
+	return &slos.RequestBasedMetricSli{
+		GoodEvents: &slos.Metric{
+			Query: goodModel.Query.ValueStringPointer(),
 		},
-		Description:               description,
-		Id:                        id,
-		Labels:                    labels,
-		Name:                      name,
-		SloTimeFrame:              timeFrame,
-		TargetThresholdPercentage: &targetThresholdPct,
+		TotalEvents: &slos.Metric{
+			Query: totalModel.Query.ValueStringPointer(),
+		},
 	}, nil
 }
 
-func extractWindowBasedSLI(ctx context.Context, id *string, labels *map[string]string, name *string, description *string, targetThresholdPct float32, timeFrame *slos.SloTimeFrame, winBased types.Object) (*slos.SloWindowBasedMetricSli, diag.Diagnostics) {
+func extractWindowBasedSLI(ctx context.Context, winBased types.Object) (*slos.WindowBasedMetricSli, diag.Diagnostics) {
 	var windowBasedModel WindowBasedMetricSliModel
 	diags := winBased.As(ctx, &windowBasedModel, basetypes.ObjectAsOptions{})
 	if diags.HasError() {
@@ -517,21 +523,13 @@ func extractWindowBasedSLI(ctx context.Context, id *string, labels *map[string]s
 		return nil, diags
 	}
 
-	return &slos.SloWindowBasedMetricSli{
-		WindowBasedMetricSli: slos.WindowBasedMetricSli{
-			Query: &slos.Metric{
-				Query: queryModel.Query.ValueStringPointer(),
-			},
-			Window:             schemaToProtoSLOWindow[windowBasedModel.Window.ValueString()].Ptr(),
-			ComparisonOperator: schemaToProtoComparisonOperator[windowBasedModel.ComparisonOperator.ValueString()].Ptr(),
-			Threshold:          windowBasedModel.Threshold.ValueFloat32Pointer(),
+	return &slos.WindowBasedMetricSli{
+		Query: &slos.Metric{
+			Query: queryModel.Query.ValueStringPointer(),
 		},
-		Description:               description,
-		Id:                        id,
-		Labels:                    labels,
-		Name:                      name,
-		SloTimeFrame:              timeFrame,
-		TargetThresholdPercentage: &targetThresholdPct,
+		Window:             schemaToProtoSLOWindow[windowBasedModel.Window.ValueString()].Ptr(),
+		ComparisonOperator: schemaToProtoComparisonOperator[windowBasedModel.ComparisonOperator.ValueString()].Ptr(),
+		Threshold:          windowBasedModel.Threshold.ValueFloat32Pointer(),
 	}, nil
 }
 
@@ -551,10 +549,10 @@ func extractWindow(ctx context.Context, rule types.Object) (*slos.SloTimeFrame, 
 
 func flattenSLOV2(ctx context.Context, slo *slos.Slo) (*SLOV2ResourceModel, diag.Diagnostics) {
 
-	if rb := slo.SloRequestBasedMetricSli; rb != nil {
-		return flattenRequestBasedSLI(ctx, rb)
-	} else if wb := slo.SloWindowBasedMetricSli; wb != nil {
-		return flattenWindowBasedSLI(ctx, wb)
+	if slo.RequestBasedMetricSli != nil {
+		return flattenRequestBasedSLI(ctx, slo)
+	} else if slo.WindowBasedMetricSli != nil {
+		return flattenWindowBasedSLI(ctx, slo)
 	} else {
 		diags := diag.Diagnostics{}
 		log.Printf("[ERROR] Response was neither a request nor window based SLO; %s", utils.FormatJSON(slo))
@@ -591,13 +589,14 @@ func flattenWindow(ctx context.Context, tf slos.SloTimeFrame) (types.Object, dia
 	}, model)
 }
 
-func flattenRequestBasedSLI(ctx context.Context, sli *slos.SloRequestBasedMetricSli) (*SLOV2ResourceModel, diag.Diagnostics) {
+func flattenRequestBasedSLI(ctx context.Context, slo *slos.Slo) (*SLOV2ResourceModel, diag.Diagnostics) {
+	sli := slo.RequestBasedMetricSli
 	goodEvents := SLOMetricQueryModel{
-		Query: types.StringPointerValue(sli.RequestBasedMetricSli.GoodEvents.Query),
+		Query: types.StringPointerValue(sli.GoodEvents.Query),
 	}
 
 	totalEvents := SLOMetricQueryModel{
-		Query: types.StringPointerValue(sli.RequestBasedMetricSli.TotalEvents.Query),
+		Query: types.StringPointerValue(sli.TotalEvents.Query),
 	}
 
 	goodObj, diags := types.ObjectValueFrom(ctx, sloMetricQueryAttr(), goodEvents)
@@ -628,36 +627,37 @@ func flattenRequestBasedSLI(ctx context.Context, sli *slos.SloRequestBasedMetric
 		return nil, diags
 	}
 
-	labels, diags := utils.StringMapToTypeMap(ctx, sli.Labels)
+	labels, diags := utils.StringMapToTypeMap(ctx, slo.Labels)
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	grouping, diags := flattenGrouping(ctx, sli.Grouping)
+	grouping, diags := flattenGrouping(ctx, slo.Grouping)
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	window, diags := flattenWindow(ctx, sli.GetSloTimeFrame())
+	window, diags := flattenWindow(ctx, slo.GetSloTimeFrame())
 	if diags.HasError() {
 		return nil, diags
 	}
 
 	return &SLOV2ResourceModel{
-		ID:                        types.StringPointerValue(sli.Id),
-		Name:                      types.StringPointerValue(sli.Name),
-		Description:               types.StringPointerValue(sli.Description),
+		ID:                        types.StringPointerValue(slo.Id),
+		Name:                      types.StringPointerValue(slo.Name),
+		Description:               types.StringPointerValue(slo.Description),
 		Labels:                    labels,
 		Grouping:                  grouping,
-		TargetThresholdPercentage: types.Float32PointerValue(sli.TargetThresholdPercentage),
+		TargetThresholdPercentage: types.Float32PointerValue(slo.TargetThresholdPercentage),
 		SLI:                       sliObj,
 		Window:                    window,
 	}, diags
 }
 
-func flattenWindowBasedSLI(ctx context.Context, sli *slos.SloWindowBasedMetricSli) (*SLOV2ResourceModel, diag.Diagnostics) {
+func flattenWindowBasedSLI(ctx context.Context, slo *slos.Slo) (*SLOV2ResourceModel, diag.Diagnostics) {
+	sli := slo.WindowBasedMetricSli
 	queryModel := SLOMetricQueryModel{
-		Query: types.StringPointerValue(sli.WindowBasedMetricSli.Query.Query),
+		Query: types.StringPointerValue(sli.Query.Query),
 	}
 	queryObj, diags := types.ObjectValueFrom(ctx, sloMetricQueryAttr(), queryModel)
 	if diags.HasError() {
@@ -666,9 +666,9 @@ func flattenWindowBasedSLI(ctx context.Context, sli *slos.SloWindowBasedMetricSl
 
 	model := WindowBasedMetricSliModel{
 		Query:              queryObj,
-		Window:             types.StringValue(protoToSchemaSloWindow[sli.WindowBasedMetricSli.GetWindow()]),
-		ComparisonOperator: types.StringValue(protoToSchemaComparisonOperator[sli.WindowBasedMetricSli.GetComparisonOperator()]),
-		Threshold:          types.Float32Value(sli.WindowBasedMetricSli.GetThreshold()),
+		Window:             types.StringValue(protoToSchemaSloWindow[sli.GetWindow()]),
+		ComparisonOperator: types.StringValue(protoToSchemaComparisonOperator[sli.GetComparisonOperator()]),
+		Threshold:          types.Float32Value(sli.GetThreshold()),
 	}
 	winObj, diags := types.ObjectValueFrom(ctx, windowBasedMetricSliAttr(), model)
 	if diags.HasError() {
@@ -683,27 +683,27 @@ func flattenWindowBasedSLI(ctx context.Context, sli *slos.SloWindowBasedMetricSl
 		return nil, diags
 	}
 
-	grouping, diags := flattenGrouping(ctx, sli.Grouping)
+	grouping, diags := flattenGrouping(ctx, slo.Grouping)
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	window, diags := flattenWindow(ctx, sli.GetSloTimeFrame())
+	window, diags := flattenWindow(ctx, slo.GetSloTimeFrame())
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	labels, diags := utils.StringMapToTypeMap(ctx, sli.Labels)
+	labels, diags := utils.StringMapToTypeMap(ctx, slo.Labels)
 	if diags.HasError() {
 		return nil, diags
 	}
 
 	return &SLOV2ResourceModel{
-		ID:                        types.StringPointerValue(sli.Id),
-		Name:                      types.StringPointerValue(sli.Name),
-		Description:               types.StringPointerValue(sli.Description),
+		ID:                        types.StringPointerValue(slo.Id),
+		Name:                      types.StringPointerValue(slo.Name),
+		Description:               types.StringPointerValue(slo.Description),
 		Grouping:                  grouping,
-		TargetThresholdPercentage: types.Float32PointerValue(sli.TargetThresholdPercentage),
+		TargetThresholdPercentage: types.Float32PointerValue(slo.TargetThresholdPercentage),
 		SLI:                       sliObj,
 		Window:                    window,
 		Labels:                    labels,


### PR DESCRIPTION
### Description

Updates the Terraform provider to use the merged `coralogix-management-sdk` version that was regenerated from the independent OpenAPI `oneOf` schema model.

The SDK no longer exposes generated Cartesian wrapper structs for many OpenAPI `oneOf` shapes. Instead, affected fields are exposed directly on the parent SDK model. This PR updates the provider code to use those new direct fields and keeps the provider behavior the same for valid Terraform configurations.

Before, some SDK models represented `oneOf` combinations as wrapper structs. Provider code had to build or inspect those wrapper types.

Now, the SDK model is closer to the JSON wire shape:
- normal fields live directly on the parent model
- required OpenAPI fields are generated as Go values
- optional OpenAPI fields remain pointers when absence matters

So provider code follows this pattern:
- required Terraform/API fields -> SDK value fields -> `ValueString()` / concrete values
- optional Terraform/API fields -> SDK pointer fields -> `ValueStringPointer()` / `nil`

### Main Adjustments

- Bumped `github.com/coralogix/coralogix-management-sdk` to the merged SDK commit:
  `v1.9.4-0.20260710130404-1b9d69a25d39`
- Updated OpenAPI-backed provider code that referenced old generated `oneOf` wrapper shapes.
- Adjusted recording-rules fields that are now required SDK values instead of pointers:
  - rule group `name`
  - rule `record`
  - rule `expr`
- Adjusted archive logs flattening because `archiveSpec` is now a required SDK value instead of a pointer.

### Compatibility / Risk

This is mainly a source compatibility update for the regenerated SDK model shapes.

The main semantic risk is around fields that changed from pointer to value: Go no longer distinguishes missing from empty. For the changed fields, that is acceptable because they are required/semantically mandatory fields. Missing and empty are both invalid inputs.

For optional fields, the provider continues to preserve absence with pointer values.

### Validation

Ran after rebasing on latest `master`:

```sh
env GOCACHE=/private/tmp/go-build-cache go test ./... -run '^$' -count=1

env GOCACHE=/private/tmp/go-build-cache go test \
  ./internal/provider/alerts \
  ./internal/provider/ai \
  ./internal/provider/integrations \
  ./internal/provider/slo_mgmt \
  ./internal/provider/parsing_rules \
  ./internal/provider/logs \
  ./internal/provider/recording_rules \
  -count=1

git diff --check
```

All passed.
