### PR TITLE
feat(notifications): add NC IaC gap fields (CX-47025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 #### resource/coralogix_integration
 
 - FIX: Changing `version` now plans as an in-place update instead of forcing a destroy-and-recreate. The `RequiresReplace()` plan modifier was removed from `version`; version bumps flow through the existing `Update` method, preserving the integration's identity (and, for managed integrations, its provisioned service account) instead of deleting and re-provisioning it.
+
+#### resource/coralogix_preset
+- FEAT: Add `attachment_config` (`AUTO` / `ENABLED` / `DISABLED`, default `AUTO`) to control whether notification payloads include attachments.
+
+#### resource/coralogix_connector
+- FEAT: Add support for the `pagerduty_incidents` connector type.
+
+#### resource/coralogix_global_router
+- FEAT: Add `disabled` flag to disable a router without deleting it, and `fallback_targets` for per-entity-type fallback. The flat `fallback` attribute is now deprecated in favor of `fallback_targets`.
+
 #### resource/coralogix_dashboard
 
 - DOCS: Clarify when to use `observation_field` over the bare `field` string in logs filters, logs aggregations, and dashboard variables. `observation_field` is required for flat field identifiers whose name contains literal dots (e.g. `log.level`) and for disambiguating fields that share a name across multiple scopes; the bare `field` value is resolved by the backend via dot-split, which silently fails to match literal-dot identifiers.

--- a/docs/data-sources/connector.md
+++ b/docs/data-sources/connector.md
@@ -35,7 +35,7 @@ data "coralogix_connector" "generic_https_example_data_by_name" {
 - `config_overrides` (Attributes List) (see [below for nested schema](#nestedatt--config_overrides))
 - `connector_config` (Attributes) (see [below for nested schema](#nestedatt--connector_config))
 - `description` (String)
-- `type` (String) Connector type. Valid values are: [email generic_https pagerduty service_now slack unspecified]
+- `type` (String) Connector type. Valid values are: [email generic_https pagerduty pagerduty_incidents service_now slack unspecified]
 
 <a id="nestedatt--config_overrides"></a>
 ### Nested Schema for `config_overrides`

--- a/docs/data-sources/global_router.md
+++ b/docs/data-sources/global_router.md
@@ -33,8 +33,10 @@ data "coralogix_global_router" "example_data_by_name" {
 ### Read-Only
 
 - `description` (String) Description of the GlobalRouter.
+- `disabled` (Boolean) Disables the router without deleting it. Defaults to false.
 - `entity_labels` (Map of String)
 - `fallback` (Attributes List) Fallback routing targets. (see [below for nested schema](#nestedatt--fallback))
+- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. (see [below for nested schema](#nestedatt--fallback_targets))
 - `routing_labels` (Attributes) Routers other than `router_default` require at least one of the properties to be set. Note that these values are globally unique. Labels matching is linked with AND, so an alert has to have all labels specified below. (see [below for nested schema](#nestedatt--routing_labels))
 - `rules` (Attributes List) Routing rules for the GlobalRouter. (see [below for nested schema](#nestedatt--rules))
 
@@ -46,6 +48,25 @@ Read-Only:
 - `connector_id` (String) ID of the connector.
 - `custom_details` (Map of String) Custom details for the target.
 - `preset_id` (String) ID of the preset.
+
+
+<a id="nestedatt--fallback_targets"></a>
+### Nested Schema for `fallback_targets`
+
+Read-Only:
+
+- `entity_type` (String) The entity type this fallback applies to.
+- `target` (Attributes) The fallback routing target. (see [below for nested schema](#nestedatt--fallback_targets--target))
+
+<a id="nestedatt--fallback_targets--target"></a>
+### Nested Schema for `fallback_targets.target`
+
+Read-Only:
+
+- `connector_id` (String) ID of the connector.
+- `custom_details` (Map of String) Custom details for the target.
+- `preset_id` (String) ID of the preset.
+
 
 
 <a id="nestedatt--routing_labels"></a>

--- a/docs/data-sources/global_router.md
+++ b/docs/data-sources/global_router.md
@@ -35,8 +35,8 @@ data "coralogix_global_router" "example_data_by_name" {
 - `description` (String) Description of the GlobalRouter.
 - `disabled` (Boolean) Disables the router without deleting it. Defaults to false.
 - `entity_labels` (Map of String)
-- `fallback` (Attributes List) Fallback routing targets. (see [below for nested schema](#nestedatt--fallback))
-- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Removing the block clears the fallback targets. (see [below for nested schema](#nestedatt--fallback_targets))
+- `fallback` (Attributes List) Fallback routing targets. Removing the block clears them. (see [below for nested schema](#nestedatt--fallback))
+- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Omit the block to clear the fallback targets. (see [below for nested schema](#nestedatt--fallback_targets))
 - `routing_labels` (Attributes) Routers other than `router_default` require at least one of the properties to be set. Note that these values are globally unique. Labels matching is linked with AND, so an alert has to have all labels specified below. (see [below for nested schema](#nestedatt--routing_labels))
 - `rules` (Attributes List) Routing rules for the GlobalRouter. (see [below for nested schema](#nestedatt--rules))
 

--- a/docs/data-sources/global_router.md
+++ b/docs/data-sources/global_router.md
@@ -36,7 +36,7 @@ data "coralogix_global_router" "example_data_by_name" {
 - `disabled` (Boolean) Disables the router without deleting it. Defaults to false.
 - `entity_labels` (Map of String)
 - `fallback` (Attributes List) Fallback routing targets. (see [below for nested schema](#nestedatt--fallback))
-- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. (see [below for nested schema](#nestedatt--fallback_targets))
+- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Removing the block clears the fallback targets. (see [below for nested schema](#nestedatt--fallback_targets))
 - `routing_labels` (Attributes) Routers other than `router_default` require at least one of the properties to be set. Note that these values are globally unique. Labels matching is linked with AND, so an alert has to have all labels specified below. (see [below for nested schema](#nestedatt--routing_labels))
 - `rules` (Attributes List) Routing rules for the GlobalRouter. (see [below for nested schema](#nestedatt--rules))
 

--- a/docs/data-sources/preset.md
+++ b/docs/data-sources/preset.md
@@ -34,7 +34,7 @@ data "coralogix_preset" "generic_https_example_data_by_name" {
 
 - `attachment_config` (String) Controls whether notification payloads include attachments. Valid values are: AUTO, ENABLED, DISABLED. Defaults to AUTO.
 - `config_overrides` (Attributes List) (see [below for nested schema](#nestedatt--config_overrides))
-- `connector_type` (String) The type of connector for the preset. Valid values are: email, generic_https, pagerduty, service_now, slack, unspecified
+- `connector_type` (String) The type of connector for the preset. Valid values are: email, generic_https, pagerduty, pagerduty_incidents, service_now, slack, unspecified
 - `description` (String)
 - `entity_type` (String) The type of entity for the preset. Valid values are: alerts, cases, test_notifications, unspecified
 - `parent_id` (String)

--- a/docs/data-sources/preset.md
+++ b/docs/data-sources/preset.md
@@ -32,7 +32,7 @@ data "coralogix_preset" "generic_https_example_data_by_name" {
 
 ### Read-Only
 
-- `attachment_config` (String) Controls whether notification payloads include attachments. Valid values are: AUTO, ENABLED, DISABLED. Defaults to AUTO.
+- `attachment_config` (String) Controls whether notification payloads include attachments. Valid values are: AUTO, ENABLED, DISABLED. Defaults to AUTO. Removing the attribute resets it to AUTO.
 - `config_overrides` (Attributes List) (see [below for nested schema](#nestedatt--config_overrides))
 - `connector_type` (String) The type of connector for the preset. Valid values are: email, generic_https, pagerduty, pagerduty_incidents, service_now, slack, unspecified
 - `description` (String)

--- a/docs/data-sources/preset.md
+++ b/docs/data-sources/preset.md
@@ -32,6 +32,7 @@ data "coralogix_preset" "generic_https_example_data_by_name" {
 
 ### Read-Only
 
+- `attachment_config` (String) Controls whether notification payloads include attachments. Valid values are: AUTO, ENABLED, DISABLED. Defaults to AUTO.
 - `config_overrides` (Attributes List) (see [below for nested schema](#nestedatt--config_overrides))
 - `connector_type` (String) The type of connector for the preset. Valid values are: email, generic_https, pagerduty, service_now, slack, unspecified
 - `description` (String)

--- a/docs/resources/connector.md
+++ b/docs/resources/connector.md
@@ -183,6 +183,24 @@ resource "coralogix_connector" "email_example" {
   }
 }
 
+resource "coralogix_connector" "pagerduty_incidents_example" {
+  type        = "pagerduty_incidents"
+  name        = "pagerduty incidents connector"
+  description = "pagerduty incidents connector example"
+  connector_config = {
+    fields = [
+      {
+        field_name = "integrationId"
+        value      = "integrationId-example"
+      },
+      {
+        field_name = "service"
+        value      = "PXXXXXX"
+      }
+    ]
+  }
+}
+
 resource "coralogix_connector" "service_now_example" {
   type        = "service_now"
   name        = "service now connector"
@@ -212,7 +230,7 @@ resource "coralogix_connector" "service_now_example" {
 ### Required
 
 - `name` (String) Connector name.
-- `type` (String) Connector type. Valid values are: [email generic_https pagerduty service_now slack unspecified]
+- `type` (String) Connector type. Valid values are: [email generic_https pagerduty pagerduty_incidents service_now slack unspecified]
 
 ### Optional
 

--- a/docs/resources/global_router.md
+++ b/docs/resources/global_router.md
@@ -67,7 +67,7 @@ resource "coralogix_global_router" "example" {
 - `disabled` (Boolean) Disables the router without deleting it. Defaults to false.
 - `entity_labels` (Map of String)
 - `fallback` (Attributes List, Deprecated) Fallback routing targets. (see [below for nested schema](#nestedatt--fallback))
-- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. (see [below for nested schema](#nestedatt--fallback_targets))
+- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Removing the block clears the fallback targets. (see [below for nested schema](#nestedatt--fallback_targets))
 - `id` (String) The ID of the GlobalRouter. Use `router_default` for the default; leave empty for auto generated or provide your own (unique) id.
 - `routing_labels` (Attributes) Routers other than `router_default` require at least one of the properties to be set. Note that these values are globally unique. Labels matching is linked with AND, so an alert has to have all labels specified below. (see [below for nested schema](#nestedatt--routing_labels))
 - `rules` (Attributes List) Routing rules for the GlobalRouter. (see [below for nested schema](#nestedatt--rules))

--- a/docs/resources/global_router.md
+++ b/docs/resources/global_router.md
@@ -27,6 +27,7 @@ resource "coralogix_global_router" "example" {
   # id          = "router_default" # specify your own or leave blank for custom routers. router_default refers to the "global" router
   name        = "global router example"
   description = "global router example"
+  disabled    = false
 
   routing_labels = {
     environment = "production"
@@ -43,6 +44,13 @@ resource "coralogix_global_router" "example" {
     }]
     }
   ]
+  # Per-entity-type fallback used when no rule matches. Replaces the deprecated `fallback`.
+  fallback_targets = [{
+    entity_type = "alerts"
+    target = {
+      connector_id = "<some_connector_id>"
+    }
+  }]
 }
 ```
 
@@ -56,8 +64,10 @@ resource "coralogix_global_router" "example" {
 ### Optional
 
 - `description` (String) Description of the GlobalRouter.
+- `disabled` (Boolean) Disables the router without deleting it. Defaults to false.
 - `entity_labels` (Map of String)
-- `fallback` (Attributes List) Fallback routing targets. (see [below for nested schema](#nestedatt--fallback))
+- `fallback` (Attributes List, Deprecated) Fallback routing targets. (see [below for nested schema](#nestedatt--fallback))
+- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. (see [below for nested schema](#nestedatt--fallback_targets))
 - `id` (String) The ID of the GlobalRouter. Use `router_default` for the default; leave empty for auto generated or provide your own (unique) id.
 - `routing_labels` (Attributes) Routers other than `router_default` require at least one of the properties to be set. Note that these values are globally unique. Labels matching is linked with AND, so an alert has to have all labels specified below. (see [below for nested schema](#nestedatt--routing_labels))
 - `rules` (Attributes List) Routing rules for the GlobalRouter. (see [below for nested schema](#nestedatt--rules))
@@ -73,6 +83,28 @@ Optional:
 
 - `custom_details` (Map of String) Custom details for the target.
 - `preset_id` (String) ID of the preset.
+
+
+<a id="nestedatt--fallback_targets"></a>
+### Nested Schema for `fallback_targets`
+
+Required:
+
+- `entity_type` (String) The entity type this fallback applies to.
+- `target` (Attributes) The fallback routing target. (see [below for nested schema](#nestedatt--fallback_targets--target))
+
+<a id="nestedatt--fallback_targets--target"></a>
+### Nested Schema for `fallback_targets.target`
+
+Required:
+
+- `connector_id` (String) ID of the connector.
+
+Optional:
+
+- `custom_details` (Map of String) Custom details for the target.
+- `preset_id` (String) ID of the preset.
+
 
 
 <a id="nestedatt--routing_labels"></a>

--- a/docs/resources/global_router.md
+++ b/docs/resources/global_router.md
@@ -66,8 +66,8 @@ resource "coralogix_global_router" "example" {
 - `description` (String) Description of the GlobalRouter.
 - `disabled` (Boolean) Disables the router without deleting it. Defaults to false.
 - `entity_labels` (Map of String)
-- `fallback` (Attributes List, Deprecated) Fallback routing targets. (see [below for nested schema](#nestedatt--fallback))
-- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Removing the block clears the fallback targets. (see [below for nested schema](#nestedatt--fallback_targets))
+- `fallback` (Attributes List, Deprecated) Fallback routing targets. Removing the block clears them. (see [below for nested schema](#nestedatt--fallback))
+- `fallback_targets` (Attributes List) Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Omit the block to clear the fallback targets. (see [below for nested schema](#nestedatt--fallback_targets))
 - `id` (String) The ID of the GlobalRouter. Use `router_default` for the default; leave empty for auto generated or provide your own (unique) id.
 - `routing_labels` (Attributes) Routers other than `router_default` require at least one of the properties to be set. Note that these values are globally unique. Labels matching is linked with AND, so an alert has to have all labels specified below. (see [below for nested schema](#nestedatt--routing_labels))
 - `rules` (Attributes List) Routing rules for the GlobalRouter. (see [below for nested schema](#nestedatt--rules))

--- a/docs/resources/preset.md
+++ b/docs/resources/preset.md
@@ -28,12 +28,13 @@ provider "coralogix" {
 }
 
 resource "coralogix_preset" "generic_https_example" {
-  id             = "generic_https_example"
-  name           = "generic_https example"
-  description    = "generic_https preset example"
-  entity_type    = "alerts"
-  connector_type = "generic_https"
-  parent_id      = "preset_system_generic_https_alerts_empty"
+  id                = "generic_https_example"
+  name              = "generic_https example"
+  description       = "generic_https preset example"
+  entity_type       = "alerts"
+  connector_type    = "generic_https"
+  parent_id         = "preset_system_generic_https_alerts_empty"
+  attachment_config = "ENABLED"
   config_overrides = [
     {
       condition_type = {
@@ -174,6 +175,7 @@ resource "coralogix_preset" "email_example" {
 
 ### Optional
 
+- `attachment_config` (String) Controls whether notification payloads include attachments. Valid values are: AUTO, ENABLED, DISABLED. Defaults to AUTO.
 - `config_overrides` (Attributes List) (see [below for nested schema](#nestedatt--config_overrides))
 - `description` (String)
 - `id` (String) The ID of the Preset. Can be set to a custom value, or left empty to auto-generate. Requires recreation in case of change.

--- a/docs/resources/preset.md
+++ b/docs/resources/preset.md
@@ -168,7 +168,7 @@ resource "coralogix_preset" "email_example" {
 
 ### Required
 
-- `connector_type` (String) The type of connector for the preset. Valid values are: email, generic_https, pagerduty, service_now, slack, unspecified
+- `connector_type` (String) The type of connector for the preset. Valid values are: email, generic_https, pagerduty, pagerduty_incidents, service_now, slack, unspecified
 - `entity_type` (String) The type of entity for the preset. Valid values are: alerts, cases, test_notifications, unspecified
 - `name` (String)
 - `parent_id` (String)

--- a/docs/resources/preset.md
+++ b/docs/resources/preset.md
@@ -175,7 +175,7 @@ resource "coralogix_preset" "email_example" {
 
 ### Optional
 
-- `attachment_config` (String) Controls whether notification payloads include attachments. Valid values are: AUTO, ENABLED, DISABLED. Defaults to AUTO.
+- `attachment_config` (String) Controls whether notification payloads include attachments. Valid values are: AUTO, ENABLED, DISABLED. Defaults to AUTO. Removing the attribute resets it to AUTO.
 - `config_overrides` (Attributes List) (see [below for nested schema](#nestedatt--config_overrides))
 - `description` (String)
 - `id` (String) The ID of the Preset. Can be set to a custom value, or left empty to auto-generate. Requires recreation in case of change.

--- a/examples/resources/coralogix_connector/resource.tf
+++ b/examples/resources/coralogix_connector/resource.tf
@@ -168,6 +168,24 @@ resource "coralogix_connector" "email_example" {
   }
 }
 
+resource "coralogix_connector" "pagerduty_incidents_example" {
+  type        = "pagerduty_incidents"
+  name        = "pagerduty incidents connector"
+  description = "pagerduty incidents connector example"
+  connector_config = {
+    fields = [
+      {
+        field_name = "integrationId"
+        value      = "integrationId-example"
+      },
+      {
+        field_name = "service"
+        value      = "PXXXXXX"
+      }
+    ]
+  }
+}
+
 resource "coralogix_connector" "service_now_example" {
   type        = "service_now"
   name        = "service now connector"

--- a/examples/resources/coralogix_global_router/resource.tf
+++ b/examples/resources/coralogix_global_router/resource.tf
@@ -12,6 +12,7 @@ resource "coralogix_global_router" "example" {
   # id          = "router_default" # specify your own or leave blank for custom routers. router_default refers to the "global" router
   name        = "global router example"
   description = "global router example"
+  disabled    = false
 
   routing_labels = {
     environment = "production"
@@ -28,4 +29,11 @@ resource "coralogix_global_router" "example" {
     }]
     }
   ]
+  # Per-entity-type fallback used when no rule matches. Replaces the deprecated `fallback`.
+  fallback_targets = [{
+    entity_type = "alerts"
+    target = {
+      connector_id = "<some_connector_id>"
+    }
+  }]
 }

--- a/examples/resources/coralogix_preset/resource.tf
+++ b/examples/resources/coralogix_preset/resource.tf
@@ -13,12 +13,13 @@ provider "coralogix" {
 }
 
 resource "coralogix_preset" "generic_https_example" {
-  id             = "generic_https_example"
-  name           = "generic_https example"
-  description    = "generic_https preset example"
-  entity_type    = "alerts"
-  connector_type = "generic_https"
-  parent_id      = "preset_system_generic_https_alerts_empty"
+  id                = "generic_https_example"
+  name              = "generic_https example"
+  description       = "generic_https preset example"
+  entity_type       = "alerts"
+  connector_type    = "generic_https"
+  parent_id         = "preset_system_generic_https_alerts_empty"
+  attachment_config = "ENABLED"
   config_overrides = [
     {
       condition_type = {

--- a/internal/provider/notifications/global_router_schema/common.go
+++ b/internal/provider/notifications/global_router_schema/common.go
@@ -36,6 +36,13 @@ func RoutingTargetAttr() map[string]attr.Type {
 	}
 }
 
+func FallbackTargetAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"entity_type": types.StringType,
+		"target":      types.ObjectType{AttrTypes: RoutingTargetAttr()},
+	}
+}
+
 func MessageConfigFieldAttr() map[string]attr.Type {
 	return map[string]attr.Type{
 		"field_name": types.StringType,

--- a/internal/provider/notifications/global_router_schema/v1.go
+++ b/internal/provider/notifications/global_router_schema/v1.go
@@ -154,8 +154,7 @@ func V1() schema.Schema {
 			},
 			"fallback_targets": schema.ListNestedAttribute{
 				Optional:    true,
-				Computed:    true,
-				Description: "Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`.",
+				Description: "Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Removing the block clears the fallback targets.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"entity_type": schema.StringAttribute{

--- a/internal/provider/notifications/global_router_schema/v1.go
+++ b/internal/provider/notifications/global_router_schema/v1.go
@@ -17,6 +17,7 @@ package globalrouterschema
 import (
 	globalRouters "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/global_routers_service"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -130,9 +131,11 @@ func V1() schema.Schema {
 			},
 			"fallback": schema.ListNestedAttribute{
 				Optional:           true,
-				Computed:           true,
-				Description:        "Fallback routing targets.",
+				Description:        "Fallback routing targets. Removing the block clears them.",
 				DeprecationMessage: "Use `fallback_targets` instead, which supports per-entity-type fallback.",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"connector_id": schema.StringAttribute{
@@ -154,7 +157,10 @@ func V1() schema.Schema {
 			},
 			"fallback_targets": schema.ListNestedAttribute{
 				Optional:    true,
-				Description: "Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Removing the block clears the fallback targets.",
+				Description: "Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`. Omit the block to clear the fallback targets.",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"entity_type": schema.StringAttribute{

--- a/internal/provider/notifications/global_router_schema/v1.go
+++ b/internal/provider/notifications/global_router_schema/v1.go
@@ -18,6 +18,7 @@ import (
 	globalRouters "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/global_routers_service"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -128,9 +129,10 @@ func V1() schema.Schema {
 				},
 			},
 			"fallback": schema.ListNestedAttribute{
-				Optional:    true,
-				Computed:    true,
-				Description: "Fallback routing targets.",
+				Optional:           true,
+				Computed:           true,
+				Description:        "Fallback routing targets.",
+				DeprecationMessage: "Use `fallback_targets` instead, which supports per-entity-type fallback.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"connector_id": schema.StringAttribute{
@@ -149,6 +151,48 @@ func V1() schema.Schema {
 						},
 					},
 				},
+			},
+			"fallback_targets": schema.ListNestedAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Per-entity-type fallback targets used when no routing rule matches. Replaces the deprecated `fallback`.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"entity_type": schema.StringAttribute{
+							Required:    true,
+							Description: "The entity type this fallback applies to.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(GlobalRouterValidNotificationCenterEntityTypesSchemaToApi...),
+							},
+						},
+						"target": schema.SingleNestedAttribute{
+							Required:    true,
+							Description: "The fallback routing target.",
+							Attributes: map[string]schema.Attribute{
+								"connector_id": schema.StringAttribute{
+									Required:    true,
+									Description: "ID of the connector.",
+								},
+								"preset_id": schema.StringAttribute{
+									Optional:    true,
+									Description: "ID of the preset.",
+								},
+								"custom_details": schema.MapAttribute{
+									Optional:    true,
+									Computed:    true,
+									ElementType: types.StringType,
+									Description: "Custom details for the target.",
+								},
+							},
+						},
+					},
+				},
+			},
+			"disabled": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Disables the router without deleting it. Defaults to false.",
 			},
 			"entity_labels": schema.MapAttribute{
 				Optional:    true,

--- a/internal/provider/notifications/resource_coralogix_connector.go
+++ b/internal/provider/notifications/resource_coralogix_connector.go
@@ -41,12 +41,13 @@ import (
 var (
 	_                        resource.ResourceWithImportState = &ConnectorResource{}
 	connectorTypeSchemaToApi                                  = map[string]connectors.NotificationCenterConnectorType{
-		utils.UNSPECIFIED: connectors.NOTIFICATIONCENTERCONNECTORTYPE_CONNECTOR_TYPE_UNSPECIFIED,
-		"slack":           connectors.NOTIFICATIONCENTERCONNECTORTYPE_SLACK,
-		"generic_https":   connectors.NOTIFICATIONCENTERCONNECTORTYPE_GENERIC_HTTPS,
-		"pagerduty":       connectors.NOTIFICATIONCENTERCONNECTORTYPE_PAGERDUTY,
-		"email":           connectors.NOTIFICATIONCENTERCONNECTORTYPE_EMAIL,
-		"service_now":     connectors.NOTIFICATIONCENTERCONNECTORTYPE_SERVICE_NOW,
+		utils.UNSPECIFIED:     connectors.NOTIFICATIONCENTERCONNECTORTYPE_CONNECTOR_TYPE_UNSPECIFIED,
+		"slack":               connectors.NOTIFICATIONCENTERCONNECTORTYPE_SLACK,
+		"generic_https":       connectors.NOTIFICATIONCENTERCONNECTORTYPE_GENERIC_HTTPS,
+		"pagerduty":           connectors.NOTIFICATIONCENTERCONNECTORTYPE_PAGERDUTY,
+		"pagerduty_incidents": connectors.NOTIFICATIONCENTERCONNECTORTYPE_PAGERDUTY_INCIDENTS,
+		"email":               connectors.NOTIFICATIONCENTERCONNECTORTYPE_EMAIL,
+		"service_now":         connectors.NOTIFICATIONCENTERCONNECTORTYPE_SERVICE_NOW,
 	}
 	connectorTypeApiToSchema       = utils.ReverseMap(connectorTypeSchemaToApi)
 	validConnectorTypesSchemaToApi = utils.GetKeys(connectorTypeSchemaToApi)

--- a/internal/provider/notifications/resource_coralogix_global_router.go
+++ b/internal/provider/notifications/resource_coralogix_global_router.go
@@ -574,7 +574,10 @@ func flattenGlobalRouterRules(ctx context.Context, rules []globalRouters.Routing
 
 func flattenFallback(ctx context.Context, targets []globalRouters.RoutingTarget) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	if targets == nil {
+	// The API returns an empty list (not absent) when no fallback is set; normalize
+	// that to null so an unset/removed `fallback` block does not drift, and so an
+	// existing deprecated `fallback` is actually cleared on removal.
+	if len(targets) == 0 {
 		return types.ListNull(types.ObjectType{AttrTypes: globalrouterschema.RoutingTargetAttr()}), diags
 	}
 	fallbackTargetList := make([]types.Object, 0, len(targets))

--- a/internal/provider/notifications/resource_coralogix_global_router.go
+++ b/internal/provider/notifications/resource_coralogix_global_router.go
@@ -520,7 +520,10 @@ func flattenGlobalRouter(ctx context.Context, globalRouter *globalRouters.Global
 
 func flattenFallbackTargets(ctx context.Context, targets []globalRouters.FallbackTarget) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	if targets == nil {
+	// The API returns an empty list (not absent) when no fallback targets are set;
+	// normalize that to null so an unset/removed `fallback_targets` block does not
+	// drift against the empty list returned by the backend.
+	if len(targets) == 0 {
 		return types.ListNull(types.ObjectType{AttrTypes: globalrouterschema.FallbackTargetAttr()}), diags
 	}
 	targetList := make([]types.Object, 0, len(targets))

--- a/internal/provider/notifications/resource_coralogix_global_router.go
+++ b/internal/provider/notifications/resource_coralogix_global_router.go
@@ -42,13 +42,20 @@ type GlobalRouterResource struct {
 }
 
 type GlobalRouterResourceModel struct {
-	ID            types.String        `tfsdk:"id"`
-	Name          types.String        `tfsdk:"name"`
-	Description   types.String        `tfsdk:"description"`
-	Rules         types.List          `tfsdk:"rules"`    // RoutingRuleModel
-	FallBack      types.List          `tfsdk:"fallback"` // RoutingTargetModel
-	EntityLabels  types.Map           `tfsdk:"entity_labels"`
-	RoutingLabels *RoutingLabelsModel `tfsdk:"routing_labels"`
+	ID              types.String        `tfsdk:"id"`
+	Name            types.String        `tfsdk:"name"`
+	Description     types.String        `tfsdk:"description"`
+	Rules           types.List          `tfsdk:"rules"`            // RoutingRuleModel
+	FallBack        types.List          `tfsdk:"fallback"`         // RoutingTargetModel (deprecated)
+	FallbackTargets types.List          `tfsdk:"fallback_targets"` // FallbackTargetModel
+	Disabled        types.Bool          `tfsdk:"disabled"`
+	EntityLabels    types.Map           `tfsdk:"entity_labels"`
+	RoutingLabels   *RoutingLabelsModel `tfsdk:"routing_labels"`
+}
+
+type FallbackTargetModel struct {
+	EntityType types.String `tfsdk:"entity_type"`
+	Target     types.Object `tfsdk:"target"` // RoutingTargetModel
 }
 
 type RoutingRuleModel struct {
@@ -295,6 +302,11 @@ func extractGlobalRouter(ctx context.Context, plan *GlobalRouterResourceModel) (
 		return nil, diags
 	}
 
+	fallbackTargets, diags := extractFallbackTargets(ctx, plan.FallbackTargets)
+	if diags.HasError() {
+		return nil, diags
+	}
+
 	entityLabels, diags := utils.TypeMapToStringMap(ctx, plan.EntityLabels)
 	if diags.HasError() {
 		return nil, diags
@@ -308,14 +320,54 @@ func extractGlobalRouter(ctx context.Context, plan *GlobalRouterResourceModel) (
 	}
 
 	return &globalRouters.GlobalRouter{
-		Id:            routerId,
-		Name:          plan.Name.ValueStringPointer(),
-		Description:   plan.Description.ValueStringPointer(),
-		Rules:         rules,
-		Fallback:      fallback,
-		EntityLabels:  &entityLabels,
-		RoutingLabels: routingLabels,
+		Id:              routerId,
+		Name:            plan.Name.ValueStringPointer(),
+		Description:     plan.Description.ValueStringPointer(),
+		Rules:           rules,
+		Fallback:        fallback,
+		FallbackTargets: fallbackTargets,
+		Disabled:        plan.Disabled.ValueBoolPointer(),
+		EntityLabels:    &entityLabels,
+		RoutingLabels:   routingLabels,
 	}, nil
+}
+
+func extractFallbackTargets(ctx context.Context, list types.List) ([]globalRouters.FallbackTarget, diag.Diagnostics) {
+	if list.IsNull() || list.IsUnknown() {
+		return nil, nil
+	}
+	var diags diag.Diagnostics
+	var objs []types.Object
+	list.ElementsAs(ctx, &objs, true)
+	extracted := make([]globalRouters.FallbackTarget, 0, len(objs))
+	for _, o := range objs {
+		var model FallbackTargetModel
+		if dg := o.As(ctx, &model, basetypes.ObjectAsOptions{}); dg.HasError() {
+			diags.Append(dg...)
+			continue
+		}
+		var targetModel RoutingTargetModel
+		if dg := model.Target.As(ctx, &targetModel, basetypes.ObjectAsOptions{}); dg.HasError() {
+			diags.Append(dg...)
+			continue
+		}
+		target, dg := extractRoutingTarget(ctx, targetModel)
+		if dg.HasError() {
+			diags.Append(dg...)
+			continue
+		}
+		entityType := globalrouterschema.GlobalRouterEntityTypeSchemaToApi[model.EntityType.ValueString()]
+		extracted = append(extracted, globalRouters.FallbackTarget{
+			EntityType: &entityType,
+			Target:     target,
+		})
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return extracted, diags
 }
 
 func extractGlobalRouterRules(ctx context.Context, rules types.List) ([]globalRouters.RoutingRule, diag.Diagnostics) {
@@ -448,15 +500,54 @@ func flattenGlobalRouter(ctx context.Context, globalRouter *globalRouters.Global
 	if diags.HasError() {
 		return nil, diags
 	}
+
+	fallbackTargets, diags := flattenFallbackTargets(ctx, globalRouter.FallbackTargets)
+	if diags.HasError() {
+		return nil, diags
+	}
 	return &GlobalRouterResourceModel{
-		ID:            types.StringValue(globalRouter.GetId()),
-		Name:          types.StringValue(globalRouter.GetName()),
-		Description:   types.StringValue(globalRouter.GetDescription()),
-		Rules:         rules,
-		FallBack:      fallback,
-		EntityLabels:  entityLabels,
-		RoutingLabels: routingLabels,
+		ID:              types.StringValue(globalRouter.GetId()),
+		Name:            types.StringValue(globalRouter.GetName()),
+		Description:     types.StringValue(globalRouter.GetDescription()),
+		Rules:           rules,
+		FallBack:        fallback,
+		FallbackTargets: fallbackTargets,
+		Disabled:        types.BoolValue(globalRouter.GetDisabled()),
+		EntityLabels:    entityLabels,
+		RoutingLabels:   routingLabels,
 	}, nil
+}
+
+func flattenFallbackTargets(ctx context.Context, targets []globalRouters.FallbackTarget) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if targets == nil {
+		return types.ListNull(types.ObjectType{AttrTypes: globalrouterschema.FallbackTargetAttr()}), diags
+	}
+	targetList := make([]types.Object, 0, len(targets))
+	for _, t := range targets {
+		targetObject, dg := flattenRoutingTarget(ctx, t.Target)
+		if dg.HasError() {
+			diags.Append(dg...)
+			continue
+		}
+		entityType := globalrouterschema.GlobalRouterNotificationCenterEntityTypeApiToSchema[t.GetEntityType()]
+		model := FallbackTargetModel{
+			EntityType: types.StringValue(entityType),
+			Target:     targetObject,
+		}
+		object, dg := types.ObjectValueFrom(ctx, globalrouterschema.FallbackTargetAttr(), model)
+		if dg.HasError() {
+			diags.Append(dg...)
+			continue
+		}
+		targetList = append(targetList, object)
+	}
+
+	if diags.HasError() {
+		return types.ListNull(types.ObjectType{AttrTypes: globalrouterschema.FallbackTargetAttr()}), diags
+	}
+
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: globalrouterschema.FallbackTargetAttr()}, targetList)
 }
 
 func flattenGlobalRouterRules(ctx context.Context, rules []globalRouters.RoutingRule) (types.List, diag.Diagnostics) {

--- a/internal/provider/notifications/resource_coralogix_preset.go
+++ b/internal/provider/notifications/resource_coralogix_preset.go
@@ -62,6 +62,11 @@ var (
 	}
 	presetsNotificationCenterEntityTypeApiToSchema       = utils.ReverseMap(presetEntityTypeSchemaToApi)
 	presetsValidNotificationCenterEntityTypesSchemaToApi = utils.GetKeys(presetEntityTypeSchemaToApi)
+	validAttachmentConfigPolicies                        = []string{
+		string(presets.ATTACHMENTCONFIGPOLICY_AUTO),
+		string(presets.ATTACHMENTCONFIGPOLICY_ENABLED),
+		string(presets.ATTACHMENTCONFIGPOLICY_DISABLED),
+	}
 )
 
 func NewPresetResource() resource.Resource {
@@ -73,13 +78,14 @@ type PresetResource struct {
 }
 
 type PresetResourceModel struct {
-	ID              types.String `tfsdk:"id"`
-	EntityType      types.String `tfsdk:"entity_type"`
-	ConnectorType   types.String `tfsdk:"connector_type"`
-	ConfigOverrides types.List   `tfsdk:"config_overrides"` // PresetConfigOverrideModel
-	Name            types.String `tfsdk:"name"`
-	ParentId        types.String `tfsdk:"parent_id"`
-	Description     types.String `tfsdk:"description"`
+	ID               types.String `tfsdk:"id"`
+	EntityType       types.String `tfsdk:"entity_type"`
+	ConnectorType    types.String `tfsdk:"connector_type"`
+	ConfigOverrides  types.List   `tfsdk:"config_overrides"` // PresetConfigOverrideModel
+	Name             types.String `tfsdk:"name"`
+	ParentId         types.String `tfsdk:"parent_id"`
+	Description      types.String `tfsdk:"description"`
+	AttachmentConfig types.String `tfsdk:"attachment_config"`
 }
 
 type PresetConfigOverrideModel struct {
@@ -221,6 +227,17 @@ func (r *PresetResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			},
 			"parent_id": schema.StringAttribute{
 				Required: true,
+			},
+			"attachment_config": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(validAttachmentConfigPolicies...),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				MarkdownDescription: fmt.Sprintf("Controls whether notification payloads include attachments. Valid values are: %s. Defaults to AUTO.", strings.Join(validAttachmentConfigPolicies, ", ")),
 			},
 		},
 		MarkdownDescription: "Coralogix Notification Center Preset. For more info please review - https://coralogix.com/docs/user-guides/notification-center/presets/introduction/. **NOTE:** This resource is in Beta stage.",
@@ -384,7 +401,7 @@ func extractPreset(ctx context.Context, plan *PresetResourceModel) (*presets.Pre
 	if diags.HasError() {
 		return nil, diags
 	}
-	return &presets.Preset{
+	preset := &presets.Preset{
 		Id:              utils.TypeStringToStringPointer(plan.ID),
 		EntityType:      &entityType,
 		ConnectorType:   &connectorType,
@@ -393,7 +410,12 @@ func extractPreset(ctx context.Context, plan *PresetResourceModel) (*presets.Pre
 		Description:     plan.Description.ValueStringPointer(),
 		PresetType:      &presetType,
 		ParentId:        utils.TypeStringToStringPointer(plan.ParentId),
-	}, nil
+	}
+	if !plan.AttachmentConfig.IsNull() && !plan.AttachmentConfig.IsUnknown() {
+		policy := presets.AttachmentConfigPolicy(plan.AttachmentConfig.ValueString())
+		preset.AttachmentConfig = &presets.AttachmentConfig{Policy: &policy}
+	}
+	return preset, nil
 }
 func extractPresetConfigOverrides(ctx context.Context, overrides types.List) ([]presets.ConfigOverrides, diag.Diagnostics) {
 	var diags diag.Diagnostics
@@ -528,15 +550,20 @@ func flattenPreset(ctx context.Context, preset *presets.Preset) (*PresetResource
 		connectorType = string(*preset.ConnectorType)
 	}
 
-	return &PresetResourceModel{
-		ID:              utils.StringPointerToTypeString(preset.Id),
-		EntityType:      types.StringValue(presetsNotificationCenterEntityTypeApiToSchema[*preset.EntityType]),
-		ConnectorType:   types.StringValue(connectorType),
-		ConfigOverrides: configOverrides,
-		Name:            types.StringPointerValue(preset.Name),
-		ParentId:        utils.StringPointerToTypeString(preset.ParentId),
-		Description:     types.StringPointerValue(preset.Description),
-	}, nil
+	model := &PresetResourceModel{
+		ID:               utils.StringPointerToTypeString(preset.Id),
+		EntityType:       types.StringValue(presetsNotificationCenterEntityTypeApiToSchema[*preset.EntityType]),
+		ConnectorType:    types.StringValue(connectorType),
+		ConfigOverrides:  configOverrides,
+		Name:             types.StringPointerValue(preset.Name),
+		ParentId:         utils.StringPointerToTypeString(preset.ParentId),
+		Description:      types.StringPointerValue(preset.Description),
+		AttachmentConfig: types.StringNull(),
+	}
+	if preset.AttachmentConfig != nil && preset.AttachmentConfig.Policy != nil {
+		model.AttachmentConfig = types.StringValue(string(*preset.AttachmentConfig.Policy))
+	}
+	return model, nil
 
 }
 

--- a/internal/provider/notifications/resource_coralogix_preset.go
+++ b/internal/provider/notifications/resource_coralogix_preset.go
@@ -558,7 +558,8 @@ func flattenPreset(ctx context.Context, preset *presets.Preset) (*PresetResource
 		Name:             types.StringPointerValue(preset.Name),
 		ParentId:         utils.StringPointerToTypeString(preset.ParentId),
 		Description:      types.StringPointerValue(preset.Description),
-		AttachmentConfig: types.StringNull(),
+		// Normalize a missing policy to the schema default (AUTO) to avoid drift.
+		AttachmentConfig: types.StringValue(string(presets.ATTACHMENTCONFIGPOLICY_AUTO)),
 	}
 	if preset.AttachmentConfig != nil && preset.AttachmentConfig.Policy != nil {
 		model.AttachmentConfig = types.StringValue(string(*preset.AttachmentConfig.Policy))

--- a/internal/provider/notifications/resource_coralogix_preset.go
+++ b/internal/provider/notifications/resource_coralogix_preset.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
@@ -232,13 +233,11 @@ func (r *PresetResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"attachment_config": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				Default:  stringdefault.StaticString(string(presets.ATTACHMENTCONFIGPOLICY_AUTO)),
 				Validators: []validator.String{
 					stringvalidator.OneOf(validAttachmentConfigPolicies...),
 				},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-				MarkdownDescription: fmt.Sprintf("Controls whether notification payloads include attachments. Valid values are: %s. Defaults to AUTO.", strings.Join(validAttachmentConfigPolicies, ", ")),
+				MarkdownDescription: fmt.Sprintf("Controls whether notification payloads include attachments. Valid values are: %s. Defaults to AUTO. Removing the attribute resets it to AUTO.", strings.Join(validAttachmentConfigPolicies, ", ")),
 			},
 		},
 		MarkdownDescription: "Coralogix Notification Center Preset. For more info please review - https://coralogix.com/docs/user-guides/notification-center/presets/introduction/. **NOTE:** This resource is in Beta stage.",

--- a/internal/provider/notifications/resource_coralogix_preset.go
+++ b/internal/provider/notifications/resource_coralogix_preset.go
@@ -45,12 +45,13 @@ var (
 	_                              resource.ResourceWithConfigure   = &PresetResource{}
 	_                              resource.ResourceWithImportState = &PresetResource{}
 	presetConnectorTypeSchemaToApi                                  = map[string]presets.NotificationCenterConnectorType{
-		utils.UNSPECIFIED: presets.NOTIFICATIONCENTERCONNECTORTYPE_CONNECTOR_TYPE_UNSPECIFIED,
-		"slack":           presets.NOTIFICATIONCENTERCONNECTORTYPE_SLACK,
-		"generic_https":   presets.NOTIFICATIONCENTERCONNECTORTYPE_GENERIC_HTTPS,
-		"pagerduty":       presets.NOTIFICATIONCENTERCONNECTORTYPE_PAGERDUTY,
-		"service_now":     presets.NOTIFICATIONCENTERCONNECTORTYPE_SERVICE_NOW,
-		"email":           presets.NOTIFICATIONCENTERCONNECTORTYPE_EMAIL,
+		utils.UNSPECIFIED:     presets.NOTIFICATIONCENTERCONNECTORTYPE_CONNECTOR_TYPE_UNSPECIFIED,
+		"slack":               presets.NOTIFICATIONCENTERCONNECTORTYPE_SLACK,
+		"generic_https":       presets.NOTIFICATIONCENTERCONNECTORTYPE_GENERIC_HTTPS,
+		"pagerduty":           presets.NOTIFICATIONCENTERCONNECTORTYPE_PAGERDUTY,
+		"pagerduty_incidents": presets.NOTIFICATIONCENTERCONNECTORTYPE_PAGERDUTY_INCIDENTS,
+		"service_now":         presets.NOTIFICATIONCENTERCONNECTORTYPE_SERVICE_NOW,
+		"email":               presets.NOTIFICATIONCENTERCONNECTORTYPE_EMAIL,
 	}
 	presetConnectorTypeApiToSchema = utils.ReverseMap(presetConnectorTypeSchemaToApi)
 	validConnectorTypes            = utils.GetKeys(presetConnectorTypeSchemaToApi)

--- a/internal/provider/resource_coralogix_connector_test.go
+++ b/internal/provider/resource_coralogix_connector_test.go
@@ -173,6 +173,38 @@ func TestAccCoralogixResourcePagerdutyConnector(t *testing.T) {
 	})
 }
 
+func TestAccCoralogixResourcePagerdutyIncidentsConnector(t *testing.T) {
+	name := uuid.NewString()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceCoralogixPagerdutyIncidentsConnector(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(connectorResourceName, "id", name),
+					resource.TestCheckResourceAttr(connectorResourceName, "type", "pagerduty_incidents"),
+					resource.TestCheckResourceAttr(connectorResourceName, "name", name),
+					resource.TestCheckResourceAttr(connectorResourceName, "description", "test pagerduty incidents connector"),
+					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
+						"field_name": "integrationId",
+						"value":      "integration-id-example",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(connectorResourceName, "connector_config.fields.*", map[string]string{
+						"field_name": "service",
+						"value":      "PXXXXXX",
+					}),
+				),
+			},
+			{
+				ResourceName:      connectorResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCoralogixResourceEmailConnector(t *testing.T) {
 	name := uuid.NewString()
 	resource.Test(t, resource.TestCase{
@@ -336,6 +368,27 @@ func testAccResourceCoralogixPagerdutyConnectorUpdate(name string) string {
        {
          field_name = "integrationKey"
          value      = "integration-key-example"
+       }
+     ]
+   }
+ }`, name)
+}
+
+func testAccResourceCoralogixPagerdutyIncidentsConnector(name string) string {
+	return fmt.Sprintf(`resource "coralogix_connector" "example" {
+   id               = "%[1]v"
+   type             = "pagerduty_incidents"
+   name             = "%[1]v"
+   description      = "test pagerduty incidents connector"
+   connector_config = {
+     fields = [
+       {
+         field_name = "integrationId"
+         value      = "integration-id-example"
+       },
+       {
+         field_name = "service"
+         value      = "PXXXXXX"
        }
      ]
    }

--- a/internal/provider/resource_coralogix_global_router_test.go
+++ b/internal/provider/resource_coralogix_global_router_test.go
@@ -35,6 +35,12 @@ func TestAccCoralogixResourceGlobalRouter(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(globalRouterResourceName, "name", name),
 					resource.TestCheckResourceAttr(globalRouterResourceName, "description", name),
+					resource.TestCheckResourceAttr(globalRouterResourceName, "disabled", "true"),
+					resource.TestCheckResourceAttr(globalRouterResourceName, "fallback_targets.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(globalRouterResourceName, "fallback_targets.*", map[string]string{
+						"entity_type":         "alerts",
+						"target.connector_id": fmt.Sprintf("http-%v", name),
+					}),
 					resource.TestCheckTypeSetElemNestedAttrs(globalRouterResourceName, "rules.*", map[string]string{
 						"name":      "rule-name",
 						"condition": "alertDef.priority == \"P1\"",
@@ -252,8 +258,9 @@ func testAccResourceCoralogixGlobalRouter(name string) string {
     resource "coralogix_global_router" "example" {
       name        = "%[1]v"
       description = "%[1]v"
+      disabled    = true
       routing_labels = {
-        environment = "%[1]v" 
+        environment = "%[1]v"
       }
       rules       = [
         {
@@ -274,6 +281,14 @@ func testAccResourceCoralogixGlobalRouter(name string) string {
               preset_id      = coralogix_preset.pagerduty_example.id
             }
           ]
+        }
+      ]
+      fallback_targets = [
+        {
+          entity_type = "alerts"
+          target = {
+            connector_id = coralogix_connector.generic_https_example.id
+          }
         }
       ]
     }

--- a/internal/provider/resource_coralogix_global_router_test.go
+++ b/internal/provider/resource_coralogix_global_router_test.go
@@ -69,6 +69,10 @@ func TestAccCoralogixResourceGlobalRouter(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(globalRouterResourceName, "name", fmt.Sprintf("%s updated", name)),
 					resource.TestCheckResourceAttr(globalRouterResourceName, "description", name),
+					// disabled was true and fallback_targets was set on create; both are omitted
+					// here, so they must reset (disabled -> false, fallback_targets cleared).
+					resource.TestCheckResourceAttr(globalRouterResourceName, "disabled", "false"),
+					resource.TestCheckResourceAttr(globalRouterResourceName, "fallback_targets.#", "0"),
 					resource.TestCheckTypeSetElemNestedAttrs(globalRouterResourceName, "rules.*", map[string]string{
 						"name":      "rule-name",
 						"condition": "alertDef.priority == \"P1\"",

--- a/internal/provider/resource_coralogix_preset_test.go
+++ b/internal/provider/resource_coralogix_preset_test.go
@@ -43,6 +43,7 @@ func TestAccCoralogixResourceGenericHttpsPreset(t *testing.T) {
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "entity_type", "alerts"),
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "connector_type", "generic_https"),
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "parent_id", "preset_system_generic_https_alerts_empty"),
+					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "attachment_config", "ENABLED"),
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "config_overrides.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(genericHttpsPresetResourceName, "config_overrides.*", map[string]string{
 						"condition_type.match_entity_type_and_sub_type.entity_sub_type": "logsImmediateResolved",
@@ -281,12 +282,13 @@ func TestAccCoralogixResourceEmailPreset(t *testing.T) {
 func testAccResourceCoralogixGenericHttpsPreset(name string) string {
 	return fmt.Sprintf(`
 	resource "coralogix_preset" "generic_https_example" {
-      id               = "%[1]v"
-      name             = "%[1]v"
-      description      = "generic_https preset example"
-      entity_type      = "alerts"
-      connector_type   = "generic_https"
-      parent_id        = "preset_system_generic_https_alerts_empty"
+      id                = "%[1]v"
+      name              = "%[1]v"
+      description       = "generic_https preset example"
+      entity_type       = "alerts"
+      connector_type    = "generic_https"
+      parent_id         = "preset_system_generic_https_alerts_empty"
+      attachment_config = "ENABLED"
       config_overrides = [
         {
           condition_type = {

--- a/internal/provider/resource_coralogix_preset_test.go
+++ b/internal/provider/resource_coralogix_preset_test.go
@@ -70,6 +70,8 @@ func TestAccCoralogixResourceGenericHttpsPreset(t *testing.T) {
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "id", name),
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "name", "generic_https example updated"),
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "description", "generic_https preset example"),
+					// attachment_config was ENABLED on create and is omitted here; it must reset to AUTO.
+					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "attachment_config", "AUTO"),
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "entity_type", "alerts"),
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "connector_type", "generic_https"),
 					resource.TestCheckResourceAttr(genericHttpsPresetResourceName, "parent_id", "preset_system_generic_https_alerts_empty"),


### PR DESCRIPTION
## Context

[CX-47025](https://coralogix.atlassian.net/browse/CX-47025) — *IAC support: Notification Center gaps*. Several Notification Center fields are live in the API but not exposed by the provider, which blocks IaC management and makes View-as-Code fail with `unsupported …` errors.

Companion SDK examples PR: coralogix/coralogix-management-sdk#657. (Operator changes in a separate PR.)

## Changes

| Resource | Field added |
|----------|-------------|
| `coralogix_preset` | `attachment_config` — `AUTO` / `ENABLED` / `DISABLED` (default `AUTO`) |
| `coralogix_connector` | `pagerduty_incidents` connector type |
| `coralogix_global_router` | `disabled` (bool); `fallback_targets` (per-entity-type fallback). The flat `fallback` is now marked deprecated in favor of `fallback_targets`. |

All additions are backward-compatible (optional/computed). Includes schema, extract/flatten mapping, updated examples, regenerated docs (`make generate`), and acceptance tests.

## Verification

- `go build ./...`, `go vet`, `make generate` (docs regenerate clean).
- Acceptance tests run live against EU2 — all pass:
  - `TestAccCoralogixResourceGenericHttpsPreset` (asserts `attachment_config`)
  - `TestAccCoralogixResourcePagerdutyIncidentsConnector`
  - `TestAccCoralogixResourceGlobalRouter` (asserts `disabled` + `fallback_targets`)

## Notes

- `fallback_targets` targets reference a **connector only** (a preset in a fallback target is only supported on the default router `router_default`).
- The top-level router `entity_type` remains reserved for the default router and is intentionally not exposed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-47025]: https://coralogix.atlassian.net/browse/CX-47025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ