### PR TITLE
fix(custom_role): handle renamed permission expressions to prevent state drift

### DIFF
--- a/.claude/skills/custom-role-permission-alias-normalization.md
+++ b/.claude/skills/custom-role-permission-alias-normalization.md
@@ -1,0 +1,26 @@
+---
+name: custom-role-permission-alias-normalization
+description: "Use when the coralogix_custom_role resource shows spurious plan diffs or apply errors after a server-side permission expression rename (e.g. 'alerts-map:Read' → 'alerts:MapRead'). Documents the alias-map pattern, the ModifyPlan suppression approach, and the ListAllPermissions dependency."
+---
+
+# Custom Role Permission Expression Alias Normalization
+
+**Trigger:** `terraform plan` on `coralogix_custom_role` shows a diff or `terraform apply` errors with "permission X was not returned from API" after a permission expression is renamed on the server side.
+
+**Fix:**
+
+1. `flattenCustomRole` now takes a `map[string]string` alias map (lowercase deprecated → lowercase canonical) as a third argument. Both sides of the comparison are passed through `normalizePermission(expr, aliases)` before comparing.
+
+2. `normalizePermission` does: `lower := strings.ToLower(expr); if canon, ok := aliases[lower]; ok { return canon }; return lower`.
+
+3. The alias map is built from `PermissionsClient.ListAll()` (gRPC `PermissionsService/ListAllPermissions`) in `CustomRoleSource.Configure()`. Failures are non-fatal (empty map, warning diagnostic) so the resource degrades gracefully when the endpoint is not yet deployed.
+
+4. `CustomRoleSource` also implements `resource.ResourceWithModifyPlan`. `ModifyPlan` suppresses the diff when every element in the config normalizes to the same canonical as its counterpart in state. This handles the edge case where state already has the canonical form but config still uses the deprecated alias.
+
+**Key files:**
+- `internal/provider/aaa/resource_coralogix_custom_role.go` — resource + `flattenCustomRole` + `ModifyPlan`
+- `internal/clientset/clientset.go` — `PermissionsClient` field + accessor
+- `coralogix-management-sdk/go/permissions-client.go` — SDK wrapper for `PermissionsService`
+- `coralogix-management-sdk/go/internal/coralogixapis/aaa/rbac/v2/permissions*.go` — generated pb.go
+
+**Why:** Server-side expression renames are invisible to the provider without an alias map. The pure `strings.ToLower` comparison fails once the API stops returning the old form. The alias map bridges old and canonical names so both `flattenCustomRole` (apply correctness) and `ModifyPlan` (plan diff suppression) stay stable across renames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_custom_role
+- FIX: Deprecated permission expressions (e.g. `alerts-map:Read`) are now treated as equivalent to their canonical replacement (e.g. `alerts:MapRead`). A `terraform plan` after a server-side expression rename no longer shows a spurious diff, and `terraform apply` no longer errors because the old expression form is unrecognized by the API. Requires the companion permissions-service PR (ListAllPermissions with `deprecated_expressions`) to be deployed.
+
 #### resource/coralogix_integration
 
 - FIX: Changing `version` now plans as an in-place update instead of forcing a destroy-and-recreate. The `RequiresReplace()` plan modifier was removed from `version`; version bumps flow through the existing `Update` method, preserving the integration's identity (and, for managed integrations, its provisioned service account) instead of deleting and re-provisioning it.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.24.0
 
 replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5
 
+// TODO: remove this replace once coralogix-management-sdk PR #660 is merged and published.
+// This replaces the SDK to pick up PermissionsClient (ListAllPermissions with deprecated_expressions).
+replace github.com/coralogix/coralogix-management-sdk => /Users/marco/dev/coralogix-management-sdk
+
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -60,6 +60,7 @@ type ClientSet struct {
 	events2Metrics *cxsdk.Events2MetricsClient
 	groupGrpc      *cxsdk.GroupsClient
 	teams          *cxsdk.TeamsClient
+	permissions    *cxsdk.PermissionsClient
 
 	dahboardsFolders      *dbfs.DashboardFoldersServiceAPIService
 	customDataEnrichments *cess.CustomEnrichmentsServiceAPIService
@@ -174,6 +175,10 @@ func (c *ClientSet) CustomRoles() *roless.RoleManagementServiceAPIService {
 	return c.customRole
 }
 
+func (c *ClientSet) Permissions() *cxsdk.PermissionsClient {
+	return c.permissions
+}
+
 func (c *ClientSet) SLOs() *slos.SlosServiceAPIService {
 	return c.slos
 }
@@ -261,6 +266,7 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 		dashboards:     cxsdk.NewDashboardsClient(grpcCreator),
 		events2Metrics: cxsdk.NewEvents2MetricsClient(grpcCreator),
 		groupGrpc:      cxsdk.NewGroupsClient(grpcCreator),
+		permissions:    cxsdk.NewPermissionsClient(grpcCreator),
 
 		dahboardsFolders:      cs.DashboardFolders(),
 		parsingRuleGroups:     cs.RuleGroups(),

--- a/internal/provider/aaa/data_source_coralogix_custom_role.go
+++ b/internal/provider/aaa/data_source_coralogix_custom_role.go
@@ -108,7 +108,9 @@ func (d *CustomRoleDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	model, err := flattenCustomRole(customRole, data)
+	// The data source read path always hits the isImport branch (permissions are null in config),
+	// so no alias map is needed here.
+	model, err := flattenCustomRole(customRole, data, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error flattening coralogix_custom_role during read", err.Error())
 		return

--- a/internal/provider/aaa/resource_coralogix_custom_role.go
+++ b/internal/provider/aaa/resource_coralogix_custom_role.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 
 	roless "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/role_management_service"
@@ -43,8 +44,15 @@ func NewCustomRoleSource() resource.Resource {
 }
 
 type CustomRoleSource struct {
-	client *roless.RoleManagementServiceAPIService
+	client      *roless.RoleManagementServiceAPIService
+	permissions *cxsdk.PermissionsClient
+	// aliasMap maps lowercase deprecated permission expressions to lowercase canonical expressions.
+	// Built once from ListAllPermissions. Empty map (nil) means no alias resolution is available.
+	aliasMap map[string]string
 }
+
+// Ensure CustomRoleSource implements resource.ResourceWithModifyPlan.
+var _ resource.ResourceWithModifyPlan = &CustomRoleSource{}
 
 func (r *CustomRoleSource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_custom_role"
@@ -73,6 +81,54 @@ func (r *CustomRoleSource) Configure(ctx context.Context, req resource.Configure
 	}
 
 	r.client = clientSet.CustomRoles()
+	r.permissions = clientSet.Permissions()
+
+	// Eagerly fetch the permission alias map so flattenCustomRole and ModifyPlan can use it.
+	// This call is non-fatal: if the endpoint is unavailable (e.g., not yet deployed), we fall
+	// back to an empty alias map which preserves the pre-existing exact-case-insensitive comparison.
+	if r.permissions != nil {
+		aliasResp, err := r.permissions.ListAll(ctx, &cxsdk.ListAllPermissionsRequest{})
+		if err != nil {
+			resp.Diagnostics.AddWarning(
+				"Could not fetch permission aliases",
+				fmt.Sprintf("ListAllPermissions failed: %s. Deprecated permission expression aliases will not be resolved; existing permissions will still be compared case-insensitively.", err),
+			)
+			r.aliasMap = map[string]string{}
+		} else {
+			r.aliasMap = buildPermissionAliasMap(aliasResp.GetPermissions())
+		}
+	} else {
+		r.aliasMap = map[string]string{}
+	}
+}
+
+// buildPermissionAliasMap converts the ListAllPermissions response into a lookup map.
+// Keys are lowercase deprecated expression forms; values are lowercase canonical expressions.
+func buildPermissionAliasMap(perms []*cxsdk.RbacPermission) map[string]string {
+	aliases := make(map[string]string, len(perms))
+	for _, p := range perms {
+		canonical := strings.ToLower(p.GetExpression())
+		if canonical == "" {
+			continue
+		}
+		for _, dep := range p.GetDeprecatedExpressions() {
+			lower := strings.ToLower(dep)
+			if lower != "" && lower != canonical {
+				aliases[lower] = canonical
+			}
+		}
+	}
+	return aliases
+}
+
+// normalizePermission returns the lowercase canonical form of a permission expression.
+// If the expression is a known deprecated alias, it returns its canonical replacement.
+func normalizePermission(expr string, aliases map[string]string) string {
+	lower := strings.ToLower(expr)
+	if canonical, ok := aliases[lower]; ok {
+		return canonical
+	}
+	return lower
 }
 
 func (r *CustomRoleSource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -101,13 +157,71 @@ func (r *CustomRoleSource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"permissions": schema.SetAttribute{
 				Required:            true,
 				ElementType:         types.StringType,
-				MarkdownDescription: "Custom role permissions",
+				MarkdownDescription: "Custom role permissions. Deprecated expression forms (e.g. `alerts-map:Read`) are accepted and treated as equivalent to their canonical replacement (e.g. `alerts:MapRead`); no drift will appear unless you change the actual set of permissions.",
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),
 				},
 			},
 		},
 		MarkdownDescription: "Coralogix Custom Role. For more info please review - https://coralogix.com/docs/user-guides/account-management/user-management/create-roles-and-permissions/.",
+	}
+}
+
+// ModifyPlan suppresses spurious diffs for the permissions set when every element in the
+// plan normalizes to the same canonical expression as its counterpart in state. This handles
+// the case where state has been updated to a canonical form (e.g. "alerts:MapRead") but the
+// user's config still contains the deprecated alias (e.g. "alerts-map:Read").
+func (r *CustomRoleSource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Only act during update plans: both state and plan must be non-null.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var planPerms, statePerms types.Set
+	if diags := req.Plan.GetAttribute(ctx, path.Root("permissions"), &planPerms); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	if diags := req.State.GetAttribute(ctx, path.Root("permissions"), &statePerms); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	if planPerms.IsNull() || planPerms.IsUnknown() || statePerms.IsNull() || statePerms.IsUnknown() {
+		return
+	}
+	if len(planPerms.Elements()) != len(statePerms.Elements()) {
+		return
+	}
+
+	planList := utils.TypeStringSetToStringSlice(ctx, planPerms)
+	stateList := utils.TypeStringSetToStringSlice(ctx, statePerms)
+
+	// Build sets of normalized canonicals for both sides.
+	planNorm := make(map[string]bool, len(planList))
+	for _, p := range planList {
+		planNorm[normalizePermission(p, r.aliasMap)] = true
+	}
+	stateNorm := make(map[string]bool, len(stateList))
+	for _, p := range stateList {
+		stateNorm[normalizePermission(p, r.aliasMap)] = true
+	}
+
+	// If every canonical in the plan is covered by state canonicals (and vice-versa), the
+	// effective permission set is identical — suppress the diff by keeping the state value.
+	for k := range planNorm {
+		if !stateNorm[k] {
+			return
+		}
+	}
+	for k := range stateNorm {
+		if !planNorm[k] {
+			return
+		}
+	}
+
+	if diags := resp.Plan.SetAttribute(ctx, path.Root("permissions"), statePerms); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 	}
 }
 
@@ -145,7 +259,7 @@ func (r *CustomRoleSource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	state, err := flattenCustomRole(result.Role, plan)
+	state, err := flattenCustomRole(result.Role, plan, r.aliasMap)
 	if err != nil {
 		resp.Diagnostics.AddError("Error flattening coralogix_custom_role after creation", err.Error())
 		return
@@ -187,7 +301,7 @@ func (r *CustomRoleSource) Read(ctx context.Context, req resource.ReadRequest, r
 		}
 		return
 	}
-	state, err = flattenCustomRole(result.Role, state)
+	state, err = flattenCustomRole(result.Role, state, r.aliasMap)
 	if err != nil {
 		resp.Diagnostics.AddError("Error flattening coralogix_custom_role after read", err.Error())
 		return
@@ -243,7 +357,7 @@ func (r *CustomRoleSource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	state, err := flattenCustomRole(result.Role, plan)
+	state, err := flattenCustomRole(result.Role, plan, r.aliasMap)
 	if err != nil {
 		resp.Diagnostics.AddError("Error flattening coralogix_custom_role after update", err.Error())
 		return
@@ -298,7 +412,14 @@ func extractCreateCustomRoleRequest(ctx context.Context, roleModel *RolesModel) 
 	}, nil
 }
 
-func flattenCustomRole(customRole *roless.CustomRole, plan *RolesModel) (*RolesModel, error) {
+// flattenCustomRole converts an API CustomRole into a RolesModel.
+//
+// When plan permissions are provided (i.e. not an import), it verifies that
+// every plan permission is present in the API response — using normalizePermission
+// so that deprecated expression aliases (e.g. "alerts-map:Read") are treated as
+// equivalent to their canonical form (e.g. "alerts:MapRead"). On a match the plan's
+// original form is kept in state, preventing spurious diffs on the next plan.
+func flattenCustomRole(customRole *roless.CustomRole, plan *RolesModel, aliasMap map[string]string) (*RolesModel, error) {
 	permissionsFromPlan := utils.TypeStringSetToStringSlice(context.Background(), plan.Permissions)
 	permissionsFromAPI := customRole.Permissions
 	// permissions are required, so if plan.Permissions is null, it must mean that we're importing
@@ -323,9 +444,10 @@ func flattenCustomRole(customRole *roless.CustomRole, plan *RolesModel) (*RolesM
 		return nil, fmt.Errorf("the number of permissions specified in the plan (%d) does not match the number of permissions returned from the Coralogix API (%d).", len(permissionsFromPlan), len(permissionsFromAPI))
 	}
 	for _, perm := range permissionsFromPlan {
+		normalizedPlanPerm := normalizePermission(perm, aliasMap)
 		permissionWasReturnedFromAPI := false
 		for _, apiPerm := range permissionsFromAPI {
-			if strings.ToLower(perm) == strings.ToLower(apiPerm) {
+			if normalizedPlanPerm == normalizePermission(apiPerm, aliasMap) {
 				permissionWasReturnedFromAPI = true
 				break
 			}
@@ -338,8 +460,9 @@ func flattenCustomRole(customRole *roless.CustomRole, plan *RolesModel) (*RolesM
 	return &RolesModel{
 		ID:         utils.Int64ToStringValue(customRole.RoleId),
 		ParentRole: types.StringPointerValue(customRole.ParentRoleName),
-		// The reason we do this is that the API can return permissions with different casing than what was sent.
-		// In order to make sure that the output is correct, we perform the checks above.
+		// Keep the plan's original permission forms in state (preserving the user's spelling,
+		// whether canonical or deprecated), so that the next plan sees no diff as long as the
+		// effective permission set is unchanged.
 		Permissions: plan.Permissions,
 		Description: types.StringPointerValue(customRole.Description),
 		Name:        types.StringPointerValue(customRole.Name),


### PR DESCRIPTION
## Summary

- Permission expressions on the Coralogix platform can be renamed server-side (e.g. `alerts-map:Read` → `alerts:MapRead`). Before this fix, such a rename caused two problems:
  - **`terraform apply` errors**: `flattenCustomRole` compared plan permissions against the API response case-insensitively only; once the API stopped returning the old form, the comparison failed with _"permission X was not returned from the Coralogix API"_.
  - **Spurious `terraform plan` diffs**: state (canonical form) and config (deprecated alias) were treated as different permission sets, forcing an unnecessary update.

- **Alias map via `ListAllPermissions` (gRPC)**: `Configure()` calls `PermissionsService/ListAllPermissions` to fetch a `map[deprecated_lowercase → canonical_lowercase]`. Failures are non-fatal; an empty map preserves the previous case-insensitive behaviour.

- **`flattenCustomRole` updated**: both plan and API permissions are passed through `normalizePermission(expr, aliasMap)` before comparison. The plan's original spelling is kept in state (so `"alerts-map:Read"` stays in state — no drift on subsequent plans).

- **`ModifyPlan` implemented** (`resource.ResourceWithModifyPlan`): suppresses the plan diff when the config permission set and the state permission set normalize to the same canonical set. This guards the edge case where state already holds the new canonical but config still uses the old alias.

## Dependencies

- **coralogix-management-sdk PR #660** — adds `PermissionsServiceClient` (gRPC pb.go files + `PermissionsClient` wrapper). Must merge first.
- **cx-management-apis PR #341** — adds `permissions.proto` with `deprecated_expressions` field (upstream of the SDK PR).

The `go.mod` contains a temporary `replace` directive pointing to a local SDK clone. **This must be removed and replaced with the published SDK version once PR #660 merges.**

## Test plan

- [ ] Verify `go build ./...` passes after removing the `replace` directive and bumping the SDK version to include PR #660
- [ ] Acceptance test: create a custom role with a deprecated permission expression (`alerts-map:Read`), simulate the rename (manually update state to canonical form), then verify `terraform plan` shows no diff
- [ ] Verify `terraform apply` succeeds when the config uses a deprecated expression and the API returns only the canonical form

🤖 Generated with [Claude Code](https://claude.com/claude-code)