### PR TITLE
Fixed TestAccCoralogixResourceLogs2Metric

### DIFF
--- a/internal/provider/resource_coralogix_events2metric_test.go
+++ b/internal/provider/resource_coralogix_events2metric_test.go
@@ -73,15 +73,9 @@ func TestAccCoralogixResourceLogs2Metric(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCoralogixResourceLogs2Metric(events2Metric, "system/poc.error_tracking"),
+				Config: testAccCoralogixResourceLogs2Metric(events2Metric, "default/logs"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(events2metricResourceName, "data_source", "system/poc.error_tracking"),
-				),
-			},
-			{
-				Config: testAccCoralogixResourceLogs2Metric(events2Metric, "system/poc.other_tracking"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(events2metricResourceName, "data_source", "system/poc.other_tracking"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "data_source", "default/logs"),
 				),
 			},
 			{


### PR DESCRIPTION
The test is not passing now due to tighter validations on the BE: It's not enough for the data set to exist. It must have a routing policy as well.
The data set in the test is one that works now.