### PR TITLE
fix(alerts): stop perpetual drift on no_data_policy.auto_retire_seconds (BUGV2-6659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_alert
+- FIX: Stop perpetual `(known after apply)` drift on `no_data_policy.auto_retire_seconds` when the field is omitted from configuration.
+
 #### resource/coralogix_ai_custom_evaluation
 - FIX: Correct example score mapping and clearing of empty `criteria.*.examples` lists.
 

--- a/internal/provider/alerts/alert_schema/common.go
+++ b/internal/provider/alerts/alert_schema/common.go
@@ -586,7 +586,6 @@ func noDataPolicySchema() schema.SingleNestedAttribute {
 		Attributes: map[string]schema.Attribute{
 			"auto_retire_seconds": schema.Int64Attribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "The timeframe in seconds for auto retiring values that were detected as no-data. Accepts only multiples of 60 seconds.",
 			},
 			"state": schema.StringAttribute{

--- a/internal/provider/alerts/resource_coralogix_alert.go
+++ b/internal/provider/alerts/resource_coralogix_alert.go
@@ -3725,8 +3725,8 @@ func flattenNoDataPolicy(ctx context.Context, noDataPolicy *alerts.NoDataPolicy)
 	if noDataPolicy == nil {
 		return types.ObjectValueFrom(ctx, alertschema.NoDataPolicyAttr(), model)
 	}
-	if noDataPolicy.AutoRetireSeconds != nil {
-		model.AutoRetireSeconds = types.Int64Value(int64(*noDataPolicy.AutoRetireSeconds))
+	if autoRetireSeconds, ok := noDataPolicy.GetAutoRetireSecondsOk(); ok {
+		model.AutoRetireSeconds = types.Int64Value(int64(*autoRetireSeconds))
 	}
 	if noDataPolicy.State != nil {
 		model.State = types.StringValue(alerttypes.NoDataPolicyStateProtoToSchemaMap[*noDataPolicy.State])

--- a/internal/provider/resource_coralogix_alert_test.go
+++ b/internal/provider/resource_coralogix_alert_test.go
@@ -1104,12 +1104,8 @@ func TestAccCoralogixResourceAlert_metric_threshold_no_data_policy_omit_auto_ret
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(alertResourceName, "type_definition.metric_threshold.no_data_policy.state", "KEEP_LAST"),
 				),
-			},
-			{
-				Config:   testAccCoralogixResourceAlertMetricThresholdNoDataPolicyOmitAutoRetire(),
-				PlanOnly: true,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
@@ -3303,6 +3299,9 @@ func testAccCoralogixResourceAlertMetricThresholdNoDataPolicyOmitAutoRetire() st
         replace_with_zero = true
       }
       rules = [{
+        override = {
+          priority = "P2"
+        }
         condition = {
           threshold      = 2
           for_over_pct   = 10
@@ -3317,6 +3316,7 @@ func testAccCoralogixResourceAlertMetricThresholdNoDataPolicyOmitAutoRetire() st
   }
 }
 `
+}
 
 func testAccCoralogixResourceAlertMetricsLessThanUsual() string {
 	return `resource "coralogix_alert" "test" {

--- a/internal/provider/resource_coralogix_alert_test.go
+++ b/internal/provider/resource_coralogix_alert_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -1090,6 +1091,31 @@ func TestAccCoralogixResourceAlert_metric_less_than(t *testing.T) {
 		},
 	},
 	)
+}
+
+func TestAccCoralogixResourceAlert_metric_threshold_no_data_policy_omit_auto_retire(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAlertDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceAlertMetricThresholdNoDataPolicyOmitAutoRetire(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(alertResourceName, "type_definition.metric_threshold.no_data_policy.state", "KEEP_LAST"),
+				),
+			},
+			{
+				Config:   testAccCoralogixResourceAlertMetricThresholdNoDataPolicyOmitAutoRetire(),
+				PlanOnly: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
 }
 
 func TestAccCoralogixResourceAlert_metric_less_than_usual(t *testing.T) {
@@ -3261,6 +3287,36 @@ func testAccCoralogixResourceAlertMetricLessThanUpdated() string {
 }
 `
 }
+
+func testAccCoralogixResourceAlertMetricThresholdNoDataPolicyOmitAutoRetire() string {
+	return `resource "coralogix_alert" "test" {
+  name        = "metric-threshold-no-data-policy-omit-auto-retire"
+  description = "metric_threshold alert with no_data_policy state only"
+  priority    = "P3"
+
+  type_definition = {
+    metric_threshold = {
+      metric_filter = {
+        promql = "sum(rate(http_requests_total{job=\"api-server\"}[5m])) by (status)"
+      }
+      missing_values = {
+        replace_with_zero = true
+      }
+      rules = [{
+        condition = {
+          threshold      = 2
+          for_over_pct   = 10
+          of_the_last    = "10m"
+          condition_type = "MORE_THAN_OR_EQUALS"
+        }
+      }]
+      no_data_policy = {
+        state = "KEEP_LAST"
+      }
+    }
+  }
+}
+`
 
 func testAccCoralogixResourceAlertMetricsLessThanUsual() string {
 	return `resource "coralogix_alert" "test" {


### PR DESCRIPTION
### Description

Remove Computed from `auto_retire_seconds` so omitted values no longer plan as (known after apply) on every run. BUGV2-6659

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
➜  terraform-provider-coralogix git:(bugv2-6659-nodatapolicy) ✗ go test ./internal/provider/... \
  -run 'TestAccCoralogixResourceAlert_(metric_threshold_no_data_policy_omit_auto_retire|metric_less_than|logs_more_than)$' \
  -v -timeout 45m
=== RUN   TestAccCoralogixResourceAlert_logs_more_than
--- PASS: TestAccCoralogixResourceAlert_logs_more_than (2.77s)
=== RUN   TestAccCoralogixResourceAlert_metric_less_than
--- PASS: TestAccCoralogixResourceAlert_metric_less_than (2.49s)
=== RUN   TestAccCoralogixResourceAlert_metric_threshold_no_data_policy_omit_auto_retire
--- PASS: TestAccCoralogixResourceAlert_metric_threshold_no_data_policy_omit_auto_retire (1.14s)
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider 7.050s
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/aaa     (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/actions [no test files]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/ai      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/alerts  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/alerts/alert_schema     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/alerts/alert_types      (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/apm     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_widgets    (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/data_exploration        [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/dataengine      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/dataplans       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/enrichment_rules        (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/events2metrics  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider/integrations    (cached) [no tests to run]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/logs    [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/metrics [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/notifications   [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/notifications/global_router_schema      [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/parsing_rules   [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/recording_rules [no test files]
?       github.com/coralogix/terraform-provider-coralogix/internal/provider/slo_mgmt        [no test files]
...
```

### Release Note

```
#### resource/coralogix_alert
- FIX: Stop perpetual `(known after apply)` drift on `no_data_policy.auto_retire_seconds` when the field is omitted from configuration.
```

### Community Note

<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment