### PR TITLE
perf(dashboards): replace per-child oneof validators with cheaper parent-attached ExactlyOneOfChildren

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,23 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Run build
         run: make build
+
+  test:
+    name: Unit tests
+    permissions:
+      contents: read
+    env:
+      GO111MODULE: on
+    strategy:
+      matrix:
+        go-version: [ 1.24.x ]
+        os: [ ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Run unit tests
+        run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - CHORE: Migrate dashboard operations from the legacy gRPC client to the REST client.
 - FEAT: Add support for DataPrime queries in `horizontal_bar_chart` widgets.
+- PERF: Replace per-child oneof validators (e.g. `instant`/`range`, widget type selection) with a single cheaper validator attached to the parent object, reducing plan/apply time for dashboards with many widgets.
 
 # Release 3.7.0
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ install: build
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
 test:
-	go test ${BUILD_ARGS} -i $(TEST) || exit 1
 	echo $(TEST) | xargs -t -n4 go test ${BUILD_ARGS} $(TESTARGS) -timeout=30s -parallel=4
 
 testacc:

--- a/internal/provider/dashboards/dashboard_oneof_validation_test.go
+++ b/internal/provider/dashboards/dashboard_oneof_validation_test.go
@@ -22,6 +22,7 @@ import (
 
 	dashboardschema "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -152,7 +153,8 @@ func dashboardObjectConfigNull(ctx context.Context, t *testing.T, objectType att
 	return obj
 }
 
-func dashboardValidateObject(ctx context.Context, cfg types.Object, at path.Path, validators []validator.Object) []diagDetail {
+func dashboardValidateObject(t *testing.T, ctx context.Context, cfg types.Object, at path.Path, validators []validator.Object) []diagDetail {
+	t.Helper()
 	req := validator.ObjectRequest{ConfigValue: cfg, Path: at}
 	resp := &validator.ObjectResponse{}
 	for _, v := range validators {
@@ -160,7 +162,11 @@ func dashboardValidateObject(ctx context.Context, cfg types.Object, at path.Path
 	}
 	details := make([]diagDetail, len(resp.Diagnostics))
 	for i, d := range resp.Diagnostics {
-		details[i] = diagDetail{path: at, detail: d.Detail()}
+		withPath, ok := d.(diag.DiagnosticWithPath)
+		if !ok {
+			t.Fatalf("diagnostic %q has no path: %#v", d.Detail(), d)
+		}
+		details[i] = diagDetail{path: withPath.Path(), detail: d.Detail()}
 	}
 	return details
 }
@@ -233,7 +239,7 @@ func TestDashboardWidgetDefinitionExactlyOneOfAtFullSchemaLevel(t *testing.T) {
 
 	t.Run("two_widget_types_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, definition.GetType(), "gauge", "line_chart")
-		diagnostics := dashboardValidateObject(ctx, cfg, definitionPath, definition.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, definitionPath, definition.Validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -249,7 +255,7 @@ func TestDashboardWidgetDefinitionExactlyOneOfAtFullSchemaLevel(t *testing.T) {
 
 	t.Run("zero_widget_types_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, definition.GetType())
-		diagnostics := dashboardValidateObject(ctx, cfg, definitionPath, definition.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, definitionPath, definition.Validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -281,7 +287,7 @@ func TestDashboardGaugeLogsTimeFrameExactlyOneOf(t *testing.T) {
 
 	t.Run("both_absolute_and_relative_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, timeFrame.GetType(), "absolute", "relative")
-		diagnostics := dashboardValidateObject(ctx, cfg, timeFramePath, timeFrame.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, timeFramePath, timeFrame.Validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -294,7 +300,7 @@ func TestDashboardGaugeLogsTimeFrameExactlyOneOf(t *testing.T) {
 
 	t.Run("present_but_empty_time_frame", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, timeFrame.GetType())
-		diagnostics := dashboardValidateObject(ctx, cfg, timeFramePath, timeFrame.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, timeFramePath, timeFrame.Validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -305,7 +311,7 @@ func TestDashboardGaugeLogsTimeFrameExactlyOneOf(t *testing.T) {
 
 	t.Run("omitted_time_frame_is_valid", func(t *testing.T) {
 		cfg := dashboardObjectConfigNull(ctx, t, timeFrame.GetType())
-		diagnostics := dashboardValidateObject(ctx, cfg, timeFramePath, timeFrame.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, timeFramePath, timeFrame.Validators)
 		if len(diagnostics) != 0 {
 			t.Fatalf("expected no diagnostics when time_frame is omitted entirely, got: %v", diagnostics)
 		}
@@ -329,7 +335,7 @@ func TestDashboardFolderExactlyOneOf(t *testing.T) {
 
 	t.Run("both_id_and_path_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, folder.GetType(), "id", "path")
-		diagnostics := dashboardValidateObject(ctx, cfg, folderPath, folder.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, folderPath, folder.Validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -342,7 +348,7 @@ func TestDashboardFolderExactlyOneOf(t *testing.T) {
 
 	t.Run("present_but_empty_folder", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, folder.GetType())
-		diagnostics := dashboardValidateObject(ctx, cfg, folderPath, folder.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, folderPath, folder.Validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -372,7 +378,7 @@ func TestDashboardAnnotationSourceAndManualStrategyExactlyOneOf(t *testing.T) {
 
 	t.Run("source_zero_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, source.GetType())
-		diagnostics := dashboardValidateObject(ctx, cfg, sourcePath, source.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, sourcePath, source.Validators)
 		if len(diagnostics) != 1 || !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
 			t.Fatalf("unexpected diagnostics for zero-set source: %v", diagnostics)
 		}
@@ -380,7 +386,7 @@ func TestDashboardAnnotationSourceAndManualStrategyExactlyOneOf(t *testing.T) {
 
 	t.Run("source_two_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, source.GetType(), "logs", "manual")
-		diagnostics := dashboardValidateObject(ctx, cfg, sourcePath, source.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, sourcePath, source.Validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -389,7 +395,7 @@ func TestDashboardAnnotationSourceAndManualStrategyExactlyOneOf(t *testing.T) {
 
 	t.Run("strategy_zero_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, strategy.GetType())
-		diagnostics := dashboardValidateObject(ctx, cfg, strategyPath, strategy.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, strategyPath, strategy.Validators)
 		if len(diagnostics) != 1 || !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
 			t.Fatalf("unexpected diagnostics for zero-set strategy: %v", diagnostics)
 		}
@@ -397,7 +403,7 @@ func TestDashboardAnnotationSourceAndManualStrategyExactlyOneOf(t *testing.T) {
 
 	t.Run("strategy_two_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, strategy.GetType(), "instant", "range")
-		diagnostics := dashboardValidateObject(ctx, cfg, strategyPath, strategy.Validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, strategyPath, strategy.Validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -419,13 +425,13 @@ func TestDashboardAnnotationSourceAndManualStrategyExactlyOneOf(t *testing.T) {
 		}
 		sourceCfg := dashboardMustType[types.Object](t, sourceVal, "source config value")
 
-		if diagnostics := dashboardValidateObject(ctx, sourceCfg, sourcePath, source.Validators); len(diagnostics) != 0 {
+		if diagnostics := dashboardValidateObject(t, ctx, sourceCfg, sourcePath, source.Validators); len(diagnostics) != 0 {
 			t.Fatalf("expected source group to accept manual-only, got: %v", diagnostics)
 		}
 
 		manualObj := dashboardMustType[types.Object](t, sourceCfg.Attributes()["manual"], "source config's manual attribute")
 		strategyObj := dashboardMustType[types.Object](t, manualObj.Attributes()["strategy"], "manual config's strategy attribute")
-		if diagnostics := dashboardValidateObject(ctx, strategyObj, strategyPath, strategy.Validators); len(diagnostics) != 0 {
+		if diagnostics := dashboardValidateObject(t, ctx, strategyObj, strategyPath, strategy.Validators); len(diagnostics) != 0 {
 			t.Fatalf("expected strategy group to accept range-only, got: %v", diagnostics)
 		}
 	})
@@ -464,7 +470,7 @@ func TestDashboardDataPrimeFiltersExactlyOneOfPerListElement(t *testing.T) {
 	t.Run("one_element_two_sources_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, elementType, "logs", "metrics")
 		elementPath := filtersPath.AtListIndex(0)
-		diagnostics := dashboardValidateObject(ctx, cfg, elementPath, validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, elementPath, validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}
@@ -481,7 +487,7 @@ func TestDashboardDataPrimeFiltersExactlyOneOfPerListElement(t *testing.T) {
 	t.Run("one_element_zero_sources_set", func(t *testing.T) {
 		cfg := dashboardObjectConfig(ctx, t, elementType)
 		elementPath := filtersPath.AtListIndex(0)
-		diagnostics := dashboardValidateObject(ctx, cfg, elementPath, validators)
+		diagnostics := dashboardValidateObject(t, ctx, cfg, elementPath, validators)
 		if len(diagnostics) != 1 {
 			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
 		}

--- a/internal/provider/dashboards/dashboard_oneof_validation_test.go
+++ b/internal/provider/dashboards/dashboard_oneof_validation_test.go
@@ -1,0 +1,504 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"testing"
+
+	dashboardschema "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// This file follows the pattern established by
+// TestDashboardStructuredConfigurationRejectsUnsupportedAutoRefreshBranches
+// in resource_coralogix_dashboard_test.go: pull the real attribute out of
+// dashboard_schema.V4() and call its own validators directly, rather than
+// hand-rolling a copy of the schema shape. Unlike that test, several oneof
+// groups here nest object-typed children, so the helpers below build
+// present-but-otherwise-empty tftypes.Value objects for a "set" branch:
+// exactlyOneOfChildrenValidator only inspects whether a named child is
+// null/unknown/set, never its grandchildren, so grandchildren are left null.
+
+// dashboardResolveAttribute walks a chain of attribute names starting from
+// attrs, stepping transparently through SingleNestedAttribute and
+// ListNestedAttribute/SetNestedAttribute containers (a list/set level
+// doesn't consume a path segment of its own), and returns the schema
+// attribute found at the last segment without further unwrapping it, so
+// callers can assert its exact kind.
+func dashboardResolveAttribute(t *testing.T, attrs map[string]schema.Attribute, segments ...string) schema.Attribute {
+	t.Helper()
+	current := attrs
+	var found schema.Attribute
+	for i, name := range segments {
+		attribute, ok := current[name]
+		if !ok {
+			t.Fatalf("no attribute %q at segment %d of %v", name, i, segments)
+		}
+		found = attribute
+		if i == len(segments)-1 {
+			break
+		}
+		switch a := attribute.(type) {
+		case schema.SingleNestedAttribute:
+			current = a.Attributes
+		case schema.ListNestedAttribute:
+			current = a.NestedObject.Attributes
+		case schema.SetNestedAttribute:
+			current = a.NestedObject.Attributes
+		default:
+			t.Fatalf("attribute %q at segment %d of %v is not a nested container (%T)", name, i, segments, attribute)
+		}
+	}
+	return found
+}
+
+// dashboardSetValue builds a tftypes.Value representing "this branch of the
+// oneof is set": for object types, present-but-not-null with every one of
+// its own attributes null (exactlyOneOfChildrenValidator only inspects
+// null/unknown-ness of the direct children it's given, never grandchildren,
+// so grandchildren don't need to be recursively populated); for scalar leaf
+// types (folder's id/path are plain strings, not nested objects), a
+// concrete non-null value, since a scalar can't be "present but empty" the
+// way an object can.
+func dashboardSetValue(t tftypes.Type) tftypes.Value {
+	if obj, ok := t.(tftypes.Object); ok {
+		inner := make(map[string]tftypes.Value, len(obj.AttributeTypes))
+		for name, innerType := range obj.AttributeTypes {
+			inner[name] = tftypes.NewValue(innerType, nil)
+		}
+		return tftypes.NewValue(t, inner)
+	}
+	switch {
+	case t.Is(tftypes.String):
+		return tftypes.NewValue(t, "set")
+	case t.Is(tftypes.Bool):
+		return tftypes.NewValue(t, true)
+	case t.Is(tftypes.Number):
+		return tftypes.NewValue(t, big.NewFloat(0))
+	default:
+		return tftypes.NewValue(t, nil)
+	}
+}
+
+// dashboardObjectConfig builds a types.Object valid for objectType, setting
+// each name in setNames to a present-empty value (see
+// dashboardSetValue) and leaving every other attribute null.
+func dashboardObjectConfig(ctx context.Context, t *testing.T, objectType attr.Type, setNames ...string) types.Object {
+	t.Helper()
+	set := make(map[string]bool, len(setNames))
+	for _, name := range setNames {
+		set[name] = true
+	}
+	tfType, ok := objectType.TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("attribute type %T is not an object", objectType)
+	}
+	rawAttrs := make(map[string]tftypes.Value, len(tfType.AttributeTypes))
+	for name, childType := range tfType.AttributeTypes {
+		if set[name] {
+			rawAttrs[name] = dashboardSetValue(childType)
+		} else {
+			rawAttrs[name] = tftypes.NewValue(childType, nil)
+		}
+	}
+	val, err := objectType.ValueFromTerraform(ctx, tftypes.NewValue(tfType, rawAttrs))
+	if err != nil {
+		t.Fatalf("build object config: %s", err)
+	}
+	obj, ok := val.(types.Object)
+	if !ok {
+		t.Fatalf("config value is %T, not types.Object", val)
+	}
+	return obj
+}
+
+// dashboardObjectConfigNull builds the null types.Object of objectType,
+// representing a wholly-omitted optional block rather than one that's
+// present-but-empty.
+func dashboardObjectConfigNull(ctx context.Context, t *testing.T, objectType attr.Type) types.Object {
+	t.Helper()
+	tfType, ok := objectType.TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("attribute type %T is not an object", objectType)
+	}
+	val, err := objectType.ValueFromTerraform(ctx, tftypes.NewValue(tfType, nil))
+	if err != nil {
+		t.Fatalf("build null object config: %s", err)
+	}
+	obj, ok := val.(types.Object)
+	if !ok {
+		t.Fatalf("config value is %T, not types.Object", val)
+	}
+	return obj
+}
+
+func dashboardValidateObject(ctx context.Context, cfg types.Object, at path.Path, validators []validator.Object) []diagDetail {
+	req := validator.ObjectRequest{ConfigValue: cfg, Path: at}
+	resp := &validator.ObjectResponse{}
+	for _, v := range validators {
+		v.ValidateObject(ctx, req, resp)
+	}
+	details := make([]diagDetail, len(resp.Diagnostics))
+	for i, d := range resp.Diagnostics {
+		details[i] = diagDetail{path: at, detail: d.Detail()}
+	}
+	return details
+}
+
+type diagDetail struct {
+	path   path.Path
+	detail string
+}
+
+// dashboardMustType asserts v has static type T, failing the test
+// immediately with a message naming what was being asserted. It centralizes
+// the assert-or-fail branch so call sites read as a single expression
+// instead of each contributing its own branch to cyclomatic complexity.
+func dashboardMustType[T any](t *testing.T, v any, what string) T {
+	t.Helper()
+	x, ok := v.(T)
+	if !ok {
+		t.Fatalf("%s is %T, not %T", what, v, *new(T))
+	}
+	return x
+}
+
+// dashboardChildValue returns a tftypes.Value for objType with exactly
+// setName populated to value and every other attribute null. It's the
+// one-level building block for composing multi-level oneof configs (e.g.
+// source.manual.strategy.range) without repeating the same
+// build-a-map/range/if-else shape at each level.
+func dashboardChildValue(objType tftypes.Object, setName string, value tftypes.Value) tftypes.Value {
+	raw := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, childType := range objType.AttributeTypes {
+		if name == setName {
+			raw[name] = value
+		} else {
+			raw[name] = tftypes.NewValue(childType, nil)
+		}
+	}
+	return tftypes.NewValue(objType, raw)
+}
+
+// dashboardRequireDetailNames fails the test unless detail names every one
+// of names (each wrapped in backticks, matching
+// exactlyOneOfChildrenValidator's error format).
+func dashboardRequireDetailNames(t *testing.T, detail string, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		if !strings.Contains(detail, "`"+name+"`") {
+			t.Fatalf("diagnostic does not name %q: %s", name, detail)
+		}
+	}
+}
+
+// TestDashboardWidgetDefinitionExactlyOneOfAtFullSchemaLevel drives the
+// widget-type 8-way oneof through the real "definition" attribute pulled out
+// of dashboard_schema.V4(), confirming the diagnostic surfaces at the parent
+// "definition" path (it moved there from a per-child path as part of the
+// ExactlyOneOfChildren migration) and still names every configured branch.
+func TestDashboardWidgetDefinitionExactlyOneOfAtFullSchemaLevel(t *testing.T) {
+	ctx := context.Background()
+	root := dashboardschema.V4()
+	definitionAttr := dashboardResolveAttribute(t, root.Attributes, "layout", "sections", "rows", "widgets", "definition")
+	definition, ok := definitionAttr.(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("widget definition is not a single nested attribute")
+	}
+	if !definition.Required {
+		t.Fatal("widget definition is not Required; the zero-set case below would not be a distinct, reachable state")
+	}
+
+	definitionPath := path.Root("definition")
+
+	t.Run("two_widget_types_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, definition.GetType(), "gauge", "line_chart")
+		diagnostics := dashboardValidateObject(ctx, cfg, definitionPath, definition.Validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		if !diagnostics[0].path.Equal(definitionPath) {
+			t.Fatalf("diagnostic path = %s, want %s", diagnostics[0].path, definitionPath)
+		}
+		for _, name := range []string{"gauge", "line_chart"} {
+			if !strings.Contains(diagnostics[0].detail, "`"+name+"`") {
+				t.Fatalf("diagnostic does not name %q: %s", name, diagnostics[0].detail)
+			}
+		}
+	})
+
+	t.Run("zero_widget_types_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, definition.GetType())
+		diagnostics := dashboardValidateObject(ctx, cfg, definitionPath, definition.Validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		if !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
+			t.Fatalf("unexpected diagnostic: %s", diagnostics[0].detail)
+		}
+	})
+}
+
+// TestDashboardGaugeLogsTimeFrameExactlyOneOf exercises TimeFrameSchema() at
+// one real call site (gauge's query.logs.time_frame), the most reused
+// oneof group in the tree. It also confirms time_frame = {} (present,
+// neither branch set) is a distinct, reachable error from omitting
+// time_frame entirely, which is valid since the whole block is Optional.
+func TestDashboardGaugeLogsTimeFrameExactlyOneOf(t *testing.T) {
+	ctx := context.Background()
+	root := dashboardschema.V4()
+	timeFrameAttr := dashboardResolveAttribute(t, root.Attributes,
+		"layout", "sections", "rows", "widgets", "definition", "gauge", "query", "logs", "time_frame")
+	timeFrame, ok := timeFrameAttr.(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("gauge query.logs.time_frame is not a single nested attribute")
+	}
+	if !timeFrame.Optional {
+		t.Fatal("gauge query.logs.time_frame is not Optional; the omitted case below would not apply")
+	}
+
+	timeFramePath := path.Root("time_frame")
+
+	t.Run("both_absolute_and_relative_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, timeFrame.GetType(), "absolute", "relative")
+		diagnostics := dashboardValidateObject(ctx, cfg, timeFramePath, timeFrame.Validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		for _, name := range []string{"absolute", "relative"} {
+			if !strings.Contains(diagnostics[0].detail, "`"+name+"`") {
+				t.Fatalf("diagnostic does not name %q: %s", name, diagnostics[0].detail)
+			}
+		}
+	})
+
+	t.Run("present_but_empty_time_frame", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, timeFrame.GetType())
+		diagnostics := dashboardValidateObject(ctx, cfg, timeFramePath, timeFrame.Validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		if !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
+			t.Fatalf("unexpected diagnostic: %s", diagnostics[0].detail)
+		}
+	})
+
+	t.Run("omitted_time_frame_is_valid", func(t *testing.T) {
+		cfg := dashboardObjectConfigNull(ctx, t, timeFrame.GetType())
+		diagnostics := dashboardValidateObject(ctx, cfg, timeFramePath, timeFrame.Validators)
+		if len(diagnostics) != 0 {
+			t.Fatalf("expected no diagnostics when time_frame is omitted entirely, got: %v", diagnostics)
+		}
+	})
+}
+
+// TestDashboardFolderExactlyOneOf covers the user-facing, documented
+// "folder" attribute independently of the internal wiring test: both id and
+// path set is a conflict, and folder = {} (present, neither set) is the
+// distinct zero-set error.
+func TestDashboardFolderExactlyOneOf(t *testing.T) {
+	ctx := context.Background()
+	root := dashboardschema.V4()
+	folderAttr := dashboardResolveAttribute(t, root.Attributes, "folder")
+	folder, ok := folderAttr.(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("folder is not a single nested attribute")
+	}
+
+	folderPath := path.Root("folder")
+
+	t.Run("both_id_and_path_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, folder.GetType(), "id", "path")
+		diagnostics := dashboardValidateObject(ctx, cfg, folderPath, folder.Validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		for _, name := range []string{"id", "path"} {
+			if !strings.Contains(diagnostics[0].detail, "`"+name+"`") {
+				t.Fatalf("diagnostic does not name %q: %s", name, diagnostics[0].detail)
+			}
+		}
+	})
+
+	t.Run("present_but_empty_folder", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, folder.GetType())
+		diagnostics := dashboardValidateObject(ctx, cfg, folderPath, folder.Validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		if !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
+			t.Fatalf("unexpected diagnostic: %s", diagnostics[0].detail)
+		}
+	})
+}
+
+// TestDashboardAnnotationSourceAndManualStrategyExactlyOneOf covers the
+// annotation "source" 4-way oneof (metrics/logs/spans/manual) and the nested
+// manual "strategy" 2-way oneof (instant/range), and confirms they're
+// independent: setting source.manual with only manual.strategy.range set is
+// valid for both groups at once, neither validator interfering with the
+// other.
+func TestDashboardAnnotationSourceAndManualStrategyExactlyOneOf(t *testing.T) {
+	ctx := context.Background()
+	root := dashboardschema.V4()
+
+	source := dashboardMustType[schema.SingleNestedAttribute](t,
+		dashboardResolveAttribute(t, root.Attributes, "annotations", "source"), "annotation source")
+	strategy := dashboardMustType[schema.SingleNestedAttribute](t,
+		dashboardResolveAttribute(t, root.Attributes, "annotations", "source", "manual", "strategy"), "manual annotation strategy")
+
+	sourcePath := path.Root("source")
+	strategyPath := path.Root("source").AtName("manual").AtName("strategy")
+
+	t.Run("source_zero_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, source.GetType())
+		diagnostics := dashboardValidateObject(ctx, cfg, sourcePath, source.Validators)
+		if len(diagnostics) != 1 || !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
+			t.Fatalf("unexpected diagnostics for zero-set source: %v", diagnostics)
+		}
+	})
+
+	t.Run("source_two_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, source.GetType(), "logs", "manual")
+		diagnostics := dashboardValidateObject(ctx, cfg, sourcePath, source.Validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		dashboardRequireDetailNames(t, diagnostics[0].detail, "logs", "manual")
+	})
+
+	t.Run("strategy_zero_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, strategy.GetType())
+		diagnostics := dashboardValidateObject(ctx, cfg, strategyPath, strategy.Validators)
+		if len(diagnostics) != 1 || !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
+			t.Fatalf("unexpected diagnostics for zero-set strategy: %v", diagnostics)
+		}
+	})
+
+	t.Run("strategy_two_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, strategy.GetType(), "instant", "range")
+		diagnostics := dashboardValidateObject(ctx, cfg, strategyPath, strategy.Validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		dashboardRequireDetailNames(t, diagnostics[0].detail, "instant", "range")
+	})
+
+	t.Run("manual_with_only_strategy_range_set_is_valid_at_both_levels", func(t *testing.T) {
+		sourceType := dashboardMustType[tftypes.Object](t, source.GetType().TerraformType(ctx), "source type")
+		manualType := dashboardMustType[tftypes.Object](t, sourceType.AttributeTypes["manual"], "manual type")
+		strategyType := dashboardMustType[tftypes.Object](t, manualType.AttributeTypes["strategy"], "strategy type")
+
+		strategyRaw := dashboardChildValue(strategyType, "range", dashboardSetValue(strategyType.AttributeTypes["range"]))
+		manualRaw := dashboardChildValue(manualType, "strategy", strategyRaw)
+		sourceRaw := dashboardChildValue(sourceType, "manual", manualRaw)
+
+		sourceVal, err := source.GetType().ValueFromTerraform(ctx, sourceRaw)
+		if err != nil {
+			t.Fatalf("build source config: %s", err)
+		}
+		sourceCfg := dashboardMustType[types.Object](t, sourceVal, "source config value")
+
+		if diagnostics := dashboardValidateObject(ctx, sourceCfg, sourcePath, source.Validators); len(diagnostics) != 0 {
+			t.Fatalf("expected source group to accept manual-only, got: %v", diagnostics)
+		}
+
+		manualObj := dashboardMustType[types.Object](t, sourceCfg.Attributes()["manual"], "source config's manual attribute")
+		strategyObj := dashboardMustType[types.Object](t, manualObj.Attributes()["strategy"], "manual config's strategy attribute")
+		if diagnostics := dashboardValidateObject(ctx, strategyObj, strategyPath, strategy.Validators); len(diagnostics) != 0 {
+			t.Fatalf("expected strategy group to accept range-only, got: %v", diagnostics)
+		}
+	})
+}
+
+// TestDashboardDataPrimeFiltersExactlyOneOfPerListElement covers the
+// genuinely different shape of FiltersSourceSchema() inside a
+// ListNestedAttribute's NestedObject (gauge's query.data_prime.filters):
+// the validator runs once per list element, so a real per-element path
+// (constructed the same way the framework itself would, via AtListIndex)
+// must identify which index failed.
+func TestDashboardDataPrimeFiltersExactlyOneOfPerListElement(t *testing.T) {
+	ctx := context.Background()
+	root := dashboardschema.V4()
+	filtersAttr := dashboardResolveAttribute(t, root.Attributes,
+		"layout", "sections", "rows", "widgets", "definition", "gauge", "query", "data_prime", "filters")
+	filters, ok := filtersAttr.(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatal("gauge query.data_prime.filters is not a list nested attribute")
+	}
+	validators := filters.NestedObject.Validators
+	if len(validators) != 1 {
+		t.Fatalf("gauge query.data_prime.filters element validators = %d, want 1", len(validators))
+	}
+	elementType := types.ObjectType{AttrTypes: attrTypesOf(t, filters.NestedObject.Attributes)}
+
+	filtersPath := path.Root("filters")
+
+	t.Run("zero_elements_is_a_no_op", func(t *testing.T) {
+		// An empty list has no elements to walk, so the per-element
+		// validator is never invoked and there is nothing to assert beyond
+		// "this does not panic" — documented here as a no-op rather than
+		// silently assumed.
+	})
+
+	t.Run("one_element_two_sources_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, elementType, "logs", "metrics")
+		elementPath := filtersPath.AtListIndex(0)
+		diagnostics := dashboardValidateObject(ctx, cfg, elementPath, validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		if !diagnostics[0].path.Equal(elementPath) {
+			t.Fatalf("diagnostic path = %s, want %s", diagnostics[0].path, elementPath)
+		}
+		for _, name := range []string{"logs", "metrics"} {
+			if !strings.Contains(diagnostics[0].detail, "`"+name+"`") {
+				t.Fatalf("diagnostic does not name %q: %s", name, diagnostics[0].detail)
+			}
+		}
+	})
+
+	t.Run("one_element_zero_sources_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, elementType)
+		elementPath := filtersPath.AtListIndex(0)
+		diagnostics := dashboardValidateObject(ctx, cfg, elementPath, validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		if !diagnostics[0].path.Equal(elementPath) {
+			t.Fatalf("diagnostic path = %s, want %s", diagnostics[0].path, elementPath)
+		}
+		if !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
+			t.Fatalf("unexpected diagnostic: %s", diagnostics[0].detail)
+		}
+	})
+}
+
+func attrTypesOf(t *testing.T, attrs map[string]schema.Attribute) map[string]attr.Type {
+	t.Helper()
+	out := make(map[string]attr.Type, len(attrs))
+	for name, attribute := range attrs {
+		out[name] = attribute.GetType()
+	}
+	return out
+}

--- a/internal/provider/dashboards/dashboard_schema/common.go
+++ b/internal/provider/dashboards/dashboard_schema/common.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -118,6 +117,9 @@ func stringOrVariableSchema() schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
 		Attributes: stringOrVariableAttr(),
 		Optional:   true,
+		Validators: []validator.Object{
+			dashboardwidgets.ExactlyOneOfChildren("string_value", "variable_name"),
+		},
 	}
 }
 
@@ -125,11 +127,6 @@ func stringOrVariableAttr() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"string_value": schema.StringAttribute{
 			Optional: true,
-			Validators: []validator.String{
-				dashboardwidgets.ExactlyOneOfString(
-					path.MatchRelative().AtParent().AtName("variable_name"),
-				),
-			},
 		},
 		"variable_name": schema.StringAttribute{
 			Optional: true,

--- a/internal/provider/dashboards/dashboard_schema/common.go
+++ b/internal/provider/dashboards/dashboard_schema/common.go
@@ -217,11 +217,6 @@ func manualAnnotationSourceAttribute() schema.SingleNestedAttribute {
 							},
 						},
 						Optional: true,
-						Validators: []validator.Object{
-							dashboardwidgets.ExactlyOneOfObject(
-								path.MatchRelative().AtParent().AtName("range"),
-							),
-						},
 					},
 					"range": schema.SingleNestedAttribute{
 						Attributes: map[string]schema.Attribute{
@@ -237,23 +232,14 @@ func manualAnnotationSourceAttribute() schema.SingleNestedAttribute {
 							},
 						},
 						Optional: true,
-						Validators: []validator.Object{
-							dashboardwidgets.ExactlyOneOfObject(
-								path.MatchRelative().AtParent().AtName("instant"),
-							),
-						},
 					},
 				},
 				Required: true,
+				Validators: []validator.Object{
+					dashboardwidgets.ExactlyOneOfChildren("instant", "range"),
+				},
 			},
 		},
 		Optional: true,
-		Validators: []validator.Object{
-			dashboardwidgets.ExactlyOneOfObject(
-				path.MatchRelative().AtParent().AtName("metrics"),
-				path.MatchRelative().AtParent().AtName("logs"),
-				path.MatchRelative().AtParent().AtName("spans"),
-			),
-		},
 	}
 }

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -901,9 +901,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 						Attributes: map[string]schema.Attribute{
 							"constant_value": schema.StringAttribute{
 								Optional: true,
-								Validators: []validator.String{
-									dashboardwidgets.ExactlyOneOfString(path.MatchRelative().AtParent().AtName("multi_select")),
-								},
 								DeprecationMessage: "`constant_value` is deprecated and rejected by the Coralogix API. " +
 									"Use a `multi_select` variable with a `constant_list` source and a single `selected_values` entry instead, " +
 									"e.g. `multi_select = { source = { constant_list = [\"value\"] }, selected_values = [\"value\"], values_order_direction = \"asc\" }`.",
@@ -934,14 +931,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 										Attributes: map[string]schema.Attribute{
 											"logs_path": schema.StringAttribute{
 												Optional: true,
-												Validators: []validator.String{
-													dashboardwidgets.ExactlyOneOfString(
-														path.MatchRelative().AtParent().AtName("metric_label"),
-														path.MatchRelative().AtParent().AtName("constant_list"),
-														path.MatchRelative().AtParent().AtName("span_field"),
-														path.MatchRelative().AtParent().AtName("query"),
-													),
-												},
 											},
 											"metric_label": schema.SingleNestedAttribute{
 												Attributes: map[string]schema.Attribute{
@@ -972,9 +961,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																				Required: true,
 																			},
 																		},
-																		Validators: []validator.Object{
-																			dashboardwidgets.ExactlyOneOfObject(path.MatchRelative().AtParent().AtName("field_value")),
-																		},
 																	},
 																	"field_value": schema.SingleNestedAttribute{
 																		Optional: true,
@@ -989,10 +975,7 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																},
 																Optional: true,
 																Validators: []validator.Object{
-																	dashboardwidgets.ExactlyOneOfObject(
-																		path.MatchRelative().AtParent().AtName("spans"),
-																		path.MatchRelative().AtParent().AtName("metrics"),
-																	),
+																	dashboardwidgets.ExactlyOneOfChildren("field_name", "field_value"),
 																},
 															},
 															"metrics": schema.SingleNestedAttribute{
@@ -1003,12 +986,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																			"metric_regex": schema.StringAttribute{
 																				Required: true,
 																			},
-																		},
-																		Validators: []validator.Object{
-																			dashboardwidgets.ExactlyOneOfObject(
-																				path.MatchRelative().AtParent().AtName("label_name"),
-																				path.MatchRelative().AtParent().AtName("label_value"),
-																			),
 																		},
 																	},
 																	"label_name": schema.SingleNestedAttribute{
@@ -1048,6 +1025,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																									},
 																									NestedObject: schema.NestedAttributeObject{
 																										Attributes: stringOrVariableAttr(),
+																										Validators: []validator.Object{
+																											dashboardwidgets.ExactlyOneOfChildren("string_value", "variable_name"),
+																										},
 																									},
 																								},
 																							},
@@ -1058,6 +1038,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																		},
 																		Optional: true,
 																	},
+																},
+																Validators: []validator.Object{
+																	dashboardwidgets.ExactlyOneOfChildren("metric_name", "label_name", "label_value"),
 																},
 																Optional: true,
 															},
@@ -1070,14 +1053,17 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																			},
 																		},
 																		Optional: true,
-																		Validators: []validator.Object{
-																			dashboardwidgets.ExactlyOneOfObject(path.MatchRelative().AtParent().AtName("field_value")),
-																		},
 																	},
 																	"field_value": dashboardwidgets.SpansFieldSchema(),
 																},
+																Validators: []validator.Object{
+																	dashboardwidgets.ExactlyOneOfChildren("field_name", "field_value"),
+																},
 																Optional: true,
 															},
+														},
+														Validators: []validator.Object{
+															dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans"),
 														},
 														Required: true,
 													},
@@ -1104,11 +1090,17 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 												Optional: true,
 											},
 										},
+										Validators: []validator.Object{
+											dashboardwidgets.ExactlyOneOfChildren("logs_path", "metric_label", "constant_list", "span_field", "query"),
+										},
 										Optional: true,
 									},
 								},
 								Optional: true,
 							},
+						},
+						Validators: []validator.Object{
+							dashboardwidgets.ExactlyOneOfChildren("constant_value", "multi_select"),
 						},
 					},
 					"display_name": schema.StringAttribute{

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -134,13 +134,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"logs_aggregation": dashboardwidgets.LogsAggregationSchema(),
 																					"time_frame":       dashboardwidgets.TimeFrameSchema(),
 																				},
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("spans"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																				Optional: true,
 																			},
 																			"metrics": schema.SingleNestedAttribute{
@@ -161,13 +154,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("spans"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																			},
 																			"spans": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{
@@ -179,13 +165,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame":        dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																			},
 																			"data_prime": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{
@@ -195,22 +174,21 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"filters": schema.ListNestedAttribute{
 																						NestedObject: schema.NestedAttributeObject{
 																							Attributes: dashboardwidgets.FiltersSourceSchema(),
+																							Validators: []validator.Object{
+																								dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans"),
+																							},
 																						},
 																						Optional: true,
 																					},
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("spans"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																					),
-																				},
 																			},
 																		},
 																		Required: true,
+																		Validators: []validator.Object{
+																			dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans", "data_prime"),
+																		},
 																	},
 																	"min": schema.Float64Attribute{
 																		Optional: true,
@@ -292,7 +270,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																	},
 																},
 																Validators: []validator.Object{
-																	dashboardwidgets.SupportedWidgetsValidatorWithout("gauge"),
 																	objectvalidator.AlsoRequires(
 																		path.MatchRelative().AtParent().AtParent().AtName("title"),
 																	),
@@ -333,13 +310,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("spans"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																			},
 																			"spans": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{
@@ -353,13 +323,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame":         dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																			},
 																			"metrics": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{
@@ -377,13 +340,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("spans"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																			},
 																			"data_prime": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{
@@ -393,6 +349,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"filters": schema.ListNestedAttribute{
 																						NestedObject: schema.NestedAttributeObject{
 																							Attributes: dashboardwidgets.FiltersSourceSchema(),
+																							Validators: []validator.Object{
+																								dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans"),
+																							},
 																						},
 																						Optional: true,
 																					},
@@ -406,16 +365,12 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("spans"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																					),
-																				},
 																			},
 																		},
 																		Required: true,
+																		Validators: []validator.Object{
+																			dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans", "data_prime"),
+																		},
 																	},
 																	"max_slices_per_chart": schema.Int64Attribute{
 																		Optional: true,
@@ -497,9 +452,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																		},
 																	},
 																},
-																Validators: []validator.Object{
-																	dashboardwidgets.SupportedWidgetsValidatorWithout("pie_chart"),
-																},
 																Optional: true,
 															},
 															"bar_chart": schema.SingleNestedAttribute{
@@ -533,13 +485,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																						path.MatchRelative().AtParent().AtName("spans"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																			},
 																			"metrics": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{
@@ -557,13 +502,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("spans"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																			},
 																			"spans": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{
@@ -577,13 +515,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame":         dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																						path.MatchRelative().AtParent().AtName("data_prime"),
-																					),
-																				},
 																			},
 																			"data_prime": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{
@@ -593,6 +524,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"filters": schema.ListNestedAttribute{
 																						NestedObject: schema.NestedAttributeObject{
 																							Attributes: dashboardwidgets.FiltersSourceSchema(),
+																							Validators: []validator.Object{
+																								dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans"),
+																							},
 																						},
 																						Optional: true,
 																					},
@@ -606,16 +540,12 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																						path.MatchRelative().AtParent().AtName("spans"),
-																					),
-																				},
 																			},
 																		},
 																		Optional: true,
+																		Validators: []validator.Object{
+																			dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans", "data_prime"),
+																		},
 																	},
 																	"max_bars_per_chart": schema.Int64Attribute{
 																		Optional: true,
@@ -659,21 +589,14 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					},
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("value"),
-																					),
-																				},
 																			},
 																			"value": schema.SingleNestedAttribute{
 																				Attributes: map[string]schema.Attribute{},
 																				Optional:   true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("time"),
-																					),
-																				},
 																			},
+																		},
+																		Validators: []validator.Object{
+																			dashboardwidgets.ExactlyOneOfChildren("time", "value"),
 																		},
 																	},
 																	"unit": schema.StringAttribute{
@@ -711,7 +634,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																	},
 																},
 																Validators: []validator.Object{
-																	dashboardwidgets.SupportedWidgetsValidatorWithout("bar_chart"),
 																	objectvalidator.AlsoRequires(
 																		path.MatchRelative().AtParent().AtParent().AtName("title"),
 																	),
@@ -791,6 +713,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"filters": schema.ListNestedAttribute{
 																						NestedObject: schema.NestedAttributeObject{
 																							Attributes: dashboardwidgets.FiltersSourceSchema(),
+																							Validators: []validator.Object{
+																								dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans"),
+																							},
 																						},
 																						Optional: true,
 																					},
@@ -804,16 +729,12 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																					"time_frame": dashboardwidgets.TimeFrameSchema(),
 																				},
 																				Optional: true,
-																				Validators: []validator.Object{
-																					dashboardwidgets.ExactlyOneOfObject(
-																						path.MatchRelative().AtParent().AtName("logs"),
-																						path.MatchRelative().AtParent().AtName("metrics"),
-																						path.MatchRelative().AtParent().AtName("spans"),
-																					),
-																				},
 																			},
 																		},
 																		Optional: true,
+																		Validators: []validator.Object{
+																			dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans", "data_prime"),
+																		},
 																	},
 																	"max_bars_per_chart": schema.Int64Attribute{
 																		Optional: true,
@@ -885,7 +806,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																	},
 																},
 																Validators: []validator.Object{
-																	dashboardwidgets.SupportedWidgetsValidatorWithout("horizontal_bar_chart"),
 																	objectvalidator.AlsoRequires(
 																		path.MatchRelative().AtParent().AtParent().AtName("title"),
 																	),
@@ -902,7 +822,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																	},
 																},
 																Validators: []validator.Object{
-																	dashboardwidgets.SupportedWidgetsValidatorWithout("markdown"),
 																	objectvalidator.ConflictsWith(
 																		path.MatchRelative().AtParent().AtParent().AtName("title"),
 																	),
@@ -911,6 +830,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 															},
 														},
 														MarkdownDescription: fmt.Sprintf("The widget definition. Can contain one of %v", dashboardwidgets.SupportedWidgetTypes),
+														Validators: []validator.Object{
+															dashboardwidgets.SupportedWidgetsExactlyOneOfChildren(),
+														},
 													},
 													"width": schema.Int64Attribute{
 														Optional: true,
@@ -1205,7 +1127,10 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 				Attributes: map[string]schema.Attribute{
 					"source": schema.SingleNestedAttribute{
 						Attributes: dashboardwidgets.FiltersSourceSchema(),
-						Required:   true,
+						Validators: []validator.Object{
+							dashboardwidgets.ExactlyOneOfChildren("logs", "metrics", "spans"),
+						},
+						Required: true,
 					},
 					"enabled": schema.BoolAttribute{
 						Optional: true,
@@ -1229,11 +1154,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 			Attributes: map[string]schema.Attribute{
 				"id": schema.StringAttribute{
 					Optional: true,
-					Validators: []validator.String{
-						dashboardwidgets.ExactlyOneOfString(
-							path.MatchRelative().AtParent().AtName("path"),
-						),
-					},
 					MarkdownDescription: "ID of the dashboards folder this dashboard belongs to. " +
 						"When authoring a `coralogix_dashboard` resource, this is the lifecycle-safe " +
 						"choice: reference a `coralogix_dashboards_folder` resource's `id` so the " +
@@ -1241,11 +1161,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 				},
 				"path": schema.StringAttribute{
 					Optional: true,
-					Validators: []validator.String{
-						dashboardwidgets.ExactlyOneOfString(
-							path.MatchRelative().AtParent().AtName("id"),
-						),
-					},
 					MarkdownDescription: "Slash-separated folder path (e.g. `Team/Subteam`). When set " +
 						"on a `coralogix_dashboard` resource and the path does not already exist, the " +
 						"Coralogix dashboards service implicitly creates the missing folder hierarchy " +
@@ -1257,6 +1172,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 				},
 			},
 			Optional: true,
+			Validators: []validator.Object{
+				dashboardwidgets.ExactlyOneOfChildren("id", "path"),
+			},
 			MarkdownDescription: "The dashboards folder this dashboard belongs to. Exactly one of " +
 				"`id` or `path` is set. When authoring a `coralogix_dashboard` resource, `id` (pointing " +
 				"at a `coralogix_dashboards_folder` resource) is the recommended form; `path` is " +
@@ -1307,39 +1225,21 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 									},
 								},
 								Optional: true,
-								Validators: []validator.Object{
-									dashboardwidgets.ExactlyOneOfObject(
-										path.MatchRelative().AtParent().AtName("logs"),
-										path.MatchRelative().AtParent().AtName("spans"),
-										path.MatchRelative().AtParent().AtName("manual"),
-									),
-								},
 							},
 							"logs": schema.SingleNestedAttribute{
 								Attributes: logsAndSpansAttributes(),
 								Optional:   true,
-								Validators: []validator.Object{
-									dashboardwidgets.ExactlyOneOfObject(
-										path.MatchRelative().AtParent().AtName("metrics"),
-										path.MatchRelative().AtParent().AtName("spans"),
-										path.MatchRelative().AtParent().AtName("manual"),
-									),
-								},
 							},
 							"spans": schema.SingleNestedAttribute{
 								Attributes: logsAndSpansAttributes(),
 								Optional:   true,
-								Validators: []validator.Object{
-									dashboardwidgets.ExactlyOneOfObject(
-										path.MatchRelative().AtParent().AtName("metrics"),
-										path.MatchRelative().AtParent().AtName("logs"),
-										path.MatchRelative().AtParent().AtName("manual"),
-									),
-								},
 							},
 							"manual": manualAnnotationSourceAttribute(),
 						},
 						Required: true,
+						Validators: []validator.Object{
+							dashboardwidgets.ExactlyOneOfChildren("metrics", "logs", "spans", "manual"),
+						},
 					},
 				},
 			},

--- a/internal/provider/dashboards/dashboard_schema/v4_oneof_wiring_test.go
+++ b/internal/provider/dashboards/dashboard_schema/v4_oneof_wiring_test.go
@@ -204,18 +204,18 @@ func dashboardAssertOneOfGroupsMigrated(t *testing.T, containers []dashboardOneO
 	for _, container := range containers {
 		for _, childName := range dashboardSortedKeys(container.attributes) {
 			for _, v := range dashboardObjectValidatorsOf(container.attributes[childName]) {
-				if expressions, ok := dashboardwidgets.ExactlyOneOfObjectPathExpressions(v); ok {
+				if fv, ok := v.(dashboardwidgets.FriendlyExactlyOneOfObjectValidator); ok {
 					t.Errorf("%s.%s still carries an old-style child-attached ExactlyOneOfObject validator (siblings: %v); "+
 						"migrate this oneof group to a single ExactlyOneOfChildren validator attached to %s",
-						container.path, childName, expressions, container.path)
+						container.path, childName, fv.PathExpressions, container.path)
 				}
 			}
 		}
 
 		var matches [][]string
 		for _, v := range container.validators {
-			if names, ok := dashboardwidgets.ExactlyOneOfChildrenNames(v); ok {
-				matches = append(matches, names)
+			if ev, ok := v.(dashboardwidgets.ExactlyOneOfChildrenValidator); ok {
+				matches = append(matches, ev.ChildNames)
 			}
 		}
 		if len(matches) > 1 {
@@ -265,8 +265,8 @@ func TestV4TopLevelOneOfGroupsAreWiredToExactlyOneOfChildren(t *testing.T) {
 
 			var matches [][]string
 			for _, v := range container.validators {
-				if names, ok := dashboardwidgets.ExactlyOneOfChildrenNames(v); ok {
-					matches = append(matches, names)
+				if ev, ok := v.(dashboardwidgets.ExactlyOneOfChildrenValidator); ok {
+					matches = append(matches, ev.ChildNames)
 				}
 			}
 			if len(matches) != 1 {

--- a/internal/provider/dashboards/dashboard_schema/v4_oneof_wiring_test.go
+++ b/internal/provider/dashboards/dashboard_schema/v4_oneof_wiring_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_schema
+
+import (
+	"sort"
+	"testing"
+
+	dashboardwidgets "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_widgets"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// dashboardOneOfContainer is an object-shaped schema node that groups named
+// child attributes and can itself carry validator.Object validators: either
+// a SingleNestedAttribute, or the NestedObject wrapped by a List/Set nested
+// attribute.
+type dashboardOneOfContainer struct {
+	path       string
+	attributes map[string]schema.Attribute
+	validators []validator.Object
+}
+
+// dashboardObjectValidatorsOf returns the validator.Object list an attribute
+// carries on itself, regardless of which nested-attribute kind it is. Only
+// the kinds actually used in the V4 schema are handled; anything else
+// carries no object validators for this walk's purposes.
+func dashboardObjectValidatorsOf(attribute schema.Attribute) []validator.Object {
+	switch a := attribute.(type) {
+	case schema.SingleNestedAttribute:
+		return a.Validators
+	case schema.ListNestedAttribute:
+		return a.NestedObject.Validators
+	case schema.SetNestedAttribute:
+		return a.NestedObject.Validators
+	default:
+		return nil
+	}
+}
+
+// dashboardWalkOneOfContainers recursively collects every object-shaped
+// container reachable from attributes, tagging each with a dot-joined path
+// (list/set levels marked with "[]") for readable failure messages.
+func dashboardWalkOneOfContainers(prefix string, attributes map[string]schema.Attribute, out *[]dashboardOneOfContainer) {
+	for name, attribute := range attributes {
+		p := prefix + "." + name
+		switch a := attribute.(type) {
+		case schema.SingleNestedAttribute:
+			*out = append(*out, dashboardOneOfContainer{path: p, attributes: a.Attributes, validators: a.Validators})
+			dashboardWalkOneOfContainers(p, a.Attributes, out)
+		case schema.ListNestedAttribute:
+			*out = append(*out, dashboardOneOfContainer{path: p + "[]", attributes: a.NestedObject.Attributes, validators: a.NestedObject.Validators})
+			dashboardWalkOneOfContainers(p+"[]", a.NestedObject.Attributes, out)
+		case schema.SetNestedAttribute:
+			*out = append(*out, dashboardOneOfContainer{path: p + "[]", attributes: a.NestedObject.Attributes, validators: a.NestedObject.Validators})
+			dashboardWalkOneOfContainers(p+"[]", a.NestedObject.Attributes, out)
+		}
+	}
+}
+
+func dashboardSortedKeys(m map[string]schema.Attribute) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func dashboardSortedCopy(s []string) []string {
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+	return out
+}
+
+func dashboardEqualStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestV4WidgetOneOfGroupsAreMigratedToExactlyOneOfChildren walks every
+// object-shaped node under the widget "definition" subtree of V4() (the
+// per-widget hot path the ExactlyOneOfChildren perf migration targeted) and
+// asserts two things generically, without hand-enumerating every group:
+//
+//  1. No child attribute anywhere in the subtree still carries an old-style,
+//     child-attached ExactlyOneOfObject validator. That pattern is exactly
+//     the shape of the leftover bugs found in Hexagon's and LineChart's
+//     query oneofs: the parent-level ExactlyOneOfChildren was added
+//     elsewhere in the file, but one group was missed.
+//  2. Wherever a migrated ExactlyOneOfChildren-family validator IS attached
+//     to a container, its childNames set is exactly the container's own
+//     attribute keys — catching childNames silently drifting from the
+//     schema's real attribute map (these are plain strings with no
+//     compiler tie back to the map keys), and catching duplicate
+//     attachment.
+func TestV4WidgetOneOfGroupsAreMigratedToExactlyOneOfChildren(t *testing.T) {
+	root := V4()
+	layout, ok := root.Attributes["layout"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("layout is not a single nested attribute")
+	}
+
+	var containers []dashboardOneOfContainer
+	dashboardWalkOneOfContainers("layout", layout.Attributes, &containers)
+	if len(containers) == 0 {
+		t.Fatal("walked zero containers under layout; the walker is likely broken")
+	}
+
+	migratedGroups := 0
+	for _, container := range containers {
+		for _, childName := range dashboardSortedKeys(container.attributes) {
+			for _, v := range dashboardObjectValidatorsOf(container.attributes[childName]) {
+				if expressions, ok := dashboardwidgets.ExactlyOneOfObjectPathExpressions(v); ok {
+					t.Errorf("%s.%s still carries an old-style child-attached ExactlyOneOfObject validator (siblings: %v); "+
+						"migrate this oneof group to a single ExactlyOneOfChildren validator attached to %s",
+						container.path, childName, expressions, container.path)
+				}
+			}
+		}
+
+		var matches [][]string
+		for _, v := range container.validators {
+			if names, ok := dashboardwidgets.ExactlyOneOfChildrenNames(v); ok {
+				matches = append(matches, names)
+			}
+		}
+		if len(matches) > 1 {
+			t.Errorf("%s has %d ExactlyOneOfChildren-family validators attached, want at most 1", container.path, len(matches))
+			continue
+		}
+		if len(matches) == 1 {
+			migratedGroups++
+			got := dashboardSortedCopy(matches[0])
+			want := dashboardSortedKeys(container.attributes)
+			if !dashboardEqualStrings(got, want) {
+				t.Errorf("%s: ExactlyOneOfChildren childNames = %v, want exactly the attribute keys %v", container.path, got, want)
+			}
+		}
+	}
+
+	// Sanity floor so a future refactor that silently strips every
+	// validator from the walked subtree doesn't pass this test by having
+	// nothing left to check. As of this test's authoring there are 15
+	// migrated groups under layout: the 8-way widget "definition", one
+	// 4-way query group per of {gauge, pie_chart, bar_chart,
+	// horizontal_bar_chart, data_table, hexagon, line_chart}, bar_chart's
+	// xaxis, and several TimeFrameSchema()/FiltersSourceSchema() instances.
+	const minMigratedGroups = 15
+	if migratedGroups < minMigratedGroups {
+		t.Errorf("found %d migrated ExactlyOneOfChildren groups under layout, want at least %d", migratedGroups, minMigratedGroups)
+	}
+}
+
+// dashboardOneOfCase describes one known oneof parent attribute outside the
+// widget "definition" subtree, reached by walking SingleNestedAttribute
+// and ListNestedAttribute containers by name from V4()'s root attributes.
+type dashboardOneOfCase struct {
+	name string
+	path []string
+}
+
+// TestV4TopLevelOneOfGroupsAreWiredToExactlyOneOfChildren checks the
+// remaining known oneof parent attributes that sit outside the per-widget
+// "layout" subtree covered by TestV4WidgetOneOfGroupsAreMigratedToExactlyOneOfChildren:
+// the dashboard's folder reference and the annotation source groups.
+func TestV4TopLevelOneOfGroupsAreWiredToExactlyOneOfChildren(t *testing.T) {
+	root := V4()
+
+	cases := []dashboardOneOfCase{
+		{name: "folder (id/path)", path: []string{"folder"}},
+		{name: "annotation source (metrics/logs/spans/manual)", path: []string{"annotations", "source"}},
+		{name: "manual annotation strategy (instant/range)", path: []string{"annotations", "source", "manual", "strategy"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			container, ok := dashboardNavigateOneOfContainer(root.Attributes, tc.path)
+			if !ok {
+				t.Fatalf("could not navigate to %v", tc.path)
+			}
+
+			var matches [][]string
+			for _, v := range container.validators {
+				if names, ok := dashboardwidgets.ExactlyOneOfChildrenNames(v); ok {
+					matches = append(matches, names)
+				}
+			}
+			if len(matches) != 1 {
+				t.Fatalf("%s has %d ExactlyOneOfChildren-family validators attached, want exactly 1", container.path, len(matches))
+			}
+			got := dashboardSortedCopy(matches[0])
+			want := dashboardSortedKeys(container.attributes)
+			if !dashboardEqualStrings(got, want) {
+				t.Fatalf("%s: ExactlyOneOfChildren childNames = %v, want exactly the attribute keys %v", container.path, got, want)
+			}
+		})
+	}
+}
+
+// dashboardNavigateOneOfContainer walks a chain of attribute names starting
+// from root, stepping transparently through SingleNestedAttribute and
+// ListNestedAttribute/SetNestedAttribute containers (list/set levels don't
+// consume a path segment of their own — NestedObject.Attributes is used
+// directly), and returns the container found at the last segment.
+func dashboardNavigateOneOfContainer(root map[string]schema.Attribute, segments []string) (dashboardOneOfContainer, bool) {
+	current := dashboardOneOfContainer{path: "root", attributes: root}
+	for _, segment := range segments {
+		attribute, ok := current.attributes[segment]
+		if !ok {
+			return dashboardOneOfContainer{}, false
+		}
+		path := current.path + "." + segment
+		switch a := attribute.(type) {
+		case schema.SingleNestedAttribute:
+			current = dashboardOneOfContainer{path: path, attributes: a.Attributes, validators: a.Validators}
+		case schema.ListNestedAttribute:
+			current = dashboardOneOfContainer{path: path + "[]", attributes: a.NestedObject.Attributes, validators: a.NestedObject.Validators}
+		case schema.SetNestedAttribute:
+			current = dashboardOneOfContainer{path: path + "[]", attributes: a.NestedObject.Attributes, validators: a.NestedObject.Validators}
+		default:
+			return dashboardOneOfContainer{}, false
+		}
+	}
+	return current, true
+}

--- a/internal/provider/dashboards/dashboard_schema/v4_oneof_wiring_test.go
+++ b/internal/provider/dashboards/dashboard_schema/v4_oneof_wiring_test.go
@@ -97,6 +97,24 @@ func dashboardEqualStrings(a, b []string) bool {
 	return true
 }
 
+// dashboardUnknownChildNames returns the entries of childNames that aren't
+// keys of attributes. An ExactlyOneOfChildren-family validator's childNames
+// don't have to cover every attribute in the container it's attached to —
+// some oneof groups sit alongside an unrelated sibling that applies
+// regardless of which branch of the group is chosen (e.g. a filter's
+// `operator`, next to the mutually exclusive `field`/`observation_field`
+// pair) — but every name it does list must resolve to a real attribute, or
+// it's silently stale drift from a rename.
+func dashboardUnknownChildNames(childNames []string, attributes map[string]schema.Attribute) []string {
+	var unknown []string
+	for _, name := range childNames {
+		if _, ok := attributes[name]; !ok {
+			unknown = append(unknown, name)
+		}
+	}
+	return unknown
+}
+
 // TestV4WidgetOneOfGroupsAreMigratedToExactlyOneOfChildren walks every
 // object-shaped node under the widget "definition" subtree of V4() (the
 // per-widget hot path the ExactlyOneOfChildren perf migration targeted) and
@@ -126,6 +144,62 @@ func TestV4WidgetOneOfGroupsAreMigratedToExactlyOneOfChildren(t *testing.T) {
 		t.Fatal("walked zero containers under layout; the walker is likely broken")
 	}
 
+	migratedGroups := dashboardAssertOneOfGroupsMigrated(t, containers)
+
+	// Sanity floor so a future refactor that silently strips every
+	// validator from the walked subtree doesn't pass this test by having
+	// nothing left to check. As of this test's authoring there are 15
+	// migrated groups under layout: the 8-way widget "definition", one
+	// 4-way query group per of {gauge, pie_chart, bar_chart,
+	// horizontal_bar_chart, data_table, hexagon, line_chart}, bar_chart's
+	// xaxis, and several TimeFrameSchema()/FiltersSourceSchema() instances.
+	const minMigratedGroups = 15
+	if migratedGroups < minMigratedGroups {
+		t.Errorf("found %d migrated ExactlyOneOfChildren groups under layout, want at least %d", migratedGroups, minMigratedGroups)
+	}
+}
+
+// TestV4VariablesOneOfGroupsAreMigratedToExactlyOneOfChildren mirrors
+// TestV4WidgetOneOfGroupsAreMigratedToExactlyOneOfChildren for the
+// dashboard's top-level "variables" list, a second per-instance subtree
+// (variables aren't widgets, but a dashboard can define many of them, so
+// their oneof groups pay the same per-instance config-tree-walk cost as the
+// widget "definition" subtree if left in the old child-attached style).
+func TestV4VariablesOneOfGroupsAreMigratedToExactlyOneOfChildren(t *testing.T) {
+	root := V4()
+	variables, ok := root.Attributes["variables"].(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatal("variables is not a list nested attribute")
+	}
+
+	var containers []dashboardOneOfContainer
+	dashboardWalkOneOfContainers("variables[]", variables.NestedObject.Attributes, &containers)
+	if len(containers) == 0 {
+		t.Fatal("walked zero containers under variables; the walker is likely broken")
+	}
+
+	migratedGroups := dashboardAssertOneOfGroupsMigrated(t, containers)
+
+	// Sanity floor, mirroring the one in the widget test above. As of this
+	// test's authoring there are 11 migrated groups under variables:
+	// definition (constant_value/multi_select), multi_select.source (5-way),
+	// the query logs/metrics/spans selector plus its own logs/metrics/spans
+	// field-vs-value groups (4 groups), and 5 stringOrVariableSchema()
+	// (string_value/variable_name) instances.
+	const minMigratedGroups = 11
+	if migratedGroups < minMigratedGroups {
+		t.Errorf("found %d migrated ExactlyOneOfChildren groups under variables, want at least %d", migratedGroups, minMigratedGroups)
+	}
+}
+
+// dashboardAssertOneOfGroupsMigrated asserts, for every container walked
+// from a subtree root, that (1) no child attribute still carries an
+// old-style child-attached ExactlyOneOfObject validator, and (2) wherever an
+// ExactlyOneOfChildren-family validator is attached, its childNames resolve
+// to real attribute keys of that same container. It returns the number of
+// containers carrying a migrated validator, for callers to sanity-floor.
+func dashboardAssertOneOfGroupsMigrated(t *testing.T, containers []dashboardOneOfContainer) int {
+	t.Helper()
 	migratedGroups := 0
 	for _, container := range containers {
 		for _, childName := range dashboardSortedKeys(container.attributes) {
@@ -151,24 +225,14 @@ func TestV4WidgetOneOfGroupsAreMigratedToExactlyOneOfChildren(t *testing.T) {
 		if len(matches) == 1 {
 			migratedGroups++
 			got := dashboardSortedCopy(matches[0])
-			want := dashboardSortedKeys(container.attributes)
-			if !dashboardEqualStrings(got, want) {
-				t.Errorf("%s: ExactlyOneOfChildren childNames = %v, want exactly the attribute keys %v", container.path, got, want)
+			if unknown := dashboardUnknownChildNames(got, container.attributes); len(unknown) > 0 {
+				t.Errorf("%s: ExactlyOneOfChildren childNames = %v reference attribute(s) %v not present in this container's attribute keys %v; "+
+					"childNames is a plain string list with no compiler tie back to the schema map, so this is likely drift from a rename",
+					container.path, got, unknown, dashboardSortedKeys(container.attributes))
 			}
 		}
 	}
-
-	// Sanity floor so a future refactor that silently strips every
-	// validator from the walked subtree doesn't pass this test by having
-	// nothing left to check. As of this test's authoring there are 15
-	// migrated groups under layout: the 8-way widget "definition", one
-	// 4-way query group per of {gauge, pie_chart, bar_chart,
-	// horizontal_bar_chart, data_table, hexagon, line_chart}, bar_chart's
-	// xaxis, and several TimeFrameSchema()/FiltersSourceSchema() instances.
-	const minMigratedGroups = 15
-	if migratedGroups < minMigratedGroups {
-		t.Errorf("found %d migrated ExactlyOneOfChildren groups under layout, want at least %d", migratedGroups, minMigratedGroups)
-	}
+	return migratedGroups
 }
 
 // dashboardOneOfCase describes one known oneof parent attribute outside the

--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -1901,11 +1901,117 @@ func SupportedWidgetsValidatorWithout(current string) validator.Object {
 	return ExactlyOneOfObject(matchers...)
 }
 
+// ExactlyOneOfChildren validates that exactly one of the named direct child
+// attributes of this object is non-null. Unlike ExactlyOneOfObject/
+// objectvalidator.ExactlyOneOf, it reads req.ConfigValue directly instead of
+// resolving path.Expressions via Config.PathMatches, so it doesn't pay for a
+// full config-tree walk per check. Attach it to the parent object of a oneof
+// group instead of to each child.
+func ExactlyOneOfChildren(childNames ...string) validator.Object {
+	return exactlyOneOfChildrenValidator{childNames: childNames}
+}
+
+// SupportedWidgetsExactlyOneOfChildren is the cheap, parent-attached
+// equivalent of SupportedWidgetsValidatorWithout: attach it once to the
+// widget "definition" object instead of once per widget type.
+func SupportedWidgetsExactlyOneOfChildren() validator.Object {
+	return ExactlyOneOfChildren(SupportedWidgetTypes...)
+}
+
+// ExactlyOneOfChildrenNames reports the child attribute names an
+// ExactlyOneOfChildren-family validator.Object was constructed with, and
+// whether v is such a validator. Schema-wiring tests use this to assert a
+// validator's childNames haven't silently drifted from the actual attribute
+// map it's attached to (childNames is a plain string list with no compiler
+// tie back to the schema's attribute keys).
+func ExactlyOneOfChildrenNames(v validator.Object) ([]string, bool) {
+	ev, ok := v.(exactlyOneOfChildrenValidator)
+	if !ok {
+		return nil, false
+	}
+	return ev.childNames, true
+}
+
+type exactlyOneOfChildrenValidator struct {
+	childNames []string
+}
+
+func (v exactlyOneOfChildrenValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("exactly one of %v must be configured", v.childNames)
+}
+
+func (v exactlyOneOfChildrenValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v exactlyOneOfChildrenValidator) ValidateObject(_ context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	attrs := req.ConfigValue.Attributes()
+	var set []string
+	unknownCount := 0
+	for _, name := range v.childNames {
+		val, ok := attrs[name]
+		if !ok {
+			continue
+		}
+		if val.IsUnknown() {
+			unknownCount++
+			continue
+		}
+		if !val.IsNull() {
+			set = append(set, name)
+		}
+	}
+
+	// A second known-and-set child is an unavoidable conflict no matter how
+	// any remaining unknown children resolve, so report it immediately.
+	if len(set) > 1 {
+		quoted := make([]string, len(set))
+		for i, name := range set {
+			quoted[i] = "`" + name + "`"
+		}
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Attribute Combination",
+			fmt.Sprintf("Only one of these attributes can be configured: %s.", strings.Join(quoted, ", ")))
+		return
+	}
+
+	// With at most one known-and-set child, an unknown sibling could still
+	// resolve to satisfy (or break) "exactly one" — defer instead of
+	// reporting a false-positive "none configured" error.
+	if unknownCount > 0 {
+		return
+	}
+
+	switch len(set) {
+	case 1:
+		return
+	case 0:
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Attribute Combination",
+			"No attribute was configured in this one-of group. Configure exactly one value.")
+	}
+}
+
 func ExactlyOneOfObject(expressions ...path.Expression) validator.Object {
 	return friendlyExactlyOneOfObjectValidator{
 		Object:          objectvalidator.ExactlyOneOf(expressions...),
 		PathExpressions: expressions,
 	}
+}
+
+// ExactlyOneOfObjectPathExpressions reports the sibling path.Expressions an
+// old-style, child-attached ExactlyOneOfObject validator.Object was
+// constructed with, and whether v is such a validator. Schema-wiring tests
+// use this to catch oneof groups left behind by an incomplete migration to
+// the cheaper, parent-attached ExactlyOneOfChildren.
+func ExactlyOneOfObjectPathExpressions(v validator.Object) (path.Expressions, bool) {
+	fv, ok := v.(friendlyExactlyOneOfObjectValidator)
+	if !ok {
+		return nil, false
+	}
+	return fv.PathExpressions, true
 }
 
 func ExactlyOneOfString(expressions ...path.Expression) validator.String {

--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -1908,7 +1908,7 @@ func SupportedWidgetsValidatorWithout(current string) validator.Object {
 // full config-tree walk per check. Attach it to the parent object of a oneof
 // group instead of to each child.
 func ExactlyOneOfChildren(childNames ...string) validator.Object {
-	return exactlyOneOfChildrenValidator{childNames: childNames}
+	return ExactlyOneOfChildrenValidator{ChildNames: childNames}
 }
 
 // SupportedWidgetsExactlyOneOfChildren is the cheap, parent-attached
@@ -1918,33 +1918,25 @@ func SupportedWidgetsExactlyOneOfChildren() validator.Object {
 	return ExactlyOneOfChildren(SupportedWidgetTypes...)
 }
 
-// ExactlyOneOfChildrenNames reports the child attribute names an
-// ExactlyOneOfChildren-family validator.Object was constructed with, and
-// whether v is such a validator. Schema-wiring tests use this to assert a
-// validator's childNames haven't silently drifted from the actual attribute
-// map it's attached to (childNames is a plain string list with no compiler
-// tie back to the schema's attribute keys).
-func ExactlyOneOfChildrenNames(v validator.Object) ([]string, bool) {
-	ev, ok := v.(exactlyOneOfChildrenValidator)
-	if !ok {
-		return nil, false
-	}
-	return ev.childNames, true
+// ExactlyOneOfChildrenValidator is exported (rather than kept as an
+// unexported implementation type) so schema-wiring tests in other packages
+// can type-assert a validator.Object and inspect ChildNames directly, to
+// assert it hasn't silently drifted from the actual attribute map it's
+// attached to (ChildNames is a plain string list with no compiler tie back
+// to the schema's attribute keys).
+type ExactlyOneOfChildrenValidator struct {
+	ChildNames []string
 }
 
-type exactlyOneOfChildrenValidator struct {
-	childNames []string
+func (v ExactlyOneOfChildrenValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("exactly one of %v must be configured", v.ChildNames)
 }
 
-func (v exactlyOneOfChildrenValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("exactly one of %v must be configured", v.childNames)
-}
-
-func (v exactlyOneOfChildrenValidator) MarkdownDescription(ctx context.Context) string {
+func (v ExactlyOneOfChildrenValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v exactlyOneOfChildrenValidator) ValidateObject(_ context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+func (v ExactlyOneOfChildrenValidator) ValidateObject(_ context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
@@ -1952,7 +1944,7 @@ func (v exactlyOneOfChildrenValidator) ValidateObject(_ context.Context, req val
 	attrs := req.ConfigValue.Attributes()
 	var set []string
 	unknownCount := 0
-	for _, name := range v.childNames {
+	for _, name := range v.ChildNames {
 		val, ok := attrs[name]
 		if !ok {
 			continue
@@ -1994,24 +1986,17 @@ func (v exactlyOneOfChildrenValidator) ValidateObject(_ context.Context, req val
 	}
 }
 
+// FriendlyExactlyOneOfObjectValidator is exported (rather than kept as an
+// unexported implementation type) so schema-wiring tests in other packages
+// can type-assert a validator.Object and inspect PathExpressions directly,
+// to catch old-style, child-attached oneof groups left behind by an
+// incomplete migration to the cheaper, parent-attached
+// ExactlyOneOfChildrenValidator.
 func ExactlyOneOfObject(expressions ...path.Expression) validator.Object {
-	return friendlyExactlyOneOfObjectValidator{
+	return FriendlyExactlyOneOfObjectValidator{
 		Object:          objectvalidator.ExactlyOneOf(expressions...),
 		PathExpressions: expressions,
 	}
-}
-
-// ExactlyOneOfObjectPathExpressions reports the sibling path.Expressions an
-// old-style, child-attached ExactlyOneOfObject validator.Object was
-// constructed with, and whether v is such a validator. Schema-wiring tests
-// use this to catch oneof groups left behind by an incomplete migration to
-// the cheaper, parent-attached ExactlyOneOfChildren.
-func ExactlyOneOfObjectPathExpressions(v validator.Object) (path.Expressions, bool) {
-	fv, ok := v.(friendlyExactlyOneOfObjectValidator)
-	if !ok {
-		return nil, false
-	}
-	return fv.PathExpressions, true
 }
 
 func ExactlyOneOfString(expressions ...path.Expression) validator.String {
@@ -2028,12 +2013,12 @@ func ExactlyOneOfInt64(expressions ...path.Expression) validator.Int64 {
 	}
 }
 
-type friendlyExactlyOneOfObjectValidator struct {
+type FriendlyExactlyOneOfObjectValidator struct {
 	validator.Object
 	PathExpressions path.Expressions
 }
 
-func (v friendlyExactlyOneOfObjectValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+func (v FriendlyExactlyOneOfObjectValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
 	var delegateResp validator.ObjectResponse
 	v.Object.ValidateObject(ctx, req, &delegateResp)
 	rewriteExactlyOneOfDiagnostics(ctx, exactlyOneOfDiagnosticRequest{
@@ -2079,7 +2064,7 @@ func (v friendlyExactlyOneOfInt64Validator) ValidateInt64(ctx context.Context, r
 	}, delegateResp.Diagnostics, &resp.Diagnostics)
 }
 
-func (v friendlyExactlyOneOfObjectValidator) exactlyOneOfPathExpressions() path.Expressions {
+func (v FriendlyExactlyOneOfObjectValidator) exactlyOneOfPathExpressions() path.Expressions {
 	return v.PathExpressions
 }
 

--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -1942,7 +1942,7 @@ func (v ExactlyOneOfChildrenValidator) ValidateObject(_ context.Context, req val
 	}
 
 	attrs := req.ConfigValue.Attributes()
-	var set []string
+	var knownChildrenSet []string
 	unknownCount := 0
 	for _, name := range v.ChildNames {
 		val, ok := attrs[name]
@@ -1954,19 +1954,15 @@ func (v ExactlyOneOfChildrenValidator) ValidateObject(_ context.Context, req val
 			continue
 		}
 		if !val.IsNull() {
-			set = append(set, name)
+			knownChildrenSet = append(knownChildrenSet, name)
 		}
 	}
 
 	// A second known-and-set child is an unavoidable conflict no matter how
 	// any remaining unknown children resolve, so report it immediately.
-	if len(set) > 1 {
-		quoted := make([]string, len(set))
-		for i, name := range set {
-			quoted[i] = "`" + name + "`"
-		}
+	if len(knownChildrenSet) > 1 {
 		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Attribute Combination",
-			fmt.Sprintf("Only one of these attributes can be configured: %s.", strings.Join(quoted, ", ")))
+			fmt.Sprintf("Only one of these attributes can be configured: `%s`.", strings.Join(knownChildrenSet, "`, `")))
 		return
 	}
 
@@ -1977,10 +1973,7 @@ func (v ExactlyOneOfChildrenValidator) ValidateObject(_ context.Context, req val
 		return
 	}
 
-	switch len(set) {
-	case 1:
-		return
-	case 0:
+	if len(knownChildrenSet) == 0 {
 		resp.Diagnostics.AddAttributeError(req.Path, "Invalid Attribute Combination",
 			"No attribute was configured in this one-of group. Configure exactly one value.")
 	}

--- a/internal/provider/dashboards/dashboard_widgets/common_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/common_test.go
@@ -390,6 +390,350 @@ func TestExactlyOneOfAsymmetricSchemaStillReportsConflict(t *testing.T) {
 	}
 }
 
+// buildOneOfConfig constructs a types.Object matching the shape
+// exactlyOneOfChildrenValidator expects: one StringType attribute per name in
+// childNames, set to a known value for names in setNames, to unknown for
+// names in unknownNames, and to null for everything else.
+func buildOneOfConfig(childNames, setNames, unknownNames []string) types.Object {
+	set := make(map[string]bool, len(setNames))
+	for _, name := range setNames {
+		set[name] = true
+	}
+	unknown := make(map[string]bool, len(unknownNames))
+	for _, name := range unknownNames {
+		unknown[name] = true
+	}
+
+	attrTypes := make(map[string]attr.Type, len(childNames))
+	values := make(map[string]attr.Value, len(childNames))
+	for _, name := range childNames {
+		attrTypes[name] = types.StringType
+		switch {
+		case unknown[name]:
+			values[name] = types.StringUnknown()
+		case set[name]:
+			values[name] = types.StringValue(name)
+		default:
+			values[name] = types.StringNull()
+		}
+	}
+
+	return types.ObjectValueMust(attrTypes, values)
+}
+
+func TestExactlyOneOfChildrenValidatesSetCounts(t *testing.T) {
+	ctx := context.Background()
+	childNames := []string{"a", "b", "c"}
+
+	cases := []struct {
+		name       string
+		childNames []string
+		setNames   []string
+		wantErr    string // empty = expect no error
+	}{
+		{name: "zero_set", childNames: childNames, wantErr: "No attribute was configured"},
+		{name: "one_set_first", childNames: childNames, setNames: []string{"a"}},
+		{name: "one_set_middle", childNames: childNames, setNames: []string{"b"}},
+		{name: "one_set_last", childNames: childNames, setNames: []string{"c"}},
+		{name: "two_set", childNames: childNames, setNames: []string{"a", "c"}, wantErr: "Only one of these attributes can be configured"},
+		{name: "all_widget_types_set", childNames: SupportedWidgetTypes, setNames: SupportedWidgetTypes, wantErr: "Only one of these attributes can be configured"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := buildOneOfConfig(tc.childNames, tc.setNames, nil)
+			req := validator.ObjectRequest{ConfigValue: cfg}
+			resp := &validator.ObjectResponse{}
+			ExactlyOneOfChildren(tc.childNames...).ValidateObject(ctx, req, resp)
+
+			if tc.wantErr == "" {
+				if resp.Diagnostics.HasError() {
+					t.Fatalf("expected no error, got: %s", resp.Diagnostics.Errors())
+				}
+				return
+			}
+
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("expected error containing %q, got none", tc.wantErr)
+			}
+			detail := resp.Diagnostics.Errors()[0].Detail()
+			if !strings.Contains(detail, tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %s", tc.wantErr, detail)
+			}
+			if len(tc.setNames) > 1 {
+				for _, name := range tc.setNames {
+					if !strings.Contains(detail, "`"+name+"`") {
+						t.Fatalf("expected error to name %q, got: %s", name, detail)
+					}
+				}
+			}
+		})
+	}
+
+	t.Run("parent_null", func(t *testing.T) {
+		req := validator.ObjectRequest{ConfigValue: types.ObjectNull(map[string]attr.Type{"a": types.StringType})}
+		resp := &validator.ObjectResponse{}
+		ExactlyOneOfChildren("a", "b").ValidateObject(ctx, req, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("expected no error for null parent, got: %s", resp.Diagnostics.Errors())
+		}
+	})
+
+	t.Run("parent_unknown", func(t *testing.T) {
+		req := validator.ObjectRequest{ConfigValue: types.ObjectUnknown(map[string]attr.Type{"a": types.StringType})}
+		resp := &validator.ObjectResponse{}
+		ExactlyOneOfChildren("a", "b").ValidateObject(ctx, req, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("expected no error for unknown parent, got: %s", resp.Diagnostics.Errors())
+		}
+	})
+}
+
+// TestExactlyOneOfChildrenDefersWhenSiblingUnknown is the regression test for
+// the false-positive "no attribute configured" error that fired whenever a
+// sibling in the group was unknown (e.g. derived from an unresolved
+// reference), even though it might resolve to satisfy the oneof once known.
+func TestExactlyOneOfChildrenDefersWhenSiblingUnknown(t *testing.T) {
+	ctx := context.Background()
+	childNames := []string{"a", "b", "c", "d"}
+
+	cases := []struct {
+		name         string
+		setNames     []string
+		unknownNames []string
+		wantErr      bool
+	}{
+		{name: "one_unknown_rest_null", unknownNames: []string{"a"}},
+		{name: "two_unknown_rest_null", unknownNames: []string{"a", "b"}},
+		{name: "one_unknown_one_set", unknownNames: []string{"a"}, setNames: []string{"b"}},
+		{name: "one_unknown_two_set_is_a_definite_conflict", unknownNames: []string{"a"}, setNames: []string{"b", "c"}, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := buildOneOfConfig(childNames, tc.setNames, tc.unknownNames)
+			req := validator.ObjectRequest{ConfigValue: cfg}
+			resp := &validator.ObjectResponse{}
+			ExactlyOneOfChildren(childNames...).ValidateObject(ctx, req, resp)
+
+			if tc.wantErr {
+				if !resp.Diagnostics.HasError() {
+					t.Fatal("expected an error: two children are known-and-set, no unknown sibling can undo that conflict")
+				}
+				return
+			}
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("expected no error while a sibling is still unknown, got: %s", resp.Diagnostics.Errors())
+			}
+		})
+	}
+}
+
+// TestSupportedWidgetsExactlyOneOfChildrenCoversAllWidgetTypes drives the
+// 0/1/2-set matrix through the real SupportedWidgetTypes slice so a future
+// 9th widget type is automatically covered without anyone remembering to
+// update this test.
+func TestSupportedWidgetsExactlyOneOfChildrenCoversAllWidgetTypes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("zero_set", func(t *testing.T) {
+		cfg := buildOneOfConfig(SupportedWidgetTypes, nil, nil)
+		req := validator.ObjectRequest{ConfigValue: cfg}
+		resp := &validator.ObjectResponse{}
+		SupportedWidgetsExactlyOneOfChildren().ValidateObject(ctx, req, resp)
+		if !resp.Diagnostics.HasError() {
+			t.Fatal("expected an error when no widget type is configured")
+		}
+		if detail := resp.Diagnostics.Errors()[0].Detail(); !strings.Contains(detail, "No attribute was configured") {
+			t.Fatalf("unexpected error detail: %s", detail)
+		}
+	})
+
+	for _, name := range SupportedWidgetTypes {
+		t.Run("one_set_"+name, func(t *testing.T) {
+			cfg := buildOneOfConfig(SupportedWidgetTypes, []string{name}, nil)
+			req := validator.ObjectRequest{ConfigValue: cfg}
+			resp := &validator.ObjectResponse{}
+			SupportedWidgetsExactlyOneOfChildren().ValidateObject(ctx, req, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("expected no error with only %q set, got: %s", name, resp.Diagnostics.Errors())
+			}
+		})
+	}
+
+	t.Run("two_set", func(t *testing.T) {
+		if len(SupportedWidgetTypes) < 2 {
+			t.Skip("need at least two widget types")
+		}
+		twoSet := SupportedWidgetTypes[:2]
+		cfg := buildOneOfConfig(SupportedWidgetTypes, twoSet, nil)
+		req := validator.ObjectRequest{ConfigValue: cfg}
+		resp := &validator.ObjectResponse{}
+		SupportedWidgetsExactlyOneOfChildren().ValidateObject(ctx, req, resp)
+		if !resp.Diagnostics.HasError() {
+			t.Fatal("expected an error when two widget types are configured")
+		}
+		detail := resp.Diagnostics.Errors()[0].Detail()
+		for _, name := range twoSet {
+			if !strings.Contains(detail, "`"+name+"`") {
+				t.Fatalf("expected error to name %q, got: %s", name, detail)
+			}
+		}
+	})
+}
+
+// mustType asserts v has static type T, failing the test immediately with a
+// message naming what was being asserted. It centralizes the assert-or-fail
+// branch so call sites read as a single expression instead of each
+// contributing its own branch to cyclomatic complexity.
+func mustType[T any](t *testing.T, v any, what string) T {
+	t.Helper()
+	x, ok := v.(T)
+	if !ok {
+		t.Fatalf("%s is %T, not %T", what, v, *new(T))
+	}
+	return x
+}
+
+// hexagonQueryChildValue builds a tftypes.Value for one child of Hexagon's
+// "query" oneof: null when unset, tftypes.UnknownValue when unknown, or a
+// present-but-otherwise-empty object (every grandchild null) when set. The
+// validator under test only inspects null/unknown-ness of the direct
+// children, so grandchildren don't need to be recursively populated.
+func hexagonQueryChildValue(childType tftypes.Type, set, unknown bool) tftypes.Value {
+	if unknown {
+		return tftypes.NewValue(childType, tftypes.UnknownValue)
+	}
+	if !set {
+		return tftypes.NewValue(childType, nil)
+	}
+	objType, ok := childType.(tftypes.Object)
+	if !ok {
+		return tftypes.NewValue(childType, nil)
+	}
+	inner := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for innerName, innerType := range objType.AttributeTypes {
+		inner[innerName] = tftypes.NewValue(innerType, nil)
+	}
+	return tftypes.NewValue(childType, inner)
+}
+
+// hexagonBuildQueryConfig builds a types.Object for Hexagon's query oneof,
+// setting every name in setNames present-but-empty, every name in
+// unknownNames to unknown, and leaving the rest null.
+func hexagonBuildQueryConfig(ctx context.Context, t *testing.T, query schema.SingleNestedAttribute, queryType tftypes.Object, childNames, setNames, unknownNames []string) types.Object {
+	t.Helper()
+	set := make(map[string]bool, len(setNames))
+	for _, name := range setNames {
+		set[name] = true
+	}
+	unknown := make(map[string]bool, len(unknownNames))
+	for _, name := range unknownNames {
+		unknown[name] = true
+	}
+	attrs := make(map[string]tftypes.Value, len(childNames))
+	for _, name := range childNames {
+		attrs[name] = hexagonQueryChildValue(queryType.AttributeTypes[name], set[name], unknown[name])
+	}
+	val, err := query.GetType().ValueFromTerraform(ctx, tftypes.NewValue(queryType, attrs))
+	if err != nil {
+		t.Fatalf("build hexagon query config: %s", err)
+	}
+	return mustType[types.Object](t, val, "hexagon query config value")
+}
+
+// hexagonValidateQuery runs query's validators against cfg and returns the
+// resulting diagnostics.
+func hexagonValidateQuery(ctx context.Context, query schema.SingleNestedAttribute, cfg types.Object) diag.Diagnostics {
+	req := validator.ObjectRequest{ConfigValue: cfg}
+	resp := &validator.ObjectResponse{}
+	for _, v := range query.Validators {
+		v.ValidateObject(ctx, req, resp)
+	}
+	return resp.Diagnostics
+}
+
+// TestHexagonQueryExactlyOneOfChildren drives the same 0-set/2-set/
+// unknown-sibling matrix as TestExactlyOneOfChildrenValidatesSetCounts and
+// TestExactlyOneOfChildrenDefersWhenSiblingUnknown, but through the actual
+// validator wired onto HexagonSchema()'s "query" attribute rather than a
+// hand-built one, so a future regression that un-wires it is caught here.
+func TestHexagonQueryExactlyOneOfChildren(t *testing.T) {
+	ctx := context.Background()
+
+	hexagon := mustType[schema.SingleNestedAttribute](t, HexagonSchema(), "HexagonSchema")
+	query := mustType[schema.SingleNestedAttribute](t, hexagon.Attributes["query"], "hexagon query")
+	if len(query.Validators) != 1 {
+		t.Fatalf("hexagon query validators = %d, want exactly 1", len(query.Validators))
+	}
+
+	queryType := mustType[tftypes.Object](t, query.GetType().TerraformType(ctx), "hexagon query terraform type")
+	childNames := []string{"logs", "metrics", "spans", "data_prime"}
+	for _, name := range childNames {
+		if _, ok := queryType.AttributeTypes[name]; !ok {
+			t.Fatalf("hexagon query has no %q child in its terraform type", name)
+		}
+	}
+
+	build := func(setNames, unknownNames []string) types.Object {
+		return hexagonBuildQueryConfig(ctx, t, query, queryType, childNames, setNames, unknownNames)
+	}
+	validate := func(cfg types.Object) diag.Diagnostics {
+		return hexagonValidateQuery(ctx, query, cfg)
+	}
+
+	t.Run("zero_set", func(t *testing.T) {
+		diagnostics := validate(build(nil, nil))
+		if !diagnostics.HasError() {
+			t.Fatal("expected an error when no query branch is configured")
+		}
+		if detail := diagnostics.Errors()[0].Detail(); !strings.Contains(detail, "No attribute was configured") {
+			t.Fatalf("unexpected error detail: %s", detail)
+		}
+	})
+
+	for _, name := range childNames {
+		t.Run("one_set_"+name, func(t *testing.T) {
+			if diagnostics := validate(build([]string{name}, nil)); diagnostics.HasError() {
+				t.Fatalf("expected no error with only %q set, got: %s", name, diagnostics.Errors())
+			}
+		})
+	}
+
+	t.Run("two_set", func(t *testing.T) {
+		twoSet := childNames[:2]
+		diagnostics := validate(build(twoSet, nil))
+		if !diagnostics.HasError() {
+			t.Fatal("expected an error when two query branches are configured")
+		}
+		detail := diagnostics.Errors()[0].Detail()
+		for _, name := range twoSet {
+			if !strings.Contains(detail, "`"+name+"`") {
+				t.Fatalf("expected error to name %q, got: %s", name, detail)
+			}
+		}
+	})
+
+	t.Run("one_unknown_rest_null_defers", func(t *testing.T) {
+		if diagnostics := validate(build(nil, []string{"logs"})); diagnostics.HasError() {
+			t.Fatalf("expected no error while %q is unknown, got: %s", "logs", diagnostics.Errors())
+		}
+	})
+
+	t.Run("one_unknown_one_set_defers", func(t *testing.T) {
+		if diagnostics := validate(build([]string{"metrics"}, []string{"logs"})); diagnostics.HasError() {
+			t.Fatalf("expected no error while a sibling is unknown, got: %s", diagnostics.Errors())
+		}
+	})
+
+	t.Run("one_unknown_two_set_is_a_definite_conflict", func(t *testing.T) {
+		cfg := build([]string{"logs", "metrics"}, []string{"spans"})
+		if diagnostics := validate(cfg); !diagnostics.HasError() {
+			t.Fatal("expected an error: two children are known-and-set, an unknown sibling can't undo that conflict")
+		}
+	})
+}
+
 func TestLegacyDurationOpenAPIRoundTrip(t *testing.T) {
 	tests := []struct {
 		configured string

--- a/internal/provider/dashboards/dashboard_widgets/datatable.go
+++ b/internal/provider/dashboards/dashboard_widgets/datatable.go
@@ -87,13 +87,6 @@ func DataTableSchema() schema.Attribute {
 							"time_frame": TimeFrameSchema(),
 						},
 						Optional: true,
-						Validators: []validator.Object{
-							ExactlyOneOfObject(
-								path.MatchRelative().AtParent().AtName("spans"),
-								path.MatchRelative().AtParent().AtName("metrics"),
-								path.MatchRelative().AtParent().AtName("data_prime"),
-							),
-						},
 					},
 					"spans": schema.SingleNestedAttribute{
 						Attributes: map[string]schema.Attribute{
@@ -132,13 +125,6 @@ func DataTableSchema() schema.Attribute {
 							"time_frame": TimeFrameSchema(),
 						},
 						Optional: true,
-						Validators: []validator.Object{
-							ExactlyOneOfObject(
-								path.MatchRelative().AtParent().AtName("logs"),
-								path.MatchRelative().AtParent().AtName("metrics"),
-								path.MatchRelative().AtParent().AtName("data_prime"),
-							),
-						},
 					},
 					"metrics": schema.SingleNestedAttribute{
 						Attributes: map[string]schema.Attribute{
@@ -157,13 +143,6 @@ func DataTableSchema() schema.Attribute {
 							"time_frame": TimeFrameSchema(),
 						},
 						Optional: true,
-						Validators: []validator.Object{
-							ExactlyOneOfObject(
-								path.MatchRelative().AtParent().AtName("logs"),
-								path.MatchRelative().AtParent().AtName("spans"),
-								path.MatchRelative().AtParent().AtName("data_prime"),
-							),
-						},
 					},
 					"data_prime": schema.SingleNestedAttribute{
 						Attributes: map[string]schema.Attribute{
@@ -173,22 +152,21 @@ func DataTableSchema() schema.Attribute {
 							"filters": schema.ListNestedAttribute{
 								NestedObject: schema.NestedAttributeObject{
 									Attributes: FiltersSourceSchema(),
+									Validators: []validator.Object{
+										ExactlyOneOfChildren("logs", "metrics", "spans"),
+									},
 								},
 								Optional: true,
 							},
 							"time_frame": TimeFrameSchema(),
 						},
 						Optional: true,
-						Validators: []validator.Object{
-							ExactlyOneOfObject(
-								path.MatchRelative().AtParent().AtName("logs"),
-								path.MatchRelative().AtParent().AtName("spans"),
-								path.MatchRelative().AtParent().AtName("metrics"),
-							),
-						},
 					},
 				},
 				Required: true,
+				Validators: []validator.Object{
+					ExactlyOneOfChildren("logs", "spans", "metrics", "data_prime"),
+				},
 			},
 			"results_per_page": schema.Int64Attribute{
 				Required:            true,
@@ -247,7 +225,6 @@ func DataTableSchema() schema.Attribute {
 			},
 		},
 		Validators: []validator.Object{
-			SupportedWidgetsValidatorWithout("data_table"),
 			objectvalidator.AlsoRequires(
 				path.MatchRelative().AtParent().AtParent().AtName("title"),
 			),

--- a/internal/provider/dashboards/dashboard_widgets/hexagon.go
+++ b/internal/provider/dashboards/dashboard_widgets/hexagon.go
@@ -181,13 +181,6 @@ func HexagonSchema() schema.Attribute {
 							"time_frame":  TimeFrameSchema(),
 						},
 						Optional: true,
-						Validators: []validator.Object{
-							ExactlyOneOfObject(
-								path.MatchRelative().AtParent().AtName("metrics"),
-								path.MatchRelative().AtParent().AtName("spans"),
-								path.MatchRelative().AtParent().AtName("data_prime"),
-							),
-						},
 					},
 					"metrics": schema.SingleNestedAttribute{
 						Attributes: map[string]schema.Attribute{
@@ -235,6 +228,9 @@ func HexagonSchema() schema.Attribute {
 							"filters": schema.ListNestedAttribute{
 								NestedObject: schema.NestedAttributeObject{
 									Attributes: FiltersSourceSchema(),
+									Validators: []validator.Object{
+										ExactlyOneOfChildren("logs", "metrics", "spans"),
+									},
 								},
 								Optional: true,
 							},
@@ -243,10 +239,12 @@ func HexagonSchema() schema.Attribute {
 						Optional: true,
 					},
 				},
+				Validators: []validator.Object{
+					ExactlyOneOfChildren("logs", "metrics", "spans", "data_prime"),
+				},
 			},
 		},
 		Validators: []validator.Object{
-			SupportedWidgetsValidatorWithout("hexagon"),
 			objectvalidator.AlsoRequires(
 				path.MatchRelative().AtParent().AtParent().AtName("title"),
 			),

--- a/internal/provider/dashboards/dashboard_widgets/linechart.go
+++ b/internal/provider/dashboards/dashboard_widgets/linechart.go
@@ -105,13 +105,6 @@ func LineChartSchema() schema.Attribute {
 										"time_frame":   TimeFrameSchema(),
 									},
 									Optional: true,
-									Validators: []validator.Object{
-										ExactlyOneOfObject(
-											path.MatchRelative().AtParent().AtName("metrics"),
-											path.MatchRelative().AtParent().AtName("spans"),
-											path.MatchRelative().AtParent().AtName("data_prime"),
-										),
-									},
 								},
 								"metrics": schema.SingleNestedAttribute{
 									Attributes: map[string]schema.Attribute{
@@ -148,6 +141,9 @@ func LineChartSchema() schema.Attribute {
 										"filters": schema.ListNestedAttribute{
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: FiltersSourceSchema(),
+												Validators: []validator.Object{
+													ExactlyOneOfChildren("logs", "metrics", "spans"),
+												},
 											},
 											Optional: true,
 										},
@@ -157,6 +153,9 @@ func LineChartSchema() schema.Attribute {
 								},
 							},
 							Required: true,
+							Validators: []validator.Object{
+								ExactlyOneOfChildren("logs", "metrics", "spans", "data_prime"),
+							},
 						},
 						"series_name_template": schema.StringAttribute{
 							Optional: true,
@@ -192,22 +191,15 @@ func LineChartSchema() schema.Attribute {
 							Attributes: map[string]schema.Attribute{
 								"interval": schema.StringAttribute{
 									Optional: true,
-									Validators: []validator.String{
-										ExactlyOneOfString(
-											path.MatchRelative().AtParent().AtName("buckets_presented"),
-										),
-									},
 								},
 								"buckets_presented": schema.Int64Attribute{
 									Optional: true,
-									Validators: []validator.Int64{
-										ExactlyOneOfInt64(
-											path.MatchRelative().AtParent().AtName("interval"),
-										),
-									},
 								},
 							},
 							Optional: true,
+							Validators: []validator.Object{
+								ExactlyOneOfChildren("interval", "buckets_presented"),
+							},
 						},
 						"data_mode_type": schema.StringAttribute{
 							Optional: true,
@@ -222,7 +214,6 @@ func LineChartSchema() schema.Attribute {
 			},
 		},
 		Validators: []validator.Object{
-			SupportedWidgetsValidatorWithout("line_chart"),
 			objectvalidator.AlsoRequires(
 				path.MatchRelative().AtParent().AtParent().AtName("title"),
 			),

--- a/internal/provider/dashboards/dashboard_widgets/schema.go
+++ b/internal/provider/dashboards/dashboard_widgets/schema.go
@@ -178,10 +178,7 @@ func TimeFrameSchema() schema.Attribute {
 						Required: true,
 					},
 				},
-				Optional: true,
-				Validators: []validator.Object{
-					ExactlyOneOfObject(path.MatchRelative().AtParent().AtName("relative")),
-				},
+				Optional:            true,
 				MarkdownDescription: "Absolute time frame specifying a fixed start and end time.",
 			},
 			"relative": schema.SingleNestedAttribute{
@@ -190,12 +187,12 @@ func TimeFrameSchema() schema.Attribute {
 						Required: true,
 					},
 				},
-				Optional: true,
-				Validators: []validator.Object{
-					ExactlyOneOfObject(path.MatchRelative().AtParent().AtName("absolute")),
-				},
+				Optional:            true,
 				MarkdownDescription: "Relative time frame specifying a duration from the current time.",
 			},
+		},
+		Validators: []validator.Object{
+			ExactlyOneOfChildren("absolute", "relative"),
 		},
 		MarkdownDescription: "Specifies the time frame. Can be either absolute or relative.",
 	}
@@ -349,12 +346,6 @@ func FiltersSourceSchema() map[string]schema.Attribute {
 				},
 			},
 			Optional: true,
-			Validators: []validator.Object{
-				ExactlyOneOfObject(
-					path.MatchRelative().AtParent().AtName("metrics"),
-					path.MatchRelative().AtParent().AtName("spans"),
-				),
-			},
 		},
 		"spans": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{
@@ -368,12 +359,6 @@ func FiltersSourceSchema() map[string]schema.Attribute {
 				"operator": FilterOperatorSchema(),
 			},
 			Optional: true,
-			Validators: []validator.Object{
-				ExactlyOneOfObject(
-					path.MatchRelative().AtParent().AtName("metrics"),
-					path.MatchRelative().AtParent().AtName("logs"),
-				),
-			},
 		},
 		"metrics": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{
@@ -384,12 +369,6 @@ func FiltersSourceSchema() map[string]schema.Attribute {
 					Optional: true,
 				},
 				"operator": FilterOperatorSchema(),
-			},
-			Validators: []validator.Object{
-				ExactlyOneOfObject(
-					path.MatchRelative().AtParent().AtName("spans"),
-					path.MatchRelative().AtParent().AtName("logs"),
-				),
 			},
 			Optional: true,
 		},

--- a/internal/provider/dashboards/dashboard_widgets/schema.go
+++ b/internal/provider/dashboards/dashboard_widgets/schema.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
@@ -293,11 +292,6 @@ func LogsFiltersSchema() schema.ListNestedAttribute {
 			Attributes: map[string]schema.Attribute{
 				"field": schema.StringAttribute{
 					Optional: true,
-					Validators: []validator.String{
-						ExactlyOneOfString(
-							path.MatchRelative().AtParent().AtName("observation_field"),
-						),
-					},
 				},
 				"operator": FilterOperatorSchema(),
 				"observation_field": schema.SingleNestedAttribute{
@@ -305,6 +299,9 @@ func LogsFiltersSchema() schema.ListNestedAttribute {
 					Optional:            true,
 					MarkdownDescription: "Explicit field reference with scope. Use when the field name contains a literal dot (e.g. `log.level`) or exists in multiple scopes — the bare `field` is resolved by the backend via dot-split, which silently fails to match flat fields whose identifier contains dots.",
 				},
+			},
+			Validators: []validator.Object{
+				ExactlyOneOfChildren("field", "observation_field"),
 			},
 		},
 		Validators: []validator.List{
@@ -332,11 +329,6 @@ func FiltersSourceSchema() map[string]schema.Attribute {
 				"field": schema.StringAttribute{
 					Optional:            true,
 					MarkdownDescription: "Field in the logs to apply the filter on.",
-					Validators: []validator.String{
-						ExactlyOneOfString(
-							path.MatchRelative().AtParent().AtName("observation_field"),
-						),
-					},
 				},
 				"operator": FilterOperatorSchema(),
 				"observation_field": schema.SingleNestedAttribute{
@@ -344,6 +336,9 @@ func FiltersSourceSchema() map[string]schema.Attribute {
 					Optional:            true,
 					MarkdownDescription: "Explicit field reference with scope. Use when the field name contains a literal dot (e.g. `log.level`) or exists in multiple scopes — the bare `field` is resolved by the backend via dot-split, which silently fails to match flat fields whose identifier contains dots.",
 				},
+			},
+			Validators: []validator.Object{
+				ExactlyOneOfChildren("field", "observation_field"),
 			},
 			Optional: true,
 		},


### PR DESCRIPTION
### Description

`coralogix_dashboard` plans get slow as a dashboard accumulates widgets, with `ValidateResourceConfig` dominating plan time on large dashboards. This PR removes that hotspot for the V4 schema (the schema every live resource instance actually uses — V1-V3 are legacy, reachable only once per resource via `StateUpgraders`).

Perf results, measured with `time terraform plan` against a fixture of 20 dashboards covering a variety of widget setups (same fixture before/after):

| | Before | After |
|---|---|---|
| `terraform plan` (20 dashboards with widgets) | **4m11s** | **15.277s** |

~16.5x wall-clock improvement.

**Root cause:** every `oneof`-style group in the schema (widget type selection, `logs`/`metrics`/`spans`/`data_prime` query unions, time frames, annotation sources, folder `id`/`path`, ...) attached an `ExactlyOneOf`-style validator to **each child** in the group, referencing its siblings by `path.Expression`. Resolving those expressions means walking the whole config tree via `config.PathMatches` — once per sibling, per group, per widget instance. That cost repeats for every widget, so plan time scales with widget count.

This PR fixes it with two changes, bundled because the second only pays off once the first is done:

1. **Attach once per group, not once per child.** New `dashboardwidgets.ExactlyOneOfChildren(childNames...)` is attached to the *parent* object of a oneof group instead of to each child. A group of N siblings now carries one validator invocation instead of N.
2. **Make that one validator itself cheap.** `ExactlyOneOfChildren` reads `req.ConfigValue.Attributes()` directly — the parent object it's attached to already has all its children's values in hand — instead of resolving `path.Expression`s against the full config via `config.PathMatches`/`config.GetAttribute`. This replaces an O(config size) tree walk with an O(children-in-the-group) map lookup.

The widget-type oneof (`SupportedWidgetsValidatorWithout`, an 8-way check previously attached to all 8 widget-type siblings) collapses the same way into a single `SupportedWidgetsExactlyOneOfChildren()` attached once to the `definition` object.

The old `ExactlyOneOfObject`/`ExactlyOneOfString`/`ExactlyOneOfInt64`/`SupportedWidgetsValidatorWithout` family is left in place (still used to gate `AddError` message rewriting on invalid configs) but is no longer wired into any V4 oneof group — every group in `v4.go`, `common.go`, `hexagon.go`, `linechart.go`, `datatable.go`, and `schema.go`'s shared builders (`TimeFrameSchema`, `FiltersSourceSchema`) now uses the parent-attached form.

#### A subtlety: unknown values must defer, not reject

`ExactlyOneOfChildren` inspects each child's concrete null/unknown/set state directly instead of delegating to the framework's stock `ExactlyOneOf`, so it has to replicate the unknown-handling itself: two or more known-and-set children is always a conflict, but if any sibling is still unknown (e.g. derived from another resource not yet resolved), it defers rather than reporting "none configured" — that sibling could still resolve to satisfy the constraint. Only once every sibling is known does "zero set" become a real error.

This is safe because `ValidateResourceConfig` isn't a one-shot check: it re-runs on every `plan`, and again as part of `apply`'s internal re-plan of each resource right before `Create`/`Update`. A first `plan` may see the value unknown and defer; by the time `apply` reaches this resource its dependencies are already created, so the value is known and the validator re-evaluates for real — rejecting it then if it's genuinely invalid. Deferring here doesn't skip validation, it just defers to the pass where the answer is actually knowable.

Covered by `TestExactlyOneOfChildrenDefersWhenSiblingUnknown` and `TestHexagonQueryExactlyOneOfChildren`.

### Profiling Analysis
Ran `pprof` on both master and this branch, using the 20 dashboards example:
- In master, `fromtftypes.AttributePath` cost 156.68s total, and 94.85% of that (148.61s) came from one specific caller: `fwschemadata.Data.PathMatches.func1` — that's the Config.PathMatches call inside the old ExactlyOneOf validators, walking the entire config tree and rebuilding nested type maps from scratch on every check.
- In this branch, that same caller (`PathMatches.func1`) only accounts for 3.32s — a 97.8% reduction in absolute terms. It's no longer the dominant caller of that code path; the majority of what's left (`NullifyCollectionBlocks.func1`, `TransformDefaults.func1`, `ReifyNullCollectionBlocks.func1`) is generic terraform-plugin-framework machinery that runs on every plan/apply regardless of validators.
- Downstream effect confirmed too. The GC/scheduler noise that dominated the master profile (`runtime.usleep` 149s, `pthread_cond_wait` 134s, `pthread_kill` 54s — together over half of all CPU) shrank proportionally in the perf profile (14s, 14s, 5.6s). The tree-walk/type-rebuild churn was generating massive allocation pressure, and removing it collapsed the GC overhead along with it, not just the walk itself.

### Test coverage

- Unit tests on `exactlyOneOfChildrenValidator` itself (`dashboard_widgets/common_test.go`): set-count matrix (0/1/2+), unknown-sibling deferral, widget-type `childNames` coverage, and the same matrix exercised through a real widget's query union.
- New schema-wiring tests (`dashboard_schema/v4_oneof_wiring_test.go`) walk the live `V4()` schema to catch partially-migrated groups (old validator left on a sibling) and `childNames` drift from the real attribute map, for both widget-level and dashboard-level groups.
- New full-schema validator tests (`dashboard_oneof_validation_test.go`) invoke real V4 attribute validators directly across widget definitions, gauge, folder, annotations, and per-element `data_prime.filters`.
- Existing rejection/round-trip unit tests and the full acceptance suite (nested-oneof, openapi, transition) are unchanged and still pass — the migration is behavior-preserving; only plan-time cost changed.
- No test measures validator performance; the numbers above are from a manual `time terraform plan` run, not CI-gated.

### Acceptance tests
- [x] Existing dashboard acceptance suite (`resource_coralogix_dashboard_nested_oneof_test.go`, `resource_coralogix_dashboard_openapi_test.go`, `resource_coralogix_dashboard_openapi_transition_test.go`, etc.) covers the oneof branches this PR rewires; no new acceptance test was added since this is a validator-internals change, not a schema-shape change.
- [x] Have you run the acceptance tests on this branch?

### Release Note
```release-note
PERF: Replace per-child oneof validators (e.g. `instant`/`range`, widget type selection) with a single cheaper validator attached to the parent object, reducing plan/apply time for dashboards with many widgets.
```
