### PR TITLE
feat(tco_policies_logs): add targets block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_tco_policies_logs
+- FEAT: Add `targets` block to route matched logs to specific named datasets with optional per-target priorities. Policy-level `priority` is now optional; it may be omitted when every target carries its own priority.
+
 #### resource/coralogix_dashboard
 - CHORE: Use the shared SDK `dashboardjson.Unmarshal` helper for `content_json` (snake_case aliases, unknown-key discard) instead of a local copy. Create/replace no longer re-strip unknowns; that happens in Unmarshal, as in the operator.
 - FIX: Adding a section, row, widget or annotation without an `id` no longer fails with "Provider produced inconsistent result after apply". Generated `id` fields (section, row, widget, line-chart `query_definitions[].id`, data-table aggregation, annotation) and widget `width` now use `UseNonNullStateForUnknown` so new nested elements stay `(known after apply)` instead of planning as null.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 #### resource/coralogix_tco_policies_logs
-- FEAT: Add `targets` block to route matched logs to specific named datasets with optional per-target priorities. Policy-level `priority` is now optional; it may be omitted when every target carries its own priority.
+- FEAT: Add `targets` to route matched logs to specific named datasets. Each target requires its own `priority`. Policy-level `priority` is now optional; omit it when `targets` is set.
 
 #### resource/coralogix_dashboard
 - CHORE: Use the shared SDK `dashboardjson.Unmarshal` helper for `content_json` (snake_case aliases, unknown-key discard) instead of a local copy. Create/replace no longer re-strip unknowns; that happens in Unmarshal, as in the operator.

--- a/docs/data-sources/tco_policies_logs.md
+++ b/docs/data-sources/tco_policies_logs.md
@@ -39,11 +39,11 @@ Read-Only:
 - `id` (String) tco-policy ID.
 - `name` (String) tco-policy name.
 - `order` (Number) The policy's order between the other policies.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. Required when `targets` is not set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`). Mutually exclusive with per-target priorities.
-- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
+- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. Priority must be set either here or on every target, not both — set this when `targets` is omitted, and omit it when `targets` is set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
+- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. Like `priority`, this is policy-level and cannot be combined with `targets`; use the per-target `priority_override` instead. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
-- `targets` (Attributes List) Route matched logs to specific named datasets with optional per-target priorities. When set, all targets must provide their own `priority` (policy-level `priority` must be omitted), or all must inherit a shared policy-level `priority`. (see [below for nested schema](#nestedatt--policies--targets))
+- `targets` (Attributes List) Route matched logs to specific named datasets. Every target must specify its own `priority`. When `targets` is omitted the backend routes the policy to a single default `logs` dataset using the policy-level `priority`; that implicit target is not reflected in Terraform state. (see [below for nested schema](#nestedatt--policies--targets))
 
 <a id="nestedatt--policies--applications"></a>
 ### Nested Schema for `policies.applications`
@@ -88,7 +88,7 @@ Read-Only:
 - `archive_retention_id` (String) ID of an archive retention policy to apply to this target.
 - `dataset` (String) Name of the dataset to route matched logs to. Must be non-empty.
 - `dataspace` (String) Dataspace name. Defaults to `default` when unset. Maximum 50 characters.
-- `priority` (String) Per-target priority. Can be one of ["block" "high" "low" "medium"]. If omitted, the backend inherits the policy-level `priority` and stores it in state. **Note:** if you later change the policy-level `priority` without also updating this field, the stored value here takes precedence. To reset a target back to inheritance, remove the entire `targets` block and re-add it without `priority`.
+- `priority` (String) Per-target priority. Can be one of ["block" "high" "low" "medium"]. Every target must carry its own priority.
 - `priority_override` (Attributes) Dynamically reassign this target's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--targets--priority_override))
 
 <a id="nestedatt--policies--targets--priority_override"></a>

--- a/docs/data-sources/tco_policies_logs.md
+++ b/docs/data-sources/tco_policies_logs.md
@@ -39,10 +39,11 @@ Read-Only:
 - `id` (String) tco-policy ID.
 - `name` (String) tco-policy name.
 - `order` (Number) The policy's order between the other policies.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
+- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. Required when `targets` is not set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`). Mutually exclusive with per-target priorities.
 - `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
+- `targets` (Attributes List) Route matched logs to specific named datasets with optional per-target priorities. When set, all targets must provide their own `priority` (policy-level `priority` must be omitted), or all must inherit a shared policy-level `priority`. (see [below for nested schema](#nestedatt--policies--targets))
 
 <a id="nestedatt--policies--applications"></a>
 ### Nested Schema for `policies.applications`
@@ -77,3 +78,30 @@ Read-Only:
 
 - `names` (Set of String)
 - `rule_type` (String)
+
+
+<a id="nestedatt--policies--targets"></a>
+### Nested Schema for `policies.targets`
+
+Read-Only:
+
+- `archive_retention_id` (String) ID of an archive retention policy to apply to this target.
+- `dataset` (String) Name of the dataset to route matched logs to. Must be non-empty.
+- `dataspace` (String) Dataspace name. Defaults to `default` when unset. Maximum 50 characters.
+- `priority` (String) Per-target priority. Can be one of ["block" "high" "low" "medium"]. If omitted, the backend inherits the policy-level `priority` and stores it in state. **Note:** if you later change the policy-level `priority` without also updating this field, the stored value here takes precedence. To reset a target back to inheritance, remove the entire `targets` block and re-add it without `priority`.
+- `priority_override` (Attributes) Dynamically reassign this target's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--targets--priority_override))
+
+<a id="nestedatt--policies--targets--priority_override"></a>
+### Nested Schema for `policies.targets.priority_override`
+
+Read-Only:
+
+- `usage_tiers` (Attributes List) Ordered list of quota-consumption tiers; the target's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached. (see [below for nested schema](#nestedatt--policies--targets--priority_override--usage_tiers))
+
+<a id="nestedatt--policies--targets--priority_override--usage_tiers"></a>
+### Nested Schema for `policies.targets.priority_override.usage_tiers`
+
+Read-Only:
+
+- `daily_quota_percentage` (Number) Daily quota consumption (in percent) at which this tier becomes active.
+- `priority` (String) The priority to apply when this tier is active. Can be one of ["block" "high" "low" "medium"].

--- a/docs/resources/tco_policies_logs.md
+++ b/docs/resources/tco_policies_logs.md
@@ -109,40 +109,24 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
         ]
       }
     },
-    # Targets: route matched logs to specific named datasets.
-    # This policy has no targets — standard priority-based routing.
+    # No targets — standard priority-based routing. Behind the scenes the backend routes the
+    # policy to a single default `logs` dataset using the policy-level priority; that implicit
+    # target is not reflected in Terraform state, so `targets` stays absent here.
     {
       name       = "Example tco_policy without targets"
       priority   = "medium"
       severities = ["info", "warning"]
     },
-    # Targets with inherited priority: all targets share the policy-level priority.
-    # Omit `priority` on each target to inherit from the policy.
-    # Note: if you later change the policy-level `priority`, the inherited value
-    # already stored in state will take precedence until you remove and re-add targets.
+    # Targets: route matched logs to specific named datasets. Every target carries its own
+    # priority, and the policy-level priority is omitted.
     {
-      name       = "Example tco_policy with targets (inherited priority)"
-      priority   = "medium"
+      name       = "Example tco_policy with targets"
       severities = ["info", "warning"]
       targets = [
         {
           dataset   = "dataset-a"
           dataspace = "default"
-        },
-        {
-          dataset = "dataset-b"
-        },
-      ]
-    },
-    # Per-target priorities: each target carries its own priority.
-    # When using per-target priorities, omit the policy-level priority.
-    {
-      name       = "Example tco_policy with per-target priorities"
-      severities = ["info", "warning"]
-      targets = [
-        {
-          dataset  = "dataset-a"
-          priority = "medium"
+          priority  = "medium"
         },
         {
           dataset  = "dataset-b"
@@ -179,11 +163,11 @@ Optional:
 - `description` (String) The policy description
 - `dpxl_expression` (String) DataPrime expression to match logs for this policy. Mutually exclusive with `severities` — set exactly one. The expression must include a version prefix, e.g. `<v1> $d.severity == 'INFO'`.
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. Required when `targets` is not set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`). Mutually exclusive with per-target priorities.
-- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
+- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. Priority must be set either here or on every target, not both — set this when `targets` is omitted, and omit it when `targets` is set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
+- `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. Like `priority`, this is policy-level and cannot be combined with `targets`; use the per-target `priority_override` instead. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
-- `targets` (Attributes List) Route matched logs to specific named datasets with optional per-target priorities. When set, all targets must provide their own `priority` (policy-level `priority` must be omitted), or all must inherit a shared policy-level `priority`. (see [below for nested schema](#nestedatt--policies--targets))
+- `targets` (Attributes List) Route matched logs to specific named datasets. Every target must specify its own `priority`. When `targets` is omitted the backend routes the policy to a single default `logs` dataset using the policy-level `priority`; that implicit target is not reflected in Terraform state. (see [below for nested schema](#nestedatt--policies--targets))
 
 Read-Only:
 
@@ -237,12 +221,12 @@ Optional:
 Required:
 
 - `dataset` (String) Name of the dataset to route matched logs to. Must be non-empty.
+- `priority` (String) Per-target priority. Can be one of ["block" "high" "low" "medium"]. Every target must carry its own priority.
 
 Optional:
 
 - `archive_retention_id` (String) ID of an archive retention policy to apply to this target.
 - `dataspace` (String) Dataspace name. Defaults to `default` when unset. Maximum 50 characters.
-- `priority` (String) Per-target priority. Can be one of ["block" "high" "low" "medium"]. If omitted, the backend inherits the policy-level `priority` and stores it in state. **Note:** if you later change the policy-level `priority` without also updating this field, the stored value here takes precedence. To reset a target back to inheritance, remove the entire `targets` block and re-add it without `priority`.
 - `priority_override` (Attributes) Dynamically reassign this target's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--targets--priority_override))
 
 <a id="nestedatt--policies--targets--priority_override"></a>

--- a/docs/resources/tco_policies_logs.md
+++ b/docs/resources/tco_policies_logs.md
@@ -29,6 +29,7 @@ provider "coralogix" {
 
 resource "coralogix_tco_policies_logs" "tco_policies" {
   policies = [
+    # Standard policy without targets.
     {
       name       = "Example tco_policy from terraform 1"
       priority   = "low"
@@ -57,9 +58,8 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
       }
     },
     {
-      name     = "Example tco_policy from terraform 3"
-      priority = "high"
-
+      name       = "Example tco_policy from terraform 3"
+      priority   = "high"
       severities = ["error", "warning", "critical"]
       applications = {
         rule_type = "starts_with"
@@ -71,9 +71,8 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
       }
     },
     {
-      name     = "Example tco_policy from terraform 4"
-      priority = "high"
-
+      name       = "Example tco_policy from terraform 4"
+      priority   = "high"
       severities = ["error", "warning", "critical"]
       applications = {
         rule_type = "starts_with"
@@ -109,7 +108,48 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
           { daily_quota_percentage = 80, priority = "low" },
         ]
       }
-    }
+    },
+    # Targets: route matched logs to specific named datasets.
+    # This policy has no targets — standard priority-based routing.
+    {
+      name       = "Example tco_policy without targets"
+      priority   = "medium"
+      severities = ["info", "warning"]
+    },
+    # Targets with inherited priority: all targets share the policy-level priority.
+    # Omit `priority` on each target to inherit from the policy.
+    # Note: if you later change the policy-level `priority`, the inherited value
+    # already stored in state will take precedence until you remove and re-add targets.
+    {
+      name       = "Example tco_policy with targets (inherited priority)"
+      priority   = "medium"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset   = "dataset-a"
+          dataspace = "default"
+        },
+        {
+          dataset = "dataset-b"
+        },
+      ]
+    },
+    # Per-target priorities: each target carries its own priority.
+    # When using per-target priorities, omit the policy-level priority.
+    {
+      name       = "Example tco_policy with per-target priorities"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset  = "dataset-a"
+          priority = "medium"
+        },
+        {
+          dataset  = "dataset-b"
+          priority = "low"
+        },
+      ]
+    },
   ]
 }
 ```
@@ -131,7 +171,6 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
 Required:
 
 - `name` (String) tco-policy name.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
 
 Optional:
 
@@ -140,9 +179,11 @@ Optional:
 - `description` (String) The policy description
 - `dpxl_expression` (String) DataPrime expression to match logs for this policy. Mutually exclusive with `severities` — set exactly one. The expression must include a version prefix, e.g. `<v1> $d.severity == 'INFO'`.
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
+- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. Required when `targets` is not set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`). Mutually exclusive with per-target priorities.
 - `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
+- `targets` (Attributes List) Route matched logs to specific named datasets with optional per-target priorities. When set, all targets must provide their own `priority` (policy-level `priority` must be omitted), or all must inherit a shared policy-level `priority`. (see [below for nested schema](#nestedatt--policies--targets))
 
 Read-Only:
 
@@ -188,3 +229,33 @@ Required:
 Optional:
 
 - `rule_type` (String)
+
+
+<a id="nestedatt--policies--targets"></a>
+### Nested Schema for `policies.targets`
+
+Required:
+
+- `dataset` (String) Name of the dataset to route matched logs to. Must be non-empty.
+
+Optional:
+
+- `archive_retention_id` (String) ID of an archive retention policy to apply to this target.
+- `dataspace` (String) Dataspace name. Defaults to `default` when unset. Maximum 50 characters.
+- `priority` (String) Per-target priority. Can be one of ["block" "high" "low" "medium"]. If omitted, the backend inherits the policy-level `priority` and stores it in state. **Note:** if you later change the policy-level `priority` without also updating this field, the stored value here takes precedence. To reset a target back to inheritance, remove the entire `targets` block and re-add it without `priority`.
+- `priority_override` (Attributes) Dynamically reassign this target's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--targets--priority_override))
+
+<a id="nestedatt--policies--targets--priority_override"></a>
+### Nested Schema for `policies.targets.priority_override`
+
+Required:
+
+- `usage_tiers` (Attributes List) Ordered list of quota-consumption tiers; the target's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached. (see [below for nested schema](#nestedatt--policies--targets--priority_override--usage_tiers))
+
+<a id="nestedatt--policies--targets--priority_override--usage_tiers"></a>
+### Nested Schema for `policies.targets.priority_override.usage_tiers`
+
+Required:
+
+- `daily_quota_percentage` (Number) Daily quota consumption (in percent) at which this tier becomes active.
+- `priority` (String) The priority to apply when this tier is active. Can be one of ["block" "high" "low" "medium"].

--- a/examples/resources/coralogix_tco_policies_logs/resource.tf
+++ b/examples/resources/coralogix_tco_policies_logs/resource.tf
@@ -94,40 +94,24 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
         ]
       }
     },
-    # Targets: route matched logs to specific named datasets.
-    # This policy has no targets — standard priority-based routing.
+    # No targets — standard priority-based routing. Behind the scenes the backend routes the
+    # policy to a single default `logs` dataset using the policy-level priority; that implicit
+    # target is not reflected in Terraform state, so `targets` stays absent here.
     {
       name       = "Example tco_policy without targets"
       priority   = "medium"
       severities = ["info", "warning"]
     },
-    # Targets with inherited priority: all targets share the policy-level priority.
-    # Omit `priority` on each target to inherit from the policy.
-    # Note: if you later change the policy-level `priority`, the inherited value
-    # already stored in state will take precedence until you remove and re-add targets.
+    # Targets: route matched logs to specific named datasets. Every target carries its own
+    # priority, and the policy-level priority is omitted.
     {
-      name       = "Example tco_policy with targets (inherited priority)"
-      priority   = "medium"
+      name       = "Example tco_policy with targets"
       severities = ["info", "warning"]
       targets = [
         {
           dataset   = "dataset-a"
           dataspace = "default"
-        },
-        {
-          dataset = "dataset-b"
-        },
-      ]
-    },
-    # Per-target priorities: each target carries its own priority.
-    # When using per-target priorities, omit the policy-level priority.
-    {
-      name       = "Example tco_policy with per-target priorities"
-      severities = ["info", "warning"]
-      targets = [
-        {
-          dataset  = "dataset-a"
-          priority = "medium"
+          priority  = "medium"
         },
         {
           dataset  = "dataset-b"

--- a/examples/resources/coralogix_tco_policies_logs/resource.tf
+++ b/examples/resources/coralogix_tco_policies_logs/resource.tf
@@ -14,6 +14,7 @@ provider "coralogix" {
 
 resource "coralogix_tco_policies_logs" "tco_policies" {
   policies = [
+    # Standard policy without targets.
     {
       name       = "Example tco_policy from terraform 1"
       priority   = "low"
@@ -42,9 +43,8 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
       }
     },
     {
-      name     = "Example tco_policy from terraform 3"
-      priority = "high"
-
+      name       = "Example tco_policy from terraform 3"
+      priority   = "high"
       severities = ["error", "warning", "critical"]
       applications = {
         rule_type = "starts_with"
@@ -56,9 +56,8 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
       }
     },
     {
-      name     = "Example tco_policy from terraform 4"
-      priority = "high"
-
+      name       = "Example tco_policy from terraform 4"
+      priority   = "high"
       severities = ["error", "warning", "critical"]
       applications = {
         rule_type = "starts_with"
@@ -94,6 +93,47 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
           { daily_quota_percentage = 80, priority = "low" },
         ]
       }
-    }
+    },
+    # Targets: route matched logs to specific named datasets.
+    # This policy has no targets — standard priority-based routing.
+    {
+      name       = "Example tco_policy without targets"
+      priority   = "medium"
+      severities = ["info", "warning"]
+    },
+    # Targets with inherited priority: all targets share the policy-level priority.
+    # Omit `priority` on each target to inherit from the policy.
+    # Note: if you later change the policy-level `priority`, the inherited value
+    # already stored in state will take precedence until you remove and re-add targets.
+    {
+      name       = "Example tco_policy with targets (inherited priority)"
+      priority   = "medium"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset   = "dataset-a"
+          dataspace = "default"
+        },
+        {
+          dataset = "dataset-b"
+        },
+      ]
+    },
+    # Per-target priorities: each target carries its own priority.
+    # When using per-target priorities, omit the policy-level priority.
+    {
+      name       = "Example tco_policy with per-target priorities"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset  = "dataset-a"
+          priority = "medium"
+        },
+        {
+          dataset  = "dataset-b"
+          priority = "low"
+        },
+      ]
+    },
   ]
 }

--- a/internal/provider/dataplans/data_source_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/data_source_coralogix_tco_policies_logs.go
@@ -96,7 +96,9 @@ func (d *TCOPoliciesLogsDataSource) Read(ctx context.Context, _ datasource.ReadR
 		return
 	}
 
-	state, diags := flattenGetTCOPoliciesLogsList(ctx, result)
+	// nil prior targets: a data source has no prior state, so every policy's targets are reported
+	// exactly as the API returns them, including the default target the backend injects.
+	state, diags := flattenGetTCOPoliciesLogsList(ctx, result, nil)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -39,10 +39,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -52,7 +48,6 @@ import (
 var (
 	_                              resource.ResourceWithConfigure   = &TCOPoliciesLogsResource{}
 	_                              resource.ResourceWithImportState = &TCOPoliciesLogsResource{}
-	_                              resource.ResourceWithModifyPlan  = &TCOPoliciesLogsResource{}
 	tcoPoliciesPrioritySchemaToApi                                  = map[string]tcoPolicys.QuotaV1Priority{
 		"block":  tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_BLOCK,
 		"high":   tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_HIGH,
@@ -159,176 +154,11 @@ func (r *TCOPoliciesLogsResource) Configure(_ context.Context, req resource.Conf
 	r.client = clientSet.TCOPolicies()
 }
 
-// ModifyPlan normalizes per-target priorities and fills in prior state IDs.
-//
-// AtomicOverwrite assigns new UUIDs to ALL policies on every call, so any change
-// to a single policy causes all IDs to change. We fill in state IDs only when
-// nothing in the plan has actually changed, preventing perpetual drift.
-//
-// We also mirror the flatten behavior (Bug: API echoes policy-level priority back
-// onto targets): when the plan has a policy-level priority, strip per-target
-// priorities from plan targets so the plan matches what the provider will return
-// after apply.
-func (r *TCOPoliciesLogsResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
-		return // destroy or create — nothing to preserve
-	}
-
-	var plan, state TCOPoliciesListModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	var planPolicies, statePolicies []types.Object
-	resp.Diagnostics.Append(plan.Policies.ElementsAs(ctx, &planPolicies, true)...)
-	resp.Diagnostics.Append(state.Policies.ElementsAs(ctx, &statePolicies, true)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Normalize per-target priorities: strip them when the policy has a policy-level
-	// priority, matching the flatten behaviour so the plan is consistent with what
-	// the provider will return after apply.
-	normalizedPolicies, diags := normalizePlanTargetPriorities(ctx, planPolicies)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// If count differs or any element changed, AtomicOverwrite assigns new IDs to
-	// ALL policies — leave all ids as (known after apply).
-	resourceChanging := len(normalizedPolicies) != len(statePolicies)
-	if !resourceChanging {
-		for i, planObj := range normalizedPolicies {
-			if policyElementChanged(planObj, statePolicies[i]) {
-				resourceChanging = true
-				break
-			}
-		}
-	}
-
-	// Build updated policy elements: always write the normalized targets back
-	// (to suppress the per-target priorities when a policy-level priority exists),
-	// and fill in state IDs when nothing changed.
-	elemType := types.ObjectType{AttrTypes: policiesLogsAttr()}
-	newElems := make([]attr.Value, len(normalizedPolicies))
-	for i, planObj := range normalizedPolicies {
-		planAttrs := planObj.Attributes()
-		if !resourceChanging {
-			planAttrs["id"] = statePolicies[i].Attributes()["id"]
-		}
-		newObj, dg := types.ObjectValue(policiesLogsAttr(), planAttrs)
-		resp.Diagnostics.Append(dg...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		newElems[i] = newObj
-	}
-	newList, dg := types.ListValue(elemType, newElems)
-	resp.Diagnostics.Append(dg...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	plan.Policies = newList
-	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
-}
-
-// normalizePlanTargetPriorities strips per-target priorities from plan targets for
-// policies that have a policy-level priority. This mirrors what the API does (echoes
-// the policy priority onto every target) and what the flatten does (Bug 1 fix: stores
-// null for target priorities when policy has a policy-level priority).
-func normalizePlanTargetPriorities(ctx context.Context, planPolicies []types.Object) ([]types.Object, diag.Diagnostics) {
-	result := make([]types.Object, len(planPolicies))
-	var diags diag.Diagnostics
-
-	for i, policyObj := range planPolicies {
-		policyAttrs := policyObj.Attributes()
-
-		priorityVal, ok := policyAttrs["priority"]
-		priorityStr, isStr := priorityVal.(types.String)
-		if !ok || !isStr || priorityStr.IsNull() || priorityStr.IsUnknown() {
-			result[i] = policyObj
-			continue
-		}
-
-		// Policy has a non-null priority — strip per-target priorities.
-		targetsVal, ok := policyAttrs["targets"]
-		if !ok {
-			result[i] = policyObj
-			continue
-		}
-		targetsList, isList := targetsVal.(types.List)
-		if !isList || targetsList.IsNull() || targetsList.IsUnknown() {
-			result[i] = policyObj
-			continue
-		}
-
-		var targetObjs []types.Object
-		if dg := targetsList.ElementsAs(ctx, &targetObjs, true); dg.HasError() {
-			diags.Append(dg...)
-			result[i] = policyObj
-			continue
-		}
-
-		newTargetElems := make([]attr.Value, len(targetObjs))
-		for j, targetObj := range targetObjs {
-			targetAttrs := targetObj.Attributes()
-			targetAttrs["priority"] = types.StringNull()
-			newTargetObj, dg := types.ObjectValue(v1TargetAttributes(), targetAttrs)
-			if dg.HasError() {
-				diags.Append(dg...)
-				newTargetElems[j] = targetObj
-				continue
-			}
-			newTargetElems[j] = newTargetObj
-		}
-
-		newTargetsList, dg := types.ListValue(types.ObjectType{AttrTypes: v1TargetAttributes()}, newTargetElems)
-		if dg.HasError() {
-			diags.Append(dg...)
-			result[i] = policyObj
-			continue
-		}
-
-		policyAttrs["targets"] = newTargetsList
-		newPolicyObj, dg := types.ObjectValue(policiesLogsAttr(), policyAttrs)
-		if dg.HasError() {
-			diags.Append(dg...)
-			result[i] = policyObj
-			continue
-		}
-		result[i] = newPolicyObj
-	}
-
-	return result, diags
-}
-
-// policyElementChanged returns true if any non-computed attribute in the plan object
-// differs from the corresponding state attribute.
-func policyElementChanged(plan, state types.Object) bool {
-	stateAttrs := state.Attributes()
-	for name, planVal := range plan.Attributes() {
-		if name == "id" || name == "order" {
-			continue // skip provider-assigned computed fields
-		}
-		stateVal, ok := stateAttrs[name]
-		if !ok || !planVal.Equal(stateVal) {
-			return true
-		}
-	}
-	return false
-}
-
 func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
 				MarkdownDescription: "This field can be ignored",
 			},
 			"policies": schema.ListNestedAttribute{
@@ -362,13 +192,10 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 							Validators: []validator.String{
 								stringvalidator.OneOf(tcoPoliciesValidPriorities...),
 							},
-							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q. Required when `targets` is not set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of \"Route the remaining quota to\" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`). Mutually exclusive with per-target priorities.", tcoPoliciesValidPriorities),
+							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q. Priority must be set either here or on every target, not both — set this when `targets` is omitted, and omit it when `targets` is set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of \"Route the remaining quota to\" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).", tcoPoliciesValidPriorities),
 						},
 						"order": schema.Int64Attribute{
-							Computed: true,
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.UseNonNullStateForUnknown(),
-							},
+							Computed:            true,
 							MarkdownDescription: "The policy's order between the other policies.",
 						},
 						"archive_retention_id": schema.StringAttribute{
@@ -472,13 +299,12 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 									MarkdownDescription: "Ordered list of quota-consumption tiers; the policy's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached.",
 								},
 							},
-							MarkdownDescription: "Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback (\"Route the remaining quota to\" in the UI), which must be more restrictive than the last tier.",
+							MarkdownDescription: "Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback (\"Route the remaining quota to\" in the UI), which must be more restrictive than the last tier. Like `priority`, this is policy-level and cannot be combined with `targets`; use the per-target `priority_override` instead.",
 						},
 						"targets": schema.ListNestedAttribute{
 							Optional: true,
-							Computed: true,
-							PlanModifiers: []planmodifier.List{
-								listplanmodifier.UseStateForUnknown(),
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
 							},
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
@@ -499,15 +325,11 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 										MarkdownDescription: "Dataspace name. Defaults to `default` when unset. Maximum 50 characters.",
 									},
 									"priority": schema.StringAttribute{
-										Optional: true,
-										Computed: true,
-										PlanModifiers: []planmodifier.String{
-											stringplanmodifier.UseStateForUnknown(),
-										},
+										Required: true,
 										Validators: []validator.String{
 											stringvalidator.OneOf(tcoPoliciesValidPriorities...),
 										},
-										MarkdownDescription: fmt.Sprintf("Per-target priority. Can be one of %q. If omitted, the backend inherits the policy-level `priority` and stores it in state. **Note:** if you later change the policy-level `priority` without also updating this field, the stored value here takes precedence. To reset a target back to inheritance, remove the entire `targets` block and re-add it without `priority`.", tcoPoliciesValidPriorities),
+										MarkdownDescription: fmt.Sprintf("Per-target priority. Can be one of %q. Every target must carry its own priority.", tcoPoliciesValidPriorities),
 									},
 									"archive_retention_id": schema.StringAttribute{
 										Optional: true,
@@ -546,7 +368,7 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 									},
 								},
 							},
-							MarkdownDescription: "Route matched logs to specific named datasets with optional per-target priorities. When set, all targets must provide their own `priority` (policy-level `priority` must be omitted), or all must inherit a shared policy-level `priority`.",
+							MarkdownDescription: "Route matched logs to specific named datasets. Every target must specify its own `priority`. When `targets` is omitted the backend routes the policy to a single default `logs` dataset using the policy-level `priority`; that implicit target is not reflected in Terraform state.",
 						},
 					},
 				},
@@ -628,6 +450,12 @@ func (r *TCOPoliciesLogsResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
+	priorTargets, diags := priorTargetsFromPolicies(ctx, plan.Policies)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
 	result, httpResponse, err := r.client.
 		PoliciesServiceAtomicOverwriteLogPolicies(ctx).
 		AtomicOverwriteLogPoliciesRequest(*rq).
@@ -638,7 +466,7 @@ func (r *TCOPoliciesLogsResource) Create(ctx context.Context, req resource.Creat
 		)
 		return
 	}
-	state, diags := flattenOverwriteTCOPoliciesLogsList(ctx, result)
+	state, diags := flattenOverwriteTCOPoliciesLogsList(ctx, result, priorTargets)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -647,9 +475,23 @@ func (r *TCOPoliciesLogsResource) Create(ctx context.Context, req resource.Creat
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
-func (r *TCOPoliciesLogsResource) Read(ctx context.Context, _ resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *TCOPoliciesLogsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
+
+	// Prior state tells us which policies were configured without targets, so the backend's
+	// injected default target can be ignored for those. On import there is no prior state and
+	// every policy's targets come straight from the API.
+	var priorState TCOPoliciesListModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	priorTargets, diags := priorTargetsFromPolicies(ctx, priorState.Policies)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	result, httpResponse, err := r.client.PoliciesServiceGetCompanyPolicies(ctx).SourceType(LogSource).Execute()
 	if err != nil {
@@ -667,7 +509,7 @@ func (r *TCOPoliciesLogsResource) Read(ctx context.Context, _ resource.ReadReque
 		return
 	}
 
-	state, diags := flattenGetTCOPoliciesLogsList(ctx, result)
+	state, diags := flattenGetTCOPoliciesLogsList(ctx, result, priorTargets)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -692,6 +534,12 @@ func (r *TCOPoliciesLogsResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
+	priorTargets, diags := priorTargetsFromPolicies(ctx, plan.Policies)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
 	result, httpResponse, err := r.client.
 		PoliciesServiceAtomicOverwriteLogPolicies(ctx).
 		AtomicOverwriteLogPoliciesRequest(*rq).
@@ -710,7 +558,7 @@ func (r *TCOPoliciesLogsResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	state, diags := flattenOverwriteTCOPoliciesLogsList(ctx, result)
+	state, diags := flattenOverwriteTCOPoliciesLogsList(ctx, result, priorTargets)
 
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -736,11 +584,11 @@ func (r *TCOPoliciesLogsResource) Delete(ctx context.Context, req resource.Delet
 	}
 }
 
-func flattenOverwriteTCOPoliciesLogsList(ctx context.Context, overwriteResp *tcoPolicys.AtomicOverwriteLogPoliciesResponse) (*TCOPoliciesListModel, diag.Diagnostics) {
+func flattenOverwriteTCOPoliciesLogsList(ctx context.Context, overwriteResp *tcoPolicys.AtomicOverwriteLogPoliciesResponse, priorTargets []types.List) (*TCOPoliciesListModel, diag.Diagnostics) {
 	policies := make([]*TCOPolicyLogsModel, 0)
 	var diags diag.Diagnostics
-	for _, policy := range overwriteResp.GetCreateResponses() {
-		tcoPolicy, dgs := flattenTCOLogsPolicy(ctx, policy.GetPolicy())
+	for i, policy := range overwriteResp.GetCreateResponses() {
+		tcoPolicy, dgs := flattenTCOLogsPolicy(ctx, policy.GetPolicy(), priorTargetsAt(priorTargets, i))
 		if dgs.HasError() {
 			diags.Append(dgs...)
 			continue
@@ -759,11 +607,11 @@ func flattenOverwriteTCOPoliciesLogsList(ctx context.Context, overwriteResp *tco
 	return &TCOPoliciesListModel{Policies: policiesList}, nil
 }
 
-func flattenGetTCOPoliciesLogsList(ctx context.Context, getResp *tcoPolicys.GetCompanyPoliciesResponse) (*TCOPoliciesListModel, diag.Diagnostics) {
+func flattenGetTCOPoliciesLogsList(ctx context.Context, getResp *tcoPolicys.GetCompanyPoliciesResponse, priorTargets []types.List) (*TCOPoliciesListModel, diag.Diagnostics) {
 	policies := make([]*TCOPolicyLogsModel, 0)
 	var diags diag.Diagnostics
-	for _, policy := range getResp.GetPolicies() {
-		tcoPolicy, dgs := flattenTCOLogsPolicy(ctx, policy)
+	for i, policy := range getResp.GetPolicies() {
+		tcoPolicy, dgs := flattenTCOLogsPolicy(ctx, policy, priorTargetsAt(priorTargets, i))
 		if dgs.HasError() {
 			diags.Append(dgs...)
 			continue
@@ -782,7 +630,10 @@ func flattenGetTCOPoliciesLogsList(ctx context.Context, getResp *tcoPolicys.GetC
 	return &TCOPoliciesListModel{Policies: policiesList}, nil
 }
 
-func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPolicyLogsModel, diag.Diagnostics) {
+// flattenTCOLogsPolicy converts one API policy into its Terraform model. priorTargets is the
+// `targets` value already recorded for this policy (from the plan on create/update, or from prior
+// state on read); see flattenV1Targets for how it is used.
+func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy, priorTargets types.List) (*TCOPolicyLogsModel, diag.Diagnostics) {
 	logsPolicy := policy
 
 	logRules := logsPolicy.LogRules
@@ -806,10 +657,7 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 		priority = types.StringNull()
 	}
 
-	// When the policy has a policy-level priority the API echoes it back on every target.
-	// Strip those echoed priorities so state matches the plan (where target priorities are null).
-	stripTargetPriorities := policyPriority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED
-	targets, diags := flattenV1Targets(ctx, logsPolicy.Targets, stripTargetPriorities)
+	targets, diags := flattenV1Targets(ctx, logsPolicy.Targets, priorTargets)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -857,10 +705,51 @@ func flattenQuotaBasedPriorityOverride(ctx context.Context, po *tcoPolicys.Prior
 	})
 }
 
-func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target, stripPriorities bool) (types.List, diag.Diagnostics) {
+// priorTargetsAt returns the `targets` value already recorded for the policy at index i, or a
+// non-null empty list when there is no entry for it. The fallback covers import (state has no
+// policies yet), the data source (no prior state at all), and a state/API length mismatch — in all
+// of those the API response is the only source of truth, so it must be surfaced rather than dropped.
+func priorTargetsAt(prior []types.List, i int) types.List {
+	if i < len(prior) {
+		return prior[i]
+	}
+	return types.ListValueMust(types.ObjectType{AttrTypes: v1TargetAttributes()}, []attr.Value{})
+}
+
+// priorTargetsFromPolicies pulls the per-policy `targets` values out of a plan or state policies
+// list, preserving order. A null/unknown list yields nil, which makes every lookup fall through to
+// priorTargetsAt's fallback.
+func priorTargetsFromPolicies(ctx context.Context, policies types.List) ([]types.List, diag.Diagnostics) {
+	if policies.IsNull() || policies.IsUnknown() {
+		return nil, nil
+	}
+
+	var policyObjects []types.Object
+	if diags := policies.ElementsAs(ctx, &policyObjects, true); diags.HasError() {
+		return nil, diags
+	}
+
+	result := make([]types.List, 0, len(policyObjects))
+	for _, po := range policyObjects {
+		var policy TCOPolicyLogsModel
+		if diags := po.As(ctx, &policy, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return nil, diags
+		}
+		result = append(result, policy.Targets)
+	}
+	return result, nil
+}
+
+// flattenV1Targets converts the API's targets into state.
+//
+// The backend injects a default target ({dataset: "logs", dataspace: "default", priority: <the
+// policy's priority>}) into every policy that was created without explicit targets. A null
+// priorTargets means this policy had no targets configured, so that injected default is the API's
+// own bookkeeping rather than user intent — keep `targets` null so it never shows up as drift.
+func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target, priorTargets types.List) (types.List, diag.Diagnostics) {
 	elemType := types.ObjectType{AttrTypes: v1TargetAttributes()}
-	if len(targets) == 0 {
-		return types.ListValueMust(elemType, []attr.Value{}), nil
+	if priorTargets.IsNull() || len(targets) == 0 {
+		return types.ListNull(elemType), nil
 	}
 
 	items := make([]V1TargetModel, 0, len(targets))
@@ -871,7 +760,7 @@ func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target, stripP
 		}
 
 		var priority types.String
-		if !stripPriorities && t.Priority != nil && *t.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+		if t.Priority != nil && *t.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
 			priority = types.StringValue(tcoPoliciesPriorityApiToSchema[*t.Priority])
 		} else {
 			priority = types.StringNull()
@@ -1008,14 +897,6 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 	targets, diags := expandV1Targets(ctx, plan.Targets)
 	if diags.HasError() {
 		return nil, diags
-	}
-	// API rejects a request where both policy-level priority and per-target priorities are
-	// set. When the policy has a policy-level priority, the backend echoes back targets with
-	// matching per-target priorities; on the next update those echoed values must be stripped.
-	if priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
-		for i := range targets {
-			targets[i].Priority = nil
-		}
 	}
 	enabled := !plan.Enabled.ValueBool()
 

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -39,6 +39,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -304,6 +306,9 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 						"targets": schema.ListNestedAttribute{
 							Optional: true,
 							Computed: true,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"dataset": schema.StringAttribute{

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -52,6 +52,7 @@ import (
 var (
 	_                              resource.ResourceWithConfigure   = &TCOPoliciesLogsResource{}
 	_                              resource.ResourceWithImportState = &TCOPoliciesLogsResource{}
+	_                              resource.ResourceWithModifyPlan  = &TCOPoliciesLogsResource{}
 	tcoPoliciesPrioritySchemaToApi                                  = map[string]tcoPolicys.QuotaV1Priority{
 		"block":  tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_BLOCK,
 		"high":   tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_HIGH,
@@ -158,6 +159,168 @@ func (r *TCOPoliciesLogsResource) Configure(_ context.Context, req resource.Conf
 	r.client = clientSet.TCOPolicies()
 }
 
+// ModifyPlan normalizes per-target priorities and fills in prior state IDs.
+//
+// AtomicOverwrite assigns new UUIDs to ALL policies on every call, so any change
+// to a single policy causes all IDs to change. We fill in state IDs only when
+// nothing in the plan has actually changed, preventing perpetual drift.
+//
+// We also mirror the flatten behavior (Bug: API echoes policy-level priority back
+// onto targets): when the plan has a policy-level priority, strip per-target
+// priorities from plan targets so the plan matches what the provider will return
+// after apply.
+func (r *TCOPoliciesLogsResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return // destroy or create — nothing to preserve
+	}
+
+	var plan, state TCOPoliciesListModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var planPolicies, statePolicies []types.Object
+	resp.Diagnostics.Append(plan.Policies.ElementsAs(ctx, &planPolicies, true)...)
+	resp.Diagnostics.Append(state.Policies.ElementsAs(ctx, &statePolicies, true)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Normalize per-target priorities: strip them when the policy has a policy-level
+	// priority, matching the flatten behaviour so the plan is consistent with what
+	// the provider will return after apply.
+	normalizedPolicies, diags := normalizePlanTargetPriorities(ctx, planPolicies)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If count differs or any element changed, AtomicOverwrite assigns new IDs to
+	// ALL policies — leave all ids as (known after apply).
+	resourceChanging := len(normalizedPolicies) != len(statePolicies)
+	if !resourceChanging {
+		for i, planObj := range normalizedPolicies {
+			if policyElementChanged(planObj, statePolicies[i]) {
+				resourceChanging = true
+				break
+			}
+		}
+	}
+
+	// Build updated policy elements: always write the normalized targets back
+	// (to suppress the per-target priorities when a policy-level priority exists),
+	// and fill in state IDs when nothing changed.
+	elemType := types.ObjectType{AttrTypes: policiesLogsAttr()}
+	newElems := make([]attr.Value, len(normalizedPolicies))
+	for i, planObj := range normalizedPolicies {
+		planAttrs := planObj.Attributes()
+		if !resourceChanging {
+			planAttrs["id"] = statePolicies[i].Attributes()["id"]
+		}
+		newObj, dg := types.ObjectValue(policiesLogsAttr(), planAttrs)
+		resp.Diagnostics.Append(dg...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		newElems[i] = newObj
+	}
+	newList, dg := types.ListValue(elemType, newElems)
+	resp.Diagnostics.Append(dg...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Policies = newList
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
+
+// normalizePlanTargetPriorities strips per-target priorities from plan targets for
+// policies that have a policy-level priority. This mirrors what the API does (echoes
+// the policy priority onto every target) and what the flatten does (Bug 1 fix: stores
+// null for target priorities when policy has a policy-level priority).
+func normalizePlanTargetPriorities(ctx context.Context, planPolicies []types.Object) ([]types.Object, diag.Diagnostics) {
+	result := make([]types.Object, len(planPolicies))
+	var diags diag.Diagnostics
+
+	for i, policyObj := range planPolicies {
+		policyAttrs := policyObj.Attributes()
+
+		priorityVal, ok := policyAttrs["priority"]
+		priorityStr, isStr := priorityVal.(types.String)
+		if !ok || !isStr || priorityStr.IsNull() || priorityStr.IsUnknown() {
+			result[i] = policyObj
+			continue
+		}
+
+		// Policy has a non-null priority — strip per-target priorities.
+		targetsVal, ok := policyAttrs["targets"]
+		if !ok {
+			result[i] = policyObj
+			continue
+		}
+		targetsList, isList := targetsVal.(types.List)
+		if !isList || targetsList.IsNull() || targetsList.IsUnknown() {
+			result[i] = policyObj
+			continue
+		}
+
+		var targetObjs []types.Object
+		if dg := targetsList.ElementsAs(ctx, &targetObjs, true); dg.HasError() {
+			diags.Append(dg...)
+			result[i] = policyObj
+			continue
+		}
+
+		newTargetElems := make([]attr.Value, len(targetObjs))
+		for j, targetObj := range targetObjs {
+			targetAttrs := targetObj.Attributes()
+			targetAttrs["priority"] = types.StringNull()
+			newTargetObj, dg := types.ObjectValue(v1TargetAttributes(), targetAttrs)
+			if dg.HasError() {
+				diags.Append(dg...)
+				newTargetElems[j] = targetObj
+				continue
+			}
+			newTargetElems[j] = newTargetObj
+		}
+
+		newTargetsList, dg := types.ListValue(types.ObjectType{AttrTypes: v1TargetAttributes()}, newTargetElems)
+		if dg.HasError() {
+			diags.Append(dg...)
+			result[i] = policyObj
+			continue
+		}
+
+		policyAttrs["targets"] = newTargetsList
+		newPolicyObj, dg := types.ObjectValue(policiesLogsAttr(), policyAttrs)
+		if dg.HasError() {
+			diags.Append(dg...)
+			result[i] = policyObj
+			continue
+		}
+		result[i] = newPolicyObj
+	}
+
+	return result, diags
+}
+
+// policyElementChanged returns true if any non-computed attribute in the plan object
+// differs from the corresponding state attribute.
+func policyElementChanged(plan, state types.Object) bool {
+	stateAttrs := state.Attributes()
+	for name, planVal := range plan.Attributes() {
+		if name == "id" || name == "order" {
+			continue // skip provider-assigned computed fields
+		}
+		stateVal, ok := stateAttrs[name]
+		if !ok || !planVal.Equal(stateVal) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
@@ -172,10 +335,7 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseNonNullStateForUnknown(),
-							},
+							Computed:            true,
 							MarkdownDescription: "tco-policy ID.",
 						},
 						"name": schema.StringAttribute{
@@ -638,16 +798,20 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 	if diags.HasError() {
 		return nil, diags
 	}
-	targets, diags := flattenV1Targets(ctx, logsPolicy.Targets)
-	if diags.HasError() {
-		return nil, diags
-	}
-
 	var priority types.String
-	if p := logsPolicy.GetPriority(); p != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
-		priority = types.StringValue(tcoPoliciesPriorityApiToSchema[p])
+	policyPriority := logsPolicy.GetPriority()
+	if policyPriority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+		priority = types.StringValue(tcoPoliciesPriorityApiToSchema[policyPriority])
 	} else {
 		priority = types.StringNull()
+	}
+
+	// When the policy has a policy-level priority the API echoes it back on every target.
+	// Strip those echoed priorities so state matches the plan (where target priorities are null).
+	stripTargetPriorities := policyPriority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED
+	targets, diags := flattenV1Targets(ctx, logsPolicy.Targets, stripTargetPriorities)
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	return &TCOPolicyLogsModel{
@@ -693,7 +857,7 @@ func flattenQuotaBasedPriorityOverride(ctx context.Context, po *tcoPolicys.Prior
 	})
 }
 
-func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target) (types.List, diag.Diagnostics) {
+func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target, stripPriorities bool) (types.List, diag.Diagnostics) {
 	elemType := types.ObjectType{AttrTypes: v1TargetAttributes()}
 	if len(targets) == 0 {
 		return types.ListValueMust(elemType, []attr.Value{}), nil
@@ -707,7 +871,7 @@ func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target) (types
 		}
 
 		var priority types.String
-		if t.Priority != nil && *t.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+		if !stripPriorities && t.Priority != nil && *t.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
 			priority = types.StringValue(tcoPoliciesPriorityApiToSchema[*t.Priority])
 		} else {
 			priority = types.StringNull()

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -39,8 +39,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -160,14 +162,20 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed:            true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "This field can be ignored",
 			},
 			"policies": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed:            true,
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseNonNullStateForUnknown(),
+							},
 							MarkdownDescription: "tco-policy ID.",
 						},
 						"name": schema.StringAttribute{
@@ -197,7 +205,10 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q. Required when `targets` is not set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of \"Route the remaining quota to\" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`). Mutually exclusive with per-target priorities.", tcoPoliciesValidPriorities),
 						},
 						"order": schema.Int64Attribute{
-							Computed:            true,
+							Computed: true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseNonNullStateForUnknown(),
+							},
 							MarkdownDescription: "The policy's order between the other policies.",
 						},
 						"archive_retention_id": schema.StringAttribute{
@@ -330,6 +341,9 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 									"priority": schema.StringAttribute{
 										Optional: true,
 										Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 										Validators: []validator.String{
 											stringvalidator.OneOf(tcoPoliciesValidPriorities...),
 										},
@@ -563,7 +577,7 @@ func (r *TCOPoliciesLogsResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func flattenOverwriteTCOPoliciesLogsList(ctx context.Context, overwriteResp *tcoPolicys.AtomicOverwriteLogPoliciesResponse) (*TCOPoliciesListModel, diag.Diagnostics) {
-	var policies []*TCOPolicyLogsModel
+	policies := make([]*TCOPolicyLogsModel, 0)
 	var diags diag.Diagnostics
 	for _, policy := range overwriteResp.GetCreateResponses() {
 		tcoPolicy, dgs := flattenTCOLogsPolicy(ctx, policy.GetPolicy())
@@ -586,7 +600,7 @@ func flattenOverwriteTCOPoliciesLogsList(ctx context.Context, overwriteResp *tco
 }
 
 func flattenGetTCOPoliciesLogsList(ctx context.Context, getResp *tcoPolicys.GetCompanyPoliciesResponse) (*TCOPoliciesListModel, diag.Diagnostics) {
-	var policies []*TCOPolicyLogsModel
+	policies := make([]*TCOPolicyLogsModel, 0)
 	var diags diag.Diagnostics
 	for _, policy := range getResp.GetPolicies() {
 		tcoPolicy, dgs := flattenTCOLogsPolicy(ctx, policy)
@@ -682,7 +696,7 @@ func flattenQuotaBasedPriorityOverride(ctx context.Context, po *tcoPolicys.Prior
 func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target) (types.List, diag.Diagnostics) {
 	elemType := types.ObjectType{AttrTypes: v1TargetAttributes()}
 	if len(targets) == 0 {
-		return types.ListNull(elemType), nil
+		return types.ListValueMust(elemType, []attr.Value{}), nil
 	}
 
 	items := make([]V1TargetModel, 0, len(targets))
@@ -830,6 +844,14 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 	targets, diags := expandV1Targets(ctx, plan.Targets)
 	if diags.HasError() {
 		return nil, diags
+	}
+	// API rejects a request where both policy-level priority and per-target priorities are
+	// set. When the policy has a policy-level priority, the backend echoes back targets with
+	// matching per-target priorities; on the next update those echoed values must be stripped.
+	if priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+		for i := range targets {
+			targets[i].Priority = nil
+		}
 	}
 	enabled := !plan.Enabled.ValueBool()
 

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -75,9 +75,7 @@ var (
 	}
 	tcoPolicySeverityApiToSchema = utils.ReverseMap(tcoPolicySeveritySchemaToApi)
 	validPolicySeverities        = utils.GetKeys(tcoPolicySeveritySchemaToApi)
-	// overrideTCOPoliciesLogsURL     = tcoPolicys.TCOPoliciesAtomicOverwriteLogPoliciesRPC
-	// getCompanyPoliciesURL          = tcoPolicys.TCOPoliciesGetCompanyPoliciesRPC
-	LogSource = tcoPolicys.V1SOURCETYPE_SOURCE_TYPE_LOGS
+	LogSource                    = tcoPolicys.V1SOURCETYPE_SOURCE_TYPE_LOGS
 )
 
 func NewTCOPoliciesLogsResource() resource.Resource {
@@ -110,6 +108,7 @@ type TCOPolicyLogsModel struct {
 	ArchiveRetentionID         types.String `tfsdk:"archive_retention_id"`
 	DpxlExpression             types.String `tfsdk:"dpxl_expression"`
 	QuotaBasedPriorityOverride types.Object `tfsdk:"quota_based_priority_override"` // QuotaBasedPriorityOverrideModel
+	Targets                    types.List   `tfsdk:"targets"`                       // []V1TargetModel
 }
 
 type TCORuleModel struct {
@@ -124,6 +123,14 @@ type QuotaBasedPriorityOverrideModel struct {
 type UsageTierModel struct {
 	DailyQuotaPercentage types.Float64 `tfsdk:"daily_quota_percentage"`
 	Priority             types.String  `tfsdk:"priority"`
+}
+
+type V1TargetModel struct {
+	Dataset            types.String `tfsdk:"dataset"`
+	Dataspace          types.String `tfsdk:"dataspace"`
+	Priority           types.String `tfsdk:"priority"`
+	ArchiveRetentionID types.String `tfsdk:"archive_retention_id"`
+	PriorityOverride   types.Object `tfsdk:"priority_override"` // QuotaBasedPriorityOverrideModel
 }
 
 func (r *TCOPoliciesLogsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -181,11 +188,11 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 							MarkdownDescription: "Determines weather the policy will be enabled. True by default.",
 						},
 						"priority": schema.StringAttribute{
-							Required: true,
+							Optional: true,
 							Validators: []validator.String{
 								stringvalidator.OneOf(tcoPoliciesValidPriorities...),
 							},
-							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of \"Route the remaining quota to\" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).", tcoPoliciesValidPriorities),
+							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q. Required when `targets` is not set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of \"Route the remaining quota to\" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`). Mutually exclusive with per-target priorities.", tcoPoliciesValidPriorities),
 						},
 						"order": schema.Int64Attribute{
 							Computed:            true,
@@ -293,6 +300,74 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 								},
 							},
 							MarkdownDescription: "Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback (\"Route the remaining quota to\" in the UI), which must be more restrictive than the last tier.",
+						},
+						"targets": schema.ListNestedAttribute{
+							Optional: true,
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"dataset": schema.StringAttribute{
+										Required: true,
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+										MarkdownDescription: "Name of the dataset to route matched logs to. Must be non-empty.",
+									},
+									"dataspace": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+										Default:  stringdefault.StaticString("default"),
+										Validators: []validator.String{
+											stringvalidator.LengthAtMost(50),
+										},
+										MarkdownDescription: "Dataspace name. Defaults to `default` when unset. Maximum 50 characters.",
+									},
+									"priority": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+										Validators: []validator.String{
+											stringvalidator.OneOf(tcoPoliciesValidPriorities...),
+										},
+										MarkdownDescription: fmt.Sprintf("Per-target priority. Can be one of %q. If omitted, the backend inherits the policy-level `priority` and stores it in state. **Note:** if you later change the policy-level `priority` without also updating this field, the stored value here takes precedence. To reset a target back to inheritance, remove the entire `targets` block and re-add it without `priority`.", tcoPoliciesValidPriorities),
+									},
+									"archive_retention_id": schema.StringAttribute{
+										Optional: true,
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+										MarkdownDescription: "ID of an archive retention policy to apply to this target.",
+									},
+									"priority_override": schema.SingleNestedAttribute{
+										Optional: true,
+										Attributes: map[string]schema.Attribute{
+											"usage_tiers": schema.ListNestedAttribute{
+												Required: true,
+												Validators: []validator.List{
+													listvalidator.SizeAtLeast(1),
+												},
+												NestedObject: schema.NestedAttributeObject{
+													Attributes: map[string]schema.Attribute{
+														"daily_quota_percentage": schema.Float64Attribute{
+															Required:            true,
+															MarkdownDescription: "Daily quota consumption (in percent) at which this tier becomes active.",
+														},
+														"priority": schema.StringAttribute{
+															Required: true,
+															Validators: []validator.String{
+																stringvalidator.OneOf(tcoPoliciesValidPriorities...),
+															},
+															MarkdownDescription: fmt.Sprintf("The priority to apply when this tier is active. Can be one of %q.", tcoPoliciesValidPriorities),
+														},
+													},
+												},
+												MarkdownDescription: "Ordered list of quota-consumption tiers; the target's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached.",
+											},
+										},
+										MarkdownDescription: "Dynamically reassign this target's priority based on daily quota consumption tiers.",
+									},
+								},
+							},
+							MarkdownDescription: "Route matched logs to specific named datasets with optional per-target priorities. When set, all targets must provide their own `priority` (policy-level `priority` must be omitted), or all must inherit a shared policy-level `priority`.",
 						},
 					},
 				},
@@ -544,6 +619,17 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 	if diags.HasError() {
 		return nil, diags
 	}
+	targets, diags := flattenV1Targets(ctx, logsPolicy.Targets)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	var priority types.String
+	if p := logsPolicy.GetPriority(); p != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+		priority = types.StringValue(tcoPoliciesPriorityApiToSchema[p])
+	} else {
+		priority = types.StringNull()
+	}
 
 	return &TCOPolicyLogsModel{
 		ID:                         types.StringValue(logsPolicy.GetId()),
@@ -551,13 +637,14 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 		Description:                types.StringValue(logsPolicy.GetDescription()),
 		Enabled:                    types.BoolValue(logsPolicy.GetEnabled()),
 		Order:                      types.Int64Value(int64(logsPolicy.GetOrder())),
-		Priority:                   types.StringValue(tcoPoliciesPriorityApiToSchema[logsPolicy.GetPriority()]),
+		Priority:                   priority,
 		Applications:               applications,
 		Subsystems:                 subsystems,
 		ArchiveRetentionID:         flattenArchiveRetention(logsPolicy.ArchiveRetention),
 		Severities:                 flattenTCOPolicySeverities(logRules.GetSeverities()),
 		DpxlExpression:             types.StringPointerValue(logRules.DpxlExpression),
 		QuotaBasedPriorityOverride: quotaBased,
+		Targets:                    targets,
 	}, nil
 }
 
@@ -587,6 +674,45 @@ func flattenQuotaBasedPriorityOverride(ctx context.Context, po *tcoPolicys.Prior
 	})
 }
 
+func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target) (types.List, diag.Diagnostics) {
+	elemType := types.ObjectType{AttrTypes: v1TargetAttributes()}
+	if len(targets) == 0 {
+		return types.ListNull(elemType), nil
+	}
+
+	items := make([]V1TargetModel, 0, len(targets))
+	for _, t := range targets {
+		priorityOverride, diags := flattenQuotaBasedPriorityOverride(ctx, t.PriorityOverride)
+		if diags.HasError() {
+			return types.ListNull(elemType), diags
+		}
+
+		var priority types.String
+		if t.Priority != nil && *t.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+			priority = types.StringValue(tcoPoliciesPriorityApiToSchema[*t.Priority])
+		} else {
+			priority = types.StringNull()
+		}
+
+		var dataspace types.String
+		if t.Dataspace != nil {
+			dataspace = types.StringValue(*t.Dataspace)
+		} else {
+			dataspace = types.StringNull()
+		}
+
+		items = append(items, V1TargetModel{
+			Dataset:            types.StringPointerValue(t.Dataset),
+			Dataspace:          dataspace,
+			Priority:           priority,
+			ArchiveRetentionID: flattenArchiveRetention(t.ArchiveRetention),
+			PriorityOverride:   priorityOverride,
+		})
+	}
+
+	return types.ListValueFrom(ctx, elemType, items)
+}
+
 func policiesLogsAttr() map[string]attr.Type {
 	return map[string]attr.Type{
 		"id":                            types.StringType,
@@ -601,6 +727,17 @@ func policiesLogsAttr() map[string]attr.Type {
 		"archive_retention_id":          types.StringType,
 		"dpxl_expression":               types.StringType,
 		"quota_based_priority_override": types.ObjectType{AttrTypes: quotaBasedPriorityOverrideAttributes()},
+		"targets":                       types.ListType{ElemType: types.ObjectType{AttrTypes: v1TargetAttributes()}},
+	}
+}
+
+func v1TargetAttributes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"dataset":              types.StringType,
+		"dataspace":            types.StringType,
+		"priority":             types.StringType,
+		"archive_retention_id": types.StringType,
+		"priority_override":    types.ObjectType{AttrTypes: quotaBasedPriorityOverrideAttributes()},
 	}
 }
 
@@ -662,7 +799,12 @@ func extractOverwriteTcoPoliciesLogs(ctx context.Context, plan *TCOPoliciesListM
 }
 
 func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPolicys.CreateLogPolicyRequest, diag.Diagnostics) {
-	priority := tcoPoliciesPrioritySchemaToApi[plan.Priority.ValueString()]
+	var priority tcoPolicys.QuotaV1Priority
+	if plan.Priority.IsNull() || plan.Priority.IsUnknown() {
+		priority = tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED
+	} else {
+		priority = tcoPoliciesPrioritySchemaToApi[plan.Priority.ValueString()]
+	}
 	applicationRule, diags := expandTCOPolicyRule(ctx, plan.Applications)
 	if diags.HasError() {
 		return nil, diags
@@ -677,6 +819,10 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 		return nil, diags
 	}
 	priorityOverride, diags := expandQuotaBasedPriorityOverride(ctx, plan.QuotaBasedPriorityOverride)
+	if diags.HasError() {
+		return nil, diags
+	}
+	targets, diags := expandV1Targets(ctx, plan.Targets)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -699,6 +845,7 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 			ArchiveRetention: archiveRetention,
 			Disabled:         &enabled,
 			PriorityOverride: priorityOverride,
+			Targets:          targets,
 		},
 		LogRules: logRules,
 	}, nil
@@ -740,6 +887,49 @@ func expandQuotaBasedPriorityOverride(ctx context.Context, override types.Object
 			UsageTiers: tiers,
 		},
 	}, nil
+}
+
+func expandV1Targets(ctx context.Context, targets types.List) ([]tcoPolicys.V1Target, diag.Diagnostics) {
+	if targets.IsNull() || targets.IsUnknown() {
+		return nil, nil
+	}
+
+	var targetObjects []types.Object
+	if diags := targets.ElementsAs(ctx, &targetObjects, true); diags.HasError() {
+		return nil, diags
+	}
+
+	result := make([]tcoPolicys.V1Target, 0, len(targetObjects))
+	for _, to := range targetObjects {
+		var m V1TargetModel
+		if diags := to.As(ctx, &m, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return nil, diags
+		}
+
+		target := tcoPolicys.V1Target{
+			Dataset:          m.Dataset.ValueStringPointer(),
+			ArchiveRetention: expandActiveRetention(m.ArchiveRetentionID),
+		}
+
+		if !m.Dataspace.IsNull() && !m.Dataspace.IsUnknown() {
+			target.Dataspace = m.Dataspace.ValueStringPointer()
+		}
+
+		if !m.Priority.IsNull() && !m.Priority.IsUnknown() {
+			p := tcoPoliciesPrioritySchemaToApi[m.Priority.ValueString()]
+			target.Priority = &p
+		}
+
+		priorityOverride, diags := expandQuotaBasedPriorityOverride(ctx, m.PriorityOverride)
+		if diags.HasError() {
+			return nil, diags
+		}
+		target.PriorityOverride = priorityOverride
+
+		result = append(result, target)
+	}
+
+	return result, nil
 }
 
 func expandTCOPolicyRule(ctx context.Context, rule types.Object) (*tcoPolicys.QuotaV1Rule, diag.Diagnostics) {

--- a/internal/provider/resource_coralogix_tco_policies_logs_test.go
+++ b/internal/provider/resource_coralogix_tco_policies_logs_test.go
@@ -53,6 +53,9 @@ func TestAccCoralogixResourceTCOPoliciesLogsCreate(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(tcoPoliciesResourceName, "policies.0.subsystems.names.*", "mobile"),
 					resource.TestCheckTypeSetElemAttr(tcoPoliciesResourceName, "policies.0.subsystems.names.*", "web"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.archive_retention_id", "e1c980d0-c910-4c54-8326-67f3cf95645a"),
+					// No targets were configured, so the default target the backend injects must
+					// not land in state — otherwise every subsequent plan drifts.
+					resource.TestCheckNoResourceAttr(tcoPoliciesResourceName, "policies.0.targets"),
 
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.name", "Example tco_policy from terraform 2"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.priority", "medium"),
@@ -283,9 +286,8 @@ func testAccCoralogixResourceTCOPoliciesLogsQuotaBasedOverride() string {
 }
 
 // TestAccCoralogixResourceTCOPoliciesLogs_targets covers TCO log policies with the targets
-// block, exercising both the inherited-priority mode (policy-level priority applies to all
-// targets) and the per-target-priority mode (each target carries its own priority and
-// policy-level priority is omitted).
+// block. Every target carries its own priority — the backend requires one on each target — and
+// the policy-level priority is omitted.
 func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -293,19 +295,6 @@ func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
 		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				// Step 1: targets inherit the policy-level priority.
-				Config: testAccCoralogixResourceTCOPoliciesLogsTargetsInherited(),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with targets (inherited priority)"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "medium"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "2"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "dataset-b"),
-				),
-			},
-			{
-				// Step 2: each target carries its own priority; policy-level priority omitted.
 				Config: testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with per-target priorities"),
@@ -318,28 +307,6 @@ func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCoralogixResourceTCOPoliciesLogsTargetsInherited() string {
-	return `resource "coralogix_tco_policies_logs" "test" {
-  policies = [
-    {
-      name       = "Example tco_policy with targets (inherited priority)"
-      priority   = "medium"
-      severities = ["info", "warning"]
-      targets = [
-        {
-          dataset   = "dataset-a"
-          dataspace = "default"
-        },
-        {
-          dataset = "dataset-b"
-        },
-      ]
-    },
-  ]
-}
-`
 }
 
 func testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority() string {
@@ -364,10 +331,10 @@ func testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority() string {
 `
 }
 
-// TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets verifies that policies with
-// targets and policies without targets coexist correctly in the same resource.
-// The policy with targets must have exactly the targets that were configured;
-// the backend may echo computed defaults for the policy without targets.
+// TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets verifies that policies with targets and
+// policies without targets coexist correctly in the same resource. The policy with targets must
+// have exactly the targets that were configured; the policy without targets must have none in
+// state, even though the backend injects a default target for it.
 func TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -377,15 +344,17 @@ func TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets(t *testing.T) {
 			{
 				Config: testAccCoralogixResourceTCOPoliciesLogsMixedTargets(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// Policy 0: has targets.
+					// Policy 0: has targets, each with its own priority.
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "policy-with-targets"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "medium"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "1"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
-					// Policy 1: no targets configured — backend may echo computed defaults.
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority", "medium"),
+					// Policy 1: no targets configured — the backend's injected default must not
+					// reach state.
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.name", "policy-without-targets"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.priority", "low"),
+					resource.TestCheckNoResourceAttr(tcoPoliciesResourceName, "policies.1.targets"),
 				),
 			},
 		},
@@ -397,11 +366,11 @@ func testAccCoralogixResourceTCOPoliciesLogsMixedTargets() string {
   policies = [
     {
       name       = "policy-with-targets"
-      priority   = "medium"
       severities = ["info"]
       targets = [
         {
-          dataset = "dataset-a"
+          dataset  = "dataset-a"
+          priority = "medium"
         },
       ]
     },

--- a/internal/provider/resource_coralogix_tco_policies_logs_test.go
+++ b/internal/provider/resource_coralogix_tco_policies_logs_test.go
@@ -299,9 +299,9 @@ func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with targets (inherited priority)"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "medium"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "2"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "logs"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "dataset-b"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "logs"),
 				),
 			},
 			{
@@ -310,9 +310,9 @@ func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with per-target priorities"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "2"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "logs"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority", "medium"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "dataset-b"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "logs"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.priority", "low"),
 				),
 			},
@@ -329,11 +329,11 @@ func testAccCoralogixResourceTCOPoliciesLogsTargetsInherited() string {
       severities = ["info", "warning"]
       targets = [
         {
-          dataset   = "dataset-a"
+          dataset   = "logs"
           dataspace = "default"
         },
         {
-          dataset = "dataset-b"
+          dataset = "logs"
         },
       ]
     },
@@ -350,11 +350,11 @@ func testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority() string {
       severities = ["info", "warning"]
       targets = [
         {
-          dataset  = "dataset-a"
+          dataset  = "logs"
           priority = "medium"
         },
         {
-          dataset  = "dataset-b"
+          dataset  = "logs"
           priority = "low"
         },
       ]
@@ -381,7 +381,7 @@ func TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets(t *testing.T) {
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "policy-with-targets"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "medium"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "1"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "logs"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
 					// Policy 1: no targets configured — backend may echo computed defaults.
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.name", "policy-without-targets"),
@@ -401,7 +401,7 @@ func testAccCoralogixResourceTCOPoliciesLogsMixedTargets() string {
       severities = ["info"]
       targets = [
         {
-          dataset = "dataset-a"
+          dataset = "logs"
         },
       ]
     },

--- a/internal/provider/resource_coralogix_tco_policies_logs_test.go
+++ b/internal/provider/resource_coralogix_tco_policies_logs_test.go
@@ -299,9 +299,9 @@ func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with targets (inherited priority)"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "medium"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "2"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "logs"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "logs"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "dataset-b"),
 				),
 			},
 			{
@@ -310,9 +310,9 @@ func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with per-target priorities"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "2"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "logs"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority", "medium"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "logs"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "dataset-b"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.priority", "low"),
 				),
 			},
@@ -329,11 +329,11 @@ func testAccCoralogixResourceTCOPoliciesLogsTargetsInherited() string {
       severities = ["info", "warning"]
       targets = [
         {
-          dataset   = "logs"
+          dataset   = "dataset-a"
           dataspace = "default"
         },
         {
-          dataset = "logs"
+          dataset = "dataset-b"
         },
       ]
     },
@@ -350,11 +350,11 @@ func testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority() string {
       severities = ["info", "warning"]
       targets = [
         {
-          dataset  = "logs"
+          dataset  = "dataset-a"
           priority = "medium"
         },
         {
-          dataset  = "logs"
+          dataset  = "dataset-b"
           priority = "low"
         },
       ]
@@ -381,7 +381,7 @@ func TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets(t *testing.T) {
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "policy-with-targets"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "medium"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "1"),
-					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "logs"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
 					// Policy 1: no targets configured — backend may echo computed defaults.
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.name", "policy-without-targets"),
@@ -401,7 +401,7 @@ func testAccCoralogixResourceTCOPoliciesLogsMixedTargets() string {
       severities = ["info"]
       targets = [
         {
-          dataset = "logs"
+          dataset = "dataset-a"
         },
       ]
     },

--- a/internal/provider/resource_coralogix_tco_policies_logs_test.go
+++ b/internal/provider/resource_coralogix_tco_policies_logs_test.go
@@ -281,3 +281,136 @@ func testAccCoralogixResourceTCOPoliciesLogsQuotaBasedOverride() string {
 }
 `
 }
+
+// TestAccCoralogixResourceTCOPoliciesLogs_targets covers TCO log policies with the targets
+// block, exercising both the inherited-priority mode (policy-level priority applies to all
+// targets) and the per-target-priority mode (each target carries its own priority and
+// policy-level priority is omitted).
+func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: targets inherit the policy-level priority.
+				Config: testAccCoralogixResourceTCOPoliciesLogsTargetsInherited(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with targets (inherited priority)"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "medium"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "2"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "dataset-b"),
+				),
+			},
+			{
+				// Step 2: each target carries its own priority; policy-level priority omitted.
+				Config: testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with per-target priorities"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "2"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority", "medium"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "dataset-b"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.priority", "low"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsTargetsInherited() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name       = "Example tco_policy with targets (inherited priority)"
+      priority   = "medium"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset   = "dataset-a"
+          dataspace = "default"
+        },
+        {
+          dataset = "dataset-b"
+        },
+      ]
+    },
+  ]
+}
+`
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name       = "Example tco_policy with per-target priorities"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset  = "dataset-a"
+          priority = "medium"
+        },
+        {
+          dataset  = "dataset-b"
+          priority = "low"
+        },
+      ]
+    },
+  ]
+}
+`
+}
+
+// TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets verifies that policies with
+// targets and policies without targets coexist correctly in the same resource.
+// The policy with targets must have exactly the targets that were configured;
+// the backend may echo computed defaults for the policy without targets.
+func TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceTCOPoliciesLogsMixedTargets(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Policy 0: has targets.
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "policy-with-targets"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.priority", "medium"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "1"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
+					// Policy 1: no targets configured — backend may echo computed defaults.
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.name", "policy-without-targets"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.priority", "low"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsMixedTargets() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name       = "policy-with-targets"
+      priority   = "medium"
+      severities = ["info"]
+      targets = [
+        {
+          dataset = "dataset-a"
+        },
+      ]
+    },
+    {
+      name       = "policy-without-targets"
+      priority   = "low"
+      severities = ["warning"]
+    },
+  ]
+}
+`
+}


### PR DESCRIPTION
### Description

Add a `targets` list block to `coralogix_tco_policies_logs` to route matched logs to specific named datasets. Every target carries its own `priority`.

**Key behaviours:**
- `targets[*].priority` is **required**. The backend rejects a target without one (`"a priority is required on every target"`), so there is no inheritance from the policy-level `priority`.
- Priority is set **either** policy-level **or** per-target, never both. This is enforced by the backend rather than a `ConflictsWith` validator, in line with the repo's stance on changeable API limits — the 400 names the attribute and says what to do. The same rule covers `priorityOverride`, so policy-level `quota_based_priority_override` cannot be combined with `targets` either; use the per-target `priority_override`.
- Policy-level `priority` is therefore now `Optional`: set it when `targets` is omitted, omit it when `targets` is set.
- `targets` is plain `Optional` (**not** `Optional+Computed`). The backend injects a default target — `{dataset: "logs", dataspace: "default", priority: <policy priority>}` — into every policy created without explicit targets. That injected default is deliberately kept **out** of Terraform state, so a policy configured without targets shows `targets = null` and never drifts. The data source, which has no prior state, reports targets exactly as the API returns them.
- `dataspace` defaults to `"default"` when omitted; validated at ≤ 50 chars (proto-backed).
- An explicit `targets = []` is rejected at plan time. Without that, it would apply and then fail with "Provider produced inconsistent result after apply" once the backend injected its default.
- Validators aligned with [coralogix-operator#545](https://github.com/coralogix/coralogix-operator/pull/545).

<details>
<summary>Why <code>targets</code> is not <code>Optional+Computed</code></summary>

An earlier revision of this PR made `targets` `Optional+Computed` with `UseStateForUnknown`, which let the backend-injected default land in state and then re-plan as `(known after apply)`. That failed `TestAccCoralogixDataSourceTCOPoliciesLogs_basic` with a non-empty second plan:

```
~ targets = [{dataset = "logs"}] -> (known after apply)
```

As a plain `Optional` attribute, `targets` takes its planned value straight from config and can never go unknown, regardless of how sibling computed fields (`id`, `order`) plan. `flattenV1Targets` now receives the `targets` value already recorded for that policy — from the plan on create/update, prior state on read, `nil` for the data source — and returns null when that is null. Where no prior entry exists (import, or a state/API length mismatch) the API response wins, so real targets survive import.

That also removed the machinery the earlier revision had accumulated: `ModifyPlan`, `normalizePlanTargetPriorities`, `policyElementChanged`, the `stripPriorities` flag in `flattenV1Targets`, and the loop in `extractTcoPolicyLog` that nulled target priorities before sending. The plan modifiers it had added to `id` and `order` are reverted to `master`'s plain `Computed` — those fields are pre-existing and out of scope.
</details>

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? — not on the latest revision locally; relying on CI, plus the manual validation below.

<details>
<summary>Manual validation on EU2</summary>

Run against a live EU2 account via `dev_overrides`; the account was left in its original state afterwards.

| Check | Result |
|---|---|
| No-targets policies → apply | `targets = null` in state; **second plan `No changes.`** |
| Backend injection actually occurs | Data source shows `{dataset:"logs", dataspace:"default", priority:<policy priority>}`; resource filters it, data source surfaces it |
| Targets + no-targets policies in one apply | Both round-trip exactly; second plan clean |
| Change one target's `priority` | Only that change planned; third plan clean |
| Remove the `targets` block | Clears back to null; next plan clean |
| Import a config with real targets | Targets survive; the no-targets policy imports the injected default and reconciles in one apply |
| Policy-level + per-target priority together | `400 FAILED_PRECONDITION: priority/priorityOverride must be set either at the policy level or per-target, not both.` State survived the failed apply intact |
| Neither `priority` nor `targets` | `400 FAILED_PRECONDITION: A priority is required: set the policy priority (or a quota-based priority override), or provide targets that each specify a priority.` |
| Target with no `priority` | Rejected at plan time — never reaches the API |
| `targets = []` | Rejected at plan time |

</details>

### Release Note

```release-note
resource/coralogix_tco_policies_logs: Add `targets` to route matched logs to specific named datasets. Each target requires its own `priority`. Policy-level `priority` is now optional; omit it when `targets` is set.
```

### References
CX-51353

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
