### PR TITLE
docs(quota_allocation_rule_set): document browserLogs/v2 entity_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_quota_allocation_rule_set
+- DOCS: Document `browserLogs/v2` as a known `entity_type` value and note that the API may accept versioned variants.
+
 # Release 3.8.0
 
 #### resource/coralogix_parsing_rules

--- a/docs/resources/quota_allocation_rule_set.md
+++ b/docs/resources/quota_allocation_rule_set.md
@@ -3,12 +3,12 @@
 page_title: "coralogix_quota_allocation_rule_set Resource - terraform-provider-coralogix"
 subcategory: ""
 description: |-
-  Manages the account-level Coralogix quota allocation rule set. This API is a singleton overwrite surface: updates replace the full rule set, and delete removes the account rule set. Requires team-quota-rules:Read and team-quota-rules:Manage permissions. Known entity types include logs, browserLogs, spans, metrics, sessionRecordings, cpuProfiles, and olly, but the API may accept additional values.
+  Manages the account-level Coralogix quota allocation rule set. This API is a singleton overwrite surface: updates replace the full rule set, and delete removes the account rule set. Requires team-quota-rules:Read and team-quota-rules:Manage permissions. Known entity types include logs, browserLogs, browserLogs/v2, spans, metrics, sessionRecordings, cpuProfiles, and olly, but the API may accept additional values, including versioned variants.
 ---
 
 # coralogix_quota_allocation_rule_set (Resource)
 
-Manages the account-level Coralogix quota allocation rule set. This API is a singleton overwrite surface: updates replace the full rule set, and delete removes the account rule set. Requires `team-quota-rules:Read` and `team-quota-rules:Manage` permissions. Known entity types include `logs`, `browserLogs`, `spans`, `metrics`, `sessionRecordings`, `cpuProfiles`, and `olly`, but the API may accept additional values.
+Manages the account-level Coralogix quota allocation rule set. This API is a singleton overwrite surface: updates replace the full rule set, and delete removes the account rule set. Requires `team-quota-rules:Read` and `team-quota-rules:Manage` permissions. Known entity types include `logs`, `browserLogs`, `browserLogs/v2`, `spans`, `metrics`, `sessionRecordings`, `cpuProfiles`, and `olly`, but the API may accept additional values, including versioned variants.
 
 ## Example Usage
 
@@ -66,7 +66,7 @@ Required:
 - `allocation` (Number) Quota allocation value for this entity type. For `percentage`, must be between 0 and 100. For `locked_units`, must be non-negative.
 - `can_overflow` (Boolean) Whether this entity type can overflow beyond its allocation.
 - `enabled` (Boolean) Whether the quota allocation rule is enabled.
-- `entity_type` (String) Entity type covered by the rule. Known values include `logs`, `browserLogs`, `spans`, `metrics`, `sessionRecordings`, `cpuProfiles`, and `olly`.
+- `entity_type` (String) Entity type covered by the rule. Known values include `logs`, `browserLogs`, `browserLogs/v2`, `spans`, `metrics`, `sessionRecordings`, `cpuProfiles`, and `olly`. The API may accept additional values, including versioned variants.
 
 Optional:
 

--- a/internal/provider/dataplans/resource_coralogix_quota_allocation_rule_set.go
+++ b/internal/provider/dataplans/resource_coralogix_quota_allocation_rule_set.go
@@ -114,7 +114,7 @@ func (r *QuotaAllocationRuleSetResource) Configure(_ context.Context, req resour
 
 func (r *QuotaAllocationRuleSetResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages the account-level Coralogix quota allocation rule set. This API is a singleton overwrite surface: updates replace the full rule set, and delete removes the account rule set. Requires `team-quota-rules:Read` and `team-quota-rules:Manage` permissions. Known entity types include `logs`, `browserLogs`, `spans`, `metrics`, `sessionRecordings`, `cpuProfiles`, and `olly`, but the API may accept additional values.",
+		MarkdownDescription: "Manages the account-level Coralogix quota allocation rule set. This API is a singleton overwrite surface: updates replace the full rule set, and delete removes the account rule set. Requires `team-quota-rules:Read` and `team-quota-rules:Manage` permissions. Known entity types include `logs`, `browserLogs`, `browserLogs/v2`, `spans`, `metrics`, `sessionRecordings`, `cpuProfiles`, and `olly`, but the API may accept additional values, including versioned variants.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -133,7 +133,7 @@ func (r *QuotaAllocationRuleSetResource) Schema(_ context.Context, _ resource.Sc
 							Validators: []validator.String{
 								stringvalidator.LengthAtLeast(1),
 							},
-							MarkdownDescription: "Entity type covered by the rule. Known values include `logs`, `browserLogs`, `spans`, `metrics`, `sessionRecordings`, `cpuProfiles`, and `olly`.",
+							MarkdownDescription: "Entity type covered by the rule. Known values include `logs`, `browserLogs`, `browserLogs/v2`, `spans`, `metrics`, `sessionRecordings`, `cpuProfiles`, and `olly`. The API may accept additional values, including versioned variants.",
 						},
 						"allocation": schema.Float64Attribute{
 							Required: true,


### PR DESCRIPTION
Ticket: https://coralogix.atlassian.net/servicedesk/customer/portal/324/DOCS-97

## What

Documents `browserLogs/v2` as a known `entity_type` value on the `coralogix_quota_allocation_rule_set` resource, and notes that the API may accept versioned variants.

## Why

Support / Intercom (Sev-2, customer: SmartAsset): the API accepts `entity_type = "browserLogs/v2"`, but the registry docs listed only `browserLogs`, so users had no way to know the versioned value was valid.

`entity_type` is a free-form string in the schema (no `OneOf` validator — the API is the source of truth), so this is purely a documentation/known-values update, not a behavior change.

## Changes

- Schema: added `browserLogs/v2` to the known-values list in both the resource-level description and the `rules[].entity_type` attribute description (`internal/provider/dataplans/resource_coralogix_quota_allocation_rule_set.go`).
- Regenerated doc kept in sync by hand: `docs/resources/quota_allocation_rule_set.md` (top description + the `entity_type` bullet under nested schema for `rules`).
- CHANGELOG.md: Unreleased entry.

Registry page affected: https://registry.terraform.io/providers/coralogix/coralogix/latest/docs/resources/quota_allocation_rule_set#nested-schema-for-rules
