### PR TITLE
Implemented DataSource for events2metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - CHORE: Migrate dashboard operations from the legacy gRPC client to the REST client.
 - FEAT: Add support for DataPrime queries in `horizontal_bar_chart` widgets.
 
+#### resource/coralogix_events2metric
+- FEAT: Add support for `data_source` to target a specific `<namespace>/<dataset_name>` instead of the default logs/spans stream.
+
 # Release 3.7.0
 
 #### resource/coralogix_integration

--- a/docs/data-sources/events2metric.md
+++ b/docs/data-sources/events2metric.md
@@ -23,6 +23,7 @@ data "coralogix_events2metric" "imported_logs2metric" {
 
 ### Read-Only
 
+- `data_source` (String) Data source in `<namespace>/<dataset_name>` format. If not set, defaults to the standard logs/spans stream.
 - `description` (String) Events2Metric description.
 - `id` (String) The ID of this resource.
 - `logs_query` (Attributes) logs-events2metric type. Exactly one of "spans_query" or "logs_query" must be defined. (see [below for nested schema](#nestedatt--logs_query))

--- a/docs/resources/events2metric.md
+++ b/docs/resources/events2metric.md
@@ -30,6 +30,7 @@ provider "coralogix" {
 resource "coralogix_events2metric" "logs2metric" {
   name        = "logs2metricExample"
   description = "logs2metric from coralogix terraform provider"
+  data_source = "system/poc.error_tracking" // if omitted, defaults to the standard logs/spans stream
   logs_query = {
     lucene       = "remote_addr_enriched:/.*/"
     applications = ["filter:startsWith:nginx"] //change here for existing applications from your account
@@ -117,6 +118,7 @@ resource "coralogix_events2metric" "spans2metric" {
 
 ### Optional
 
+- `data_source` (String) Data source in `<namespace>/<dataset_name>` format. If not set, defaults to the standard logs/spans stream.
 - `description` (String) Events2Metric description.
 - `logs_query` (Attributes) logs-events2metric type. Exactly one of "spans_query" or "logs_query" must be defined. (see [below for nested schema](#nestedatt--logs_query))
 - `metric_fields` (Attributes Map) (see [below for nested schema](#nestedatt--metric_fields))

--- a/examples/resources/coralogix_events2metric/resource.tf
+++ b/examples/resources/coralogix_events2metric/resource.tf
@@ -15,6 +15,7 @@ provider "coralogix" {
 resource "coralogix_events2metric" "logs2metric" {
   name        = "logs2metricExample"
   description = "logs2metric from coralogix terraform provider"
+  data_source = "system/poc.error_tracking" // if omitted, defaults to the standard logs/spans stream
   logs_query = {
     lucene       = "remote_addr_enriched:/.*/"
     applications = ["filter:startsWith:nginx"] //change here for existing applications from your account

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260722083645-c4748d25d07c
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39 h1:Ng94C0STKyjwhe0PisPAf72EwfWygiE6VIROidRApsY=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260722083645-c4748d25d07c h1:DbrOeDCze0AJ5UMrTp5KivXwhbHEPV7HO1f1EUwQWQ4=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260722083645-c4748d25d07c/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5 h1:mqmL/WJA8Cdzim6r3jmXY8uiPn9KX4AvqxjEPDRXKj4=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/data_source_coralogix_events2metric_test.go
+++ b/internal/provider/data_source_coralogix_events2metric_test.go
@@ -29,7 +29,7 @@ func TestAccCoralogixDataSourceEvents2Metric_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoralogixResourceLogs2Metric(logsToMetric) +
+				Config: testAccCoralogixResourceLogs2Metric(logsToMetric, "") +
 					testAccCoralogixDataSourceEvents2Metric_read(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(events2metricDataSourceName, "name", logsToMetric.name),

--- a/internal/provider/events2metrics/resource_coralogix_events2metric.go
+++ b/internal/provider/events2metrics/resource_coralogix_events2metric.go
@@ -103,6 +103,7 @@ type Events2MetricResourceModel struct {
 	Permutations *PermutationsModel `tfsdk:"permutations"`
 	SpansQuery   *SpansQueryModel   `tfsdk:"spans_query"`
 	LogsQuery    *LogsQueryModel    `tfsdk:"logs_query"`
+	DataSource   types.String       `tfsdk:"data_source"`
 }
 
 type MetricFieldModel struct {
@@ -247,6 +248,10 @@ func (r *Events2MetricResource) Schema(_ context.Context, _ resource.SchemaReque
 			"description": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Events2Metric description.",
+			},
+			"data_source": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Data source in `<namespace>/<dataset_name>` format. If not set, defaults to the standard logs/spans stream.",
 			},
 			"metric_fields": schema.MapNestedAttribute{
 				Optional: true,
@@ -1006,6 +1011,7 @@ func flattenE2M(ctx context.Context, e2m *cxsdk.E2M) Events2MetricResourceModel 
 		Permutations: flattenE2MPermutations(e2m.GetPermutations()),
 		SpansQuery:   flattenSpansQuery(e2m.GetSpansQuery()),
 		LogsQuery:    flattenLogsQuery(e2m.GetLogsQuery()),
+		DataSource:   utils.WrapperspbStringToTypeString(e2m.GetDataSource()),
 	}
 }
 
@@ -1033,6 +1039,7 @@ func extractCreateE2M(ctx context.Context, plan Events2MetricResourceModel) (*cx
 	e2mParams := &cxsdk.E2MCreateParams{
 		Name:              name,
 		Description:       description,
+		DataSource:        utils.TypeStringToWrapperspbString(plan.DataSource),
 		PermutationsLimit: permutationsLimit,
 		MetricLabels:      metricLabels,
 		MetricFields:      metricFields,
@@ -1069,6 +1076,7 @@ func extractUpdateE2M(ctx context.Context, plan Events2MetricResourceModel) (*cx
 	id := wrapperspb.String(plan.ID.ValueString())
 	name := wrapperspb.String(plan.Name.ValueString())
 	description := wrapperspb.String(plan.Description.ValueString())
+	dataSource := utils.TypeStringToWrapperspbString(plan.DataSource)
 	permutations := expandPermutations(plan.Permutations)
 	metricLabels, diags := expandE2MLabels(ctx, plan.MetricLabels)
 	if diags.HasError() {
@@ -1083,6 +1091,7 @@ func extractUpdateE2M(ctx context.Context, plan Events2MetricResourceModel) (*cx
 		Id:           id,
 		Name:         name,
 		Description:  description,
+		DataSource:   dataSource,
 		Permutations: permutations,
 		MetricLabels: metricLabels,
 		MetricFields: metricFields,

--- a/internal/provider/resource_coralogix_events2metric_test.go
+++ b/internal/provider/resource_coralogix_events2metric_test.go
@@ -20,8 +20,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
-
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -148,7 +146,11 @@ func TestAccCoralogixResourceSpans2Metric(t *testing.T) {
 }
 
 func testAccCheckEvents2MetricDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*clientset.ClientSet).Events2Metrics()
+	clients, err := testAccNewClientSet()
+	if err != nil {
+		return err
+	}
+	client := clients.Events2Metrics()
 
 	ctx := context.TODO()
 

--- a/internal/provider/resource_coralogix_events2metric_test.go
+++ b/internal/provider/resource_coralogix_events2metric_test.go
@@ -45,7 +45,7 @@ func TestAccCoralogixResourceLogs2Metric(t *testing.T) {
 		CheckDestroy:             testAccCheckEvents2MetricDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoralogixResourceLogs2Metric(events2Metric),
+				Config: testAccCoralogixResourceLogs2Metric(events2Metric, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(events2metricResourceName, "id"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "name", events2Metric.name),
@@ -71,6 +71,25 @@ func TestAccCoralogixResourceLogs2Metric(t *testing.T) {
 					resource.TestCheckResourceAttr(events2metricResourceName, "metric_labels.Path", "http_referer"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "permutations.limit", strconv.Itoa(events2Metric.limit)),
 					resource.TestCheckResourceAttr(events2metricResourceName, "permutations.has_exceed_limit", "false"),
+					resource.TestCheckNoResourceAttr(events2metricResourceName, "data_source"),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceLogs2Metric(events2Metric, "system/poc.error_tracking"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(events2metricResourceName, "data_source", "system/poc.error_tracking"),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceLogs2Metric(events2Metric, "system/poc.other_tracking"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(events2metricResourceName, "data_source", "system/poc.other_tracking"),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceLogs2Metric(events2Metric, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(events2metricResourceName, "data_source"),
 				),
 			},
 			{
@@ -161,11 +180,15 @@ func getRandomEvents2Metric() *events2MetricTestFields {
 	}
 }
 
-func testAccCoralogixResourceLogs2Metric(l *events2MetricTestFields) string {
+func testAccCoralogixResourceLogs2Metric(l *events2MetricTestFields, dataSource string) string {
+	dataSourceAttr := ""
+	if dataSource != "" {
+		dataSourceAttr = fmt.Sprintf("data_source = %q\n", dataSource)
+	}
 	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
 name        = "%s"
 description = "%s"
-logs_query = {
+%slogs_query = {
     lucene       = "remote_addr_enriched:/.*/"
     applications = ["nginx"]
     severities   = ["Debug"]
@@ -198,7 +221,7 @@ permutations = {
 }
 }
 `,
-		l.name, l.description, l.limit)
+		l.name, l.description, dataSourceAttr, l.limit)
 }
 
 func testAccCoralogixResourceSpans2Metric(l *events2MetricTestFields) string {


### PR DESCRIPTION
### Description

Adds an optional `data_source` attribute to `coralogix_events2metric`, letting an E2M rule target a specific `<namespace>/<dataset_name>` instead of the default logs/spans stream. Bumped `coralogix-management-sdk` to pick up the new field on `E2M`/`E2MCreateParams`. Wired through schema, model, create/update/flatten, using the existing null-safe wrapper helper on update so removing `data_source` from HCL actually omits it from the request (rather than sending `""`, which the API's `min_length: 1` validation would reject).

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
go test ./internal/provider \
  -run '^(TestAccCoralogixResourceLogs2Metric|TestAccCoralogixDataSourceEvents2Metric_basic)$' \
  -v -timeout 30m
=== RUN   TestAccCoralogixDataSourceEvents2Metric_basic
--- PASS: TestAccCoralogixDataSourceEvents2Metric_basic (3.67s)
=== RUN   TestAccCoralogixResourceLogs2Metric
--- PASS: TestAccCoralogixResourceLogs2Metric (11.45s)
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider     16.087s
```

### Release Note

```release-note
resource/coralogix_events2metric: Add support for `data_source` to target a specific `<namespace>/<dataset_name>` instead of the default logs/spans stream.