### PR TITLE
chore: bump coralogix-management-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 #### provider
-- CHORE: Bump `coralogix-management-sdk` to expose the manual dashboard annotation source types (`cxsdk.AnnotationSourceManual` and its strategy aliases), unblocking manual annotation support in `coralogix_dashboard`.
+- CHORE: Bump `coralogix-management-sdk`.
 
 #### resource/coralogix_ai_custom_evaluation
 - FIX: Correct example score mapping and clearing of empty `criteria.*.examples` lists.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706120359-24699aa8864a
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260707082655-e45a5bb1f4cb
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706120359-24699aa8864a h1:I0jV0aFIBnuvwvmpGSVAmGRlVqaMngzxzcx7zVFVtV8=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706120359-24699aa8864a/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260707082655-e45a5bb1f4cb h1:4maoARuj5E6mkca1jOrltr1UI6qQzHXYzEA6vNyyBjA=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260707082655-e45a5bb1f4cb/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=


### PR DESCRIPTION
Bumps the `coralogix-management-sdk` pin to `e45a5bb` (management-sdk #655).

Additive; `go build ./...` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)