### PR TITLE
Migrate events2metrics to grpc client

### DIFF
--- a/.claude/skills/framework-optional-computed-nested-object/SKILL.md
+++ b/.claude/skills/framework-optional-computed-nested-object/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: framework-optional-computed-nested-object
+description: "Use when Create fails with 'Received unknown value' on an Optional+Computed SingleNestedAttribute Path targeting a Go struct pointer. Model that field as types.Object."
+---
+
+# Optional+Computed nested object unknown on create
+
+**Trigger:** `req.Plan.Get` fails with `Received unknown value… Path: <attr> Target Type: *…Model Suggested Type: basetypes.ObjectValue` when the nested block is omitted from HCL.
+
+**Fix:** Store the attribute as `types.Object` in the resource model (not `*SomeModel`). Decode with `.As()` only when `!IsNull() && !IsUnknown()`. Flatten with `types.ObjectValueFrom` / `ObjectNull`.
+
+**Why:** Omitted Optional+Computed nested attributes are unknown on create. Go struct pointers cannot represent unknown; `types.Object` can.

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -21,6 +21,7 @@ env:
   DASHBOARD_MIGRATION_ACC_PATTERN: &dashboard_migration_acc_pattern '^TestAccCoralogixResourceDashboardMigration'
   DASHBOARD_MIGRATION_V360_PATTERN: &dashboard_migration_v360_pattern '^TestAccCoralogixResourceDashboardMigrationFromV360$'
   DASHBOARD_MIGRATION_SCHEMA_V3_PATTERN: &dashboard_migration_schema_v3_pattern '^TestAccCoralogixResourceDashboardMigrationFromSchemaV3$'
+  EVENTS2METRIC_MIGRATION_ACC_PATTERN: &events2metric_migration_acc_pattern '^TestAccCoralogixResourceEvents2MetricMigration$'
   DASHBOARD_SHARD_STRUCTURED_LINE_AND_TABLE: &dashboard_shard_structured_line_and_table '^TestAccCoralogixResourceDashboardOpenAPIWidget(Logs|Metrics|Spans|DataPrime)Queries$/line-and-table$'
   DASHBOARD_SHARD_STRUCTURED_GAUGE_AND_BARS: &dashboard_shard_structured_gauge_and_bars '^TestAccCoralogixResourceDashboardOpenAPIWidget(Logs|Metrics|Spans|DataPrime)Queries$/gauge-and-bars$'
   DASHBOARD_SHARD_STRUCTURED_HORIZONTAL_AND_HEXAGON: &dashboard_shard_structured_horizontal_and_hexagon '^TestAccCoralogixResourceDashboardOpenAPIWidget(Logs|Metrics|Spans|DataPrime)Queries$/horizontal-and-hexagon$'
@@ -151,8 +152,8 @@ jobs:
           done
           TF_ACC=1 go test -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn" ./internal/provider -v -run "$DASHBOARD_ACC_PATTERN" -skip "$skip_pattern" -timeout 120m -parallel=4
 
-  dashboard-migration:
-    name: Dashboard provider migration (${{ matrix.shard }})
+  provider-migration:
+    name: Provider migration (${{ matrix.shard }})
     permissions:
       contents: read
     env:
@@ -161,10 +162,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard: grpc-v3.6.0
+          - shard: dashboard-grpc-v3.6.0
             pattern: *dashboard_migration_v360_pattern
-          - shard: schema-v3
+          - shard: dashboard-schema-v3
             pattern: *dashboard_migration_schema_v3_pattern
+          - shard: events2metric-grpc-v3.8.0
+            pattern: *events2metric_migration_acc_pattern
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -176,9 +179,9 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-      - name: Test pinned gRPC to current REST dashboard migration
+      - name: Test pinned gRPC to current REST provider migration
         env:
           CORALOGIX_ENV: ${{ secrets.CORALOGIX_ENV }}
           CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
         run: |
-          CORALOGIX_DASHBOARD_MIGRATION_ACC=1 TF_ACC=1 TF_ACC_PROVIDER_NAMESPACE=coralogix go test -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn" ./internal/provider -run '${{ matrix.pattern }}' -v -count=1 -timeout 120m -parallel=3
+          CORALOGIX_DASHBOARD_MIGRATION_ACC=1 CORALOGIX_EVENTS2METRIC_MIGRATION_ACC=1 TF_ACC=1 TF_ACC_PROVIDER_NAMESPACE=coralogix go test -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn" ./internal/provider -run '${{ matrix.pattern }}' -v -count=1 -timeout 120m -parallel=3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 #### resource/coralogix_dashboard
 - FIX: Adding a section, row, widget or annotation without an `id` no longer fails with "Provider produced inconsistent result after apply". Generated `id` fields (section, row, widget, line-chart `query_definitions[].id`, data-table aggregation, annotation) and widget `width` now use `UseNonNullStateForUnknown` so new nested elements stay `(known after apply)` instead of planning as null.
 
+#### resource/coralogix_events2metric
+- CHORE: Migrate events2metric operations from the legacy gRPC client to the REST client.
+- FIX: Create fails when `permutations` is omitted because the plan value is unknown.
+- FIX: Empty `metric_fields.*.aggregations.histogram.buckets` no longer becomes null after apply.
+
 #### provider
 - CHORE: Bump `terraform-plugin-framework` to v1.17.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - FIX: Create fails when `permutations` is omitted because the plan value is unknown.
 - FIX: Empty `metric_fields.*.aggregations.histogram.buckets` no longer becomes null after apply.
 - FIX: Schema v0→v1 state upgrade converts `permutations.limit` from string to int64 so pre-v1 state loads.
+- FIX: Omitted `metric_fields.*.aggregations` children no longer fail after apply when the API returns the full aggregation set. Those attributes now use `UseNonNullStateForUnknown`.
 
 #### provider
 - CHORE: Bump `terraform-plugin-framework` to v1.17.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - CHORE: Migrate events2metric operations from the legacy gRPC client to the REST client.
 - FIX: Create fails when `permutations` is omitted because the plan value is unknown.
 - FIX: Empty `metric_fields.*.aggregations.histogram.buckets` no longer becomes null after apply.
+- FIX: Schema v0→v1 state upgrade converts `permutations.limit` from string to int64 so pre-v1 state loads.
 
 #### provider
 - CHORE: Bump `terraform-plugin-framework` to v1.17.0.

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ OS_ARCH=darwin_arm64
 BUILD_ARGS=-ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn"
 DASHBOARD_ACC_PATTERN=^TestAccCoralogix(Resource|DataSource)Dashboards?
 DASHBOARD_MIGRATION_ACC_PATTERN=^TestAccCoralogixResourceDashboardMigration
+EVENTS2METRIC_MIGRATION_ACC_PATTERN=^TestAccCoralogixResourceEvents2MetricMigration$$
 
 default: install
 
@@ -50,13 +51,19 @@ test:
 	echo $(TEST) | xargs -t -n4 go test ${BUILD_ARGS} $(TESTARGS) -timeout=30s -parallel=4
 
 testacc:
-	TF_ACC=1 go test ${BUILD_ARGS} $(TEST) -v $(TESTARGS) -skip '${DASHBOARD_ACC_PATTERN}' -timeout 120m -parallel=4
+	TF_ACC=1 go test ${BUILD_ARGS} $(TEST) -v $(TESTARGS) -skip '${DASHBOARD_ACC_PATTERN}|${EVENTS2METRIC_MIGRATION_ACC_PATTERN}' -timeout 120m -parallel=4
 
 testacc-dashboard:
 	TF_ACC=1 go test ${BUILD_ARGS} ./internal/provider -v -run '${DASHBOARD_ACC_PATTERN}' $(TESTARGS) -timeout 120m -parallel=4
 
 testacc-dashboard-migration:
 	CORALOGIX_DASHBOARD_MIGRATION_ACC=1 TF_ACC=1 TF_ACC_PROVIDER_NAMESPACE=coralogix go test ${BUILD_ARGS} ./internal/provider -run '${DASHBOARD_MIGRATION_ACC_PATTERN}' -v -count=1 -timeout 120m -parallel=3
+
+testacc-events2metric-migration:
+	CORALOGIX_EVENTS2METRIC_MIGRATION_ACC=1 TF_ACC=1 TF_ACC_PROVIDER_NAMESPACE=coralogix go test ${BUILD_ARGS} ./internal/provider -run '${EVENTS2METRIC_MIGRATION_ACC_PATTERN}' -v -count=1 -timeout 120m -parallel=3
+
+testacc-provider-migration:
+	CORALOGIX_DASHBOARD_MIGRATION_ACC=1 CORALOGIX_EVENTS2METRIC_MIGRATION_ACC=1 TF_ACC=1 TF_ACC_PROVIDER_NAMESPACE=coralogix go test ${BUILD_ARGS} ./internal/provider -run '${DASHBOARD_MIGRATION_ACC_PATTERN}|${EVENTS2METRIC_MIGRATION_ACC_PATTERN}' -v -count=1 -timeout 120m -parallel=3
 
 generate:
 	go generate ${BUILD_ARGS}

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -32,6 +32,7 @@ import (
 	dbfs "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_folders_service"
 	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
 	ess "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/enrichments_service"
+	e2ms "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/events2metrics_service"
 
 	globalRouters "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/global_routers_service"
 	integrations "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/integration_service"
@@ -57,7 +58,7 @@ type ClientSet struct {
 	legacySlos     *cxsdk.LegacySLOsClient
 	ruleGroups     *cxsdk.RuleGroupsClient
 	users          *UsersClient
-	events2Metrics *cxsdk.Events2MetricsClient
+	events2Metrics *e2ms.Events2MetricsServiceAPIService
 	groupGrpc      *cxsdk.GroupsClient
 	teams          *cxsdk.TeamsClient
 
@@ -151,7 +152,7 @@ func (c *ClientSet) Webhooks() *webhhooks.OutgoingWebhooksServiceAPIService {
 	return c.webhooks
 }
 
-func (c *ClientSet) Events2Metrics() *cxsdk.Events2MetricsClient {
+func (c *ClientSet) Events2Metrics() *e2ms.Events2MetricsServiceAPIService {
 	return c.events2Metrics
 }
 
@@ -258,7 +259,7 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 
 		users: NewUsersClient(region, apiKey),
 
-		events2Metrics: cxsdk.NewEvents2MetricsClient(grpcCreator),
+		events2Metrics: cs.Events2Metrics(),
 		groupGrpc:      cxsdk.NewGroupsClient(grpcCreator),
 
 		dahboardsFolders:      cs.DashboardFolders(),

--- a/internal/provider/data_source_coralogix_events2metric_test.go
+++ b/internal/provider/data_source_coralogix_events2metric_test.go
@@ -27,6 +27,7 @@ func TestAccCoralogixDataSourceEvents2Metric_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEvents2MetricDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCoralogixResourceLogs2Metric(logsToMetric, "") +

--- a/internal/provider/events2metrics/data_source_coralogix_events2metric.go
+++ b/internal/provider/events2metrics/data_source_coralogix_events2metric.go
@@ -91,6 +91,13 @@ func (d *Events2MetricDataSource) Read(ctx context.Context, req datasource.ReadR
 		)
 		return
 	}
+	if getResp == nil {
+		resp.Diagnostics.AddError(
+			"Error reading Events2Metric",
+			"Read response did not include an Events2Metric",
+		)
+		return
+	}
 
 	data, diags := flattenE2M(ctx, &getResp.E2m)
 	if diags.HasError() {

--- a/internal/provider/events2metrics/data_source_coralogix_events2metric.go
+++ b/internal/provider/events2metrics/data_source_coralogix_events2metric.go
@@ -17,18 +17,16 @@ package events2metrics
 import (
 	"context"
 	"fmt"
-	"log"
+	"net/http"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
-	"google.golang.org/protobuf/encoding/protojson"
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	e2ms "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/events2metrics_service"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var _ datasource.DataSourceWithConfigure = &Events2MetricDataSource{}
@@ -38,7 +36,7 @@ func NewEvents2MetricDataSource() datasource.DataSource {
 }
 
 type Events2MetricDataSource struct {
-	client *cxsdk.Events2MetricsClient
+	client *e2ms.Events2MetricsServiceAPIService
 }
 
 func (d *Events2MetricDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -77,30 +75,28 @@ func (d *Events2MetricDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	//Get refreshed Events2Metric value from Coralogix
 	id := data.ID.ValueString()
-	log.Printf("[INFO] Reading Events2metric: %s", id)
-	getE2MReq := &cxsdk.GetE2MRequest{Id: wrapperspb.String(id)}
-	getE2MResp, err := d.client.Get(ctx, getE2MReq)
+	getResp, httpResponse, err := d.client.Events2MetricServiceGetE2M(ctx, id).Execute()
 	if err != nil {
-		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if responseStatus(httpResponse) == http.StatusNotFound {
 			resp.Diagnostics.AddWarning(
 				err.Error(),
 				fmt.Sprintf("Events2Metric %q is in state, but no longer exists in Coralogix backend", id),
 			)
-		} else {
-			resp.Diagnostics.AddError(
-				"Error reading Events2Metric",
-				utils.FormatRpcErrors(err, cxsdk.E2MGetRPC, protojson.Format(getE2MReq)),
-			)
+			return
 		}
+		resp.Diagnostics.AddError(
+			"Error reading Events2Metric",
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Read", nil),
+		)
 		return
 	}
-	log.Printf("[INFO] Received Events2metric: %s", protojson.Format(getE2MResp))
 
-	data = flattenE2M(ctx, getE2MResp.GetE2M())
+	data, diags := flattenE2M(ctx, &getResp.E2m)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
-	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/events2metrics/resource_coralogix_events2metric.go
+++ b/internal/provider/events2metrics/resource_coralogix_events2metric.go
@@ -17,14 +17,14 @@ package events2metrics
 import (
 	"context"
 	"fmt"
-	"log"
+	"net/http"
 	"regexp"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
-	"google.golang.org/protobuf/encoding/protojson"
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	e2ms "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/events2metrics_service"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -43,40 +43,38 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var (
-	severitySchemaToProto = map[string]cxsdk.L2MSeverity{
-		"Unspecified": cxsdk.L2MSeverityUnspecified,
-		"Debug":       cxsdk.L2MSeverityDebug,
-		"Verbose":     cxsdk.L2MSeverityVerbose,
-		"Info":        cxsdk.L2MSeverityInfo,
-		"Warning":     cxsdk.L2MSeverityWarning,
-		"Error":       cxsdk.L2MSeverityError,
-		"Critical":    cxsdk.L2MSeverityCritical,
+	severitySchemaToAPI = map[string]e2ms.Logs2metricsV2Severity{
+		"Unspecified": e2ms.LOGS2METRICSV2SEVERITY_SEVERITY_UNSPECIFIED,
+		"Debug":       e2ms.LOGS2METRICSV2SEVERITY_SEVERITY_DEBUG,
+		"Verbose":     e2ms.LOGS2METRICSV2SEVERITY_SEVERITY_VERBOSE,
+		"Info":        e2ms.LOGS2METRICSV2SEVERITY_SEVERITY_INFO,
+		"Warning":     e2ms.LOGS2METRICSV2SEVERITY_SEVERITY_WARNING,
+		"Error":       e2ms.LOGS2METRICSV2SEVERITY_SEVERITY_ERROR,
+		"Critical":    e2ms.LOGS2METRICSV2SEVERITY_SEVERITY_CRITICAL,
 	}
-	severityProtoToSchema = utils.ReverseMap(severitySchemaToProto)
-	validSeverities       = utils.GetKeys(severitySchemaToProto)
+	severityAPIToSchema = utils.ReverseMap(severitySchemaToAPI)
+	validSeverities     = utils.GetKeys(severitySchemaToAPI)
 
-	protoToSchemaAggregationType = map[cxsdk.E2MAggregationType]string{
-		cxsdk.E2MAggregationTypeMin:       "min",
-		cxsdk.E2MAggregationTypeMax:       "max",
-		cxsdk.E2MAggregationTypeCount:     "count",
-		cxsdk.E2MAggregationTypeAvg:       "avg",
-		cxsdk.E2MAggregationTypeSum:       "sum",
-		cxsdk.E2MAggregationTypeHistogram: "histogram",
-		cxsdk.E2MAggregationTypeSamples:   "samples",
+	apiToSchemaAggregationType = map[e2ms.AggType]string{
+		e2ms.AGGTYPE_AGG_TYPE_MIN:       "min",
+		e2ms.AGGTYPE_AGG_TYPE_MAX:       "max",
+		e2ms.AGGTYPE_AGG_TYPE_COUNT:     "count",
+		e2ms.AGGTYPE_AGG_TYPE_AVG:       "avg",
+		e2ms.AGGTYPE_AGG_TYPE_SUM:       "sum",
+		e2ms.AGGTYPE_AGG_TYPE_HISTOGRAM: "histogram",
+		e2ms.AGGTYPE_AGG_TYPE_SAMPLES:   "samples",
 	}
-	schemaToProtoAggregationSampleType = map[string]cxsdk.E2MAggSampleType{
-		"Min": cxsdk.E2MAggSampleTypeMin,
-		"Max": cxsdk.E2MAggSampleTypeMax,
+	schemaToAPIAggregationSampleType = map[string]e2ms.SampleType{
+		"Min": e2ms.SAMPLETYPE_SAMPLE_TYPE_MIN,
+		"Max": e2ms.SAMPLETYPE_SAMPLE_TYPE_MAX,
 	}
 
-	protoToSchemaAggregationSampleType = utils.ReverseMap(schemaToProtoAggregationSampleType)
+	apiToSchemaAggregationSampleType = utils.ReverseMap(schemaToAPIAggregationSampleType)
 
-	validSampleTypes = utils.GetKeys(schemaToProtoAggregationSampleType)
+	validSampleTypes = utils.GetKeys(schemaToAPIAggregationSampleType)
 )
 
 var (
@@ -91,19 +89,39 @@ func NewEvents2MetricResource() resource.Resource {
 }
 
 type Events2MetricResource struct {
-	client *cxsdk.Events2MetricsClient
+	client *e2ms.Events2MetricsServiceAPIService
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func nilIfEmpty[T any](s []T) []T {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}
+
+func responseStatus(response *http.Response) int {
+	if response == nil {
+		return 0
+	}
+	return response.StatusCode
 }
 
 type Events2MetricResourceModel struct {
-	ID           types.String       `tfsdk:"id"`
-	Name         types.String       `tfsdk:"name"`
-	Description  types.String       `tfsdk:"description"`
-	MetricFields types.Map          `tfsdk:"metric_fields"`
-	MetricLabels types.Map          `tfsdk:"metric_labels"`
-	Permutations *PermutationsModel `tfsdk:"permutations"`
-	SpansQuery   *SpansQueryModel   `tfsdk:"spans_query"`
-	LogsQuery    *LogsQueryModel    `tfsdk:"logs_query"`
-	DataSource   types.String       `tfsdk:"data_source"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Description  types.String `tfsdk:"description"`
+	MetricFields types.Map    `tfsdk:"metric_fields"`
+	MetricLabels types.Map    `tfsdk:"metric_labels"`
+	// types.Object (not *PermutationsModel): Optional+Computed becomes unknown on
+	// create when omitted; Go struct pointers cannot hold unknown values.
+	Permutations types.Object     `tfsdk:"permutations"`
+	SpansQuery   *SpansQueryModel `tfsdk:"spans_query"`
+	LogsQuery    *LogsQueryModel  `tfsdk:"logs_query"`
+	DataSource   types.String     `tfsdk:"data_source"`
 }
 
 type MetricFieldModel struct {
@@ -191,6 +209,13 @@ func samplesAggregationModelAttr() attr.Type {
 			"target_metric_name": types.StringType,
 			"type":               types.StringType,
 		},
+	}
+}
+
+func permutationsModelAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"limit":            types.Int64Type,
+		"has_exceed_limit": types.BoolType,
 	}
 }
 
@@ -633,16 +658,13 @@ func upgradeE2MSpansQueryV0ToV1(ctx context.Context, spansQuery types.List) *Spa
 	return &spansQueryObject
 }
 
-func upgradeE2MPermutationsV0ToV1(ctx context.Context, permutations types.List) *PermutationsModel {
+func upgradeE2MPermutationsV0ToV1(ctx context.Context, permutations types.List) types.Object {
 	var permutationsObjects []types.Object
 	permutations.ElementsAs(ctx, &permutationsObjects, true)
 	if len(permutationsObjects) == 0 {
-		return nil
+		return types.ObjectNull(permutationsModelAttr())
 	}
-
-	var permutationsObject PermutationsModel
-	permutationsObjects[0].As(ctx, &permutationsObject, basetypes.ObjectAsOptions{})
-	return &permutationsObject
+	return permutationsObjects[0]
 }
 
 func upgradeE2MMetricLabelsV0ToV1(ctx context.Context, labels types.Set) types.Map {
@@ -855,7 +877,6 @@ func (r *Events2MetricResource) ConfigValidators(_ context.Context) []resource.C
 }
 
 func (r *Events2MetricResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	// Retrieve values from plan
 	var plan Events2MetricResourceModel
 	diags := req.Plan.Get(ctx, &plan)
 	if diags.HasError() {
@@ -863,27 +884,35 @@ func (r *Events2MetricResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	e2mCreateReq, diags := extractCreateE2M(ctx, plan)
+	params, diags := extractCreateE2M(ctx, plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
-	log.Printf("[INFO] Creating new Events2metric: %s", protojson.Format(e2mCreateReq))
-	e2mCreateResp, err := r.client.Create(ctx, e2mCreateReq)
+
+	createResp, httpResponse, err := r.client.Events2MetricServiceCreateE2M(ctx).E2MCreateParams(params).Execute()
 	if err != nil {
-		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error creating Events2Metric",
-			utils.FormatRpcErrors(err, cxsdk.E2MCreateRPC, protojson.Format(e2mCreateReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Create", params),
 		)
 		return
 	}
-	log.Printf("[INFO] Submitted new Events2metric: %s", protojson.Format(e2mCreateResp))
+	if createResp == nil || createResp.E2m == nil {
+		resp.Diagnostics.AddError(
+			"Error creating Events2Metric",
+			"Create response did not include an Events2Metric",
+		)
+		return
+	}
 
-	plan = flattenE2M(ctx, e2mCreateResp.GetE2M())
+	plan, diags = flattenE2M(ctx, createResp.E2m)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *Events2MetricResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -894,37 +923,34 @@ func (r *Events2MetricResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	//Get refreshed Events2Metric value from Coralogix
 	id := state.ID.ValueString()
-	log.Printf("[INFO] Reading Events2metric: %s", id)
-	getE2MReq := &cxsdk.GetE2MRequest{Id: wrapperspb.String(id)}
-	getE2MResp, err := r.client.Get(ctx, getE2MReq)
+	getResp, httpResponse, err := r.client.Events2MetricServiceGetE2M(ctx, id).Execute()
 	if err != nil {
-		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if responseStatus(httpResponse) == http.StatusNotFound {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Events2Metric %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
 			)
 			resp.State.RemoveResource(ctx)
-		} else {
-			resp.Diagnostics.AddError(
-				"Error reading Events2Metric",
-				utils.FormatRpcErrors(err, cxsdk.E2MGetRPC, protojson.Format(getE2MReq)),
-			)
+			return
 		}
+		resp.Diagnostics.AddError(
+			"Error reading Events2Metric",
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Read", nil),
+		)
 		return
 	}
-	log.Printf("[INFO] Received Events2metric: %s", protojson.Format(getE2MResp))
 
-	state = flattenE2M(ctx, getE2MResp.GetE2M())
-	//
-	diags = resp.State.Set(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	state, diags = flattenE2M(ctx, &getResp.E2m)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *Events2MetricResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Retrieve values from plan
 	var plan Events2MetricResourceModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -932,48 +958,36 @@ func (r *Events2MetricResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	e2mUpdateReq, diags := extractUpdateE2M(ctx, plan)
+	e2m, diags := extractUpdateE2M(ctx, plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
-	log.Printf("[INFO] Updating Events2metric: %s", protojson.Format(e2mUpdateReq))
-	e2mUpdateResp, err := r.client.Replace(ctx, e2mUpdateReq)
+
+	replaceResp, httpResponse, err := r.client.Events2MetricServiceReplaceE2M(ctx).E2M1(e2m).Execute()
 	if err != nil {
-		log.Printf("[ERROR] Received error: %s", err.Error())
+		if responseStatus(httpResponse) == http.StatusNotFound {
+			resp.Diagnostics.AddWarning(
+				fmt.Sprintf("Events2Metric %q is in state, but no longer exists in Coralogix backend", plan.ID.ValueString()),
+				fmt.Sprintf("%s will be recreated when you apply", plan.ID.ValueString()),
+			)
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error updating Events2Metric",
-			utils.FormatRpcErrors(err, cxsdk.E2MReplaceRPC, protojson.Format(e2mUpdateReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Replace", e2m),
 		)
 		return
 	}
-	log.Printf("[INFO] Submitted updated Events2metric: %s", protojson.Format(e2mUpdateResp))
 
-	// Get refreshed Events2Metric value from Coralogix
-	id := plan.ID.ValueString()
-	getE2MResp, err := r.client.Get(ctx, &cxsdk.GetE2MRequest{Id: wrapperspb.String(id)})
-	if err != nil {
-		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
-			resp.Diagnostics.AddWarning(
-				fmt.Sprintf("Events2Metric %q is in state, but no longer exists in Coralogix backend", id),
-				fmt.Sprintf("%s will be recreated when you apply", id),
-			)
-			resp.State.RemoveResource(ctx)
-		} else {
-			resp.Diagnostics.AddError(
-				"Error reading Events2Metric",
-				utils.FormatRpcErrors(err, cxsdk.E2MGetRPC, protojson.Format(e2mUpdateReq)),
-			)
-		}
+	plan, diags = flattenE2M(ctx, &replaceResp.E2m)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
-	log.Printf("[INFO] Received Events2metric: %s", protojson.Format(getE2MResp))
 
-	plan = flattenE2M(ctx, e2mUpdateResp.GetE2M())
-
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *Events2MetricResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -985,373 +999,406 @@ func (r *Events2MetricResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	id := state.ID.ValueString()
-	deleteReq := &cxsdk.DeleteE2MRequest{Id: wrapperspb.String(id)}
-	log.Printf("[INFO] Deleting Events2metric %s\n", id)
-	if _, err := r.client.Delete(ctx, deleteReq); err != nil {
+	_, httpResponse, err := r.client.Events2MetricServiceDeleteE2M(ctx, id).Execute()
+	if err != nil {
+		if responseStatus(httpResponse) == http.StatusNotFound {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting Events2Metric",
-			utils.FormatRpcErrors(err, cxsdk.E2MDeleteRPC, protojson.Format(deleteReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Delete", nil),
 		)
 		return
 	}
-	log.Printf("[INFO] Events2metric %s deleted\n", id)
 }
 
 func (r *Events2MetricResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func flattenE2M(ctx context.Context, e2m *cxsdk.E2M) Events2MetricResourceModel {
-	return Events2MetricResourceModel{
-		ID:           types.StringValue(e2m.GetId().GetValue()),
-		Name:         types.StringValue(e2m.GetName().GetValue()),
-		Description:  flattenDescription(e2m.GetDescription()),
-		MetricFields: flattenE2MMetricFields(ctx, e2m.GetMetricFields()),
+func flattenE2M(ctx context.Context, e2m *e2ms.E2M) (Events2MetricResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	metricFields, d := flattenE2MMetricFields(ctx, e2m.GetMetricFields())
+	diags.Append(d...)
+
+	perms, permsOk := e2m.GetPermutationsOk()
+	permutations, d := flattenE2MPermutations(ctx, perms, permsOk)
+	diags.Append(d...)
+
+	model := Events2MetricResourceModel{
+		ID:           types.StringValue(e2m.GetId()),
+		Name:         types.StringValue(e2m.GetName()),
+		Description:  utils.StringPointerToTypeString(e2m.Description),
+		MetricFields: metricFields,
 		MetricLabels: flattenE2MMetricLabels(e2m.GetMetricLabels()),
-		Permutations: flattenE2MPermutations(e2m.GetPermutations()),
-		SpansQuery:   flattenSpansQuery(e2m.GetSpansQuery()),
-		LogsQuery:    flattenLogsQuery(e2m.GetLogsQuery()),
-		DataSource:   utils.WrapperspbStringToTypeString(e2m.GetDataSource()),
+		Permutations: permutations,
+		DataSource:   utils.StringPointerToTypeString(e2m.DataSource),
 	}
+
+	if spansQuery, ok := e2m.GetSpansQueryOk(); ok {
+		model.SpansQuery = flattenSpansQuery(spansQuery)
+	}
+	if logsQuery, ok := e2m.GetLogsQueryOk(); ok {
+		model.LogsQuery = flattenLogsQuery(logsQuery)
+	}
+
+	return model, diags
 }
 
-func flattenDescription(e2mDescription *wrapperspb.StringValue) types.String {
-	if e2mDescription == nil {
-		return types.StringNull()
-	}
-	return types.StringValue(e2mDescription.GetValue())
-}
+func extractCreateE2M(ctx context.Context, plan Events2MetricResourceModel) (e2ms.E2MCreateParams, diag.Diagnostics) {
+	var diags diag.Diagnostics
 
-func extractCreateE2M(ctx context.Context, plan Events2MetricResourceModel) (*cxsdk.CreateE2MRequest, diag.Diagnostics) {
-	name := utils.TypeStringToWrapperspbString(plan.Name)
-	description := utils.TypeStringToWrapperspbString(plan.Description)
-	permutations := expandPermutations(plan.Permutations)
-	permutationsLimit := wrapperspb.Int32(permutations.GetLimit())
-	metricLabels, diags := expandE2MLabels(ctx, plan.MetricLabels)
-	if diags.HasError() {
-		return nil, diags
-	}
-	metricFields, diags := expandE2MFields(ctx, plan.MetricFields)
-	if diags.HasError() {
-		return nil, diags
+	// Preserve gRPC create behavior: absent permutations still sends explicit 0
+	// (wrapperspb.Int32(nil.GetLimit())). Nil would change wire shape.
+	permutationsLimit := int32(0)
+	if !plan.Permutations.IsNull() && !plan.Permutations.IsUnknown() {
+		var permutations PermutationsModel
+		diags.Append(plan.Permutations.As(ctx, &permutations, basetypes.ObjectAsOptions{})...)
+		if !permutations.Limit.IsNull() && !permutations.Limit.IsUnknown() {
+			permutationsLimit = int32(permutations.Limit.ValueInt64())
+		}
 	}
 
-	e2mParams := &cxsdk.E2MCreateParams{
-		Name:              name,
-		Description:       description,
-		DataSource:        utils.TypeStringToWrapperspbString(plan.DataSource),
-		PermutationsLimit: permutationsLimit,
+	metricLabels, d := expandE2MLabels(ctx, plan.MetricLabels)
+	diags.Append(d...)
+	metricFields, d := expandE2MFields(ctx, plan.MetricFields)
+	diags.Append(d...)
+	if diags.HasError() {
+		return e2ms.E2MCreateParams{}, diags
+	}
+
+	params := e2ms.E2MCreateParams{
+		Name:              plan.Name.ValueString(),
+		Description:       utils.TypeStringToStringPointer(plan.Description),
+		DataSource:        utils.TypeStringToStringPointer(plan.DataSource),
+		PermutationsLimit: ptr(permutationsLimit),
 		MetricLabels:      metricLabels,
 		MetricFields:      metricFields,
 	}
 
 	if spansQuery := plan.SpansQuery; spansQuery != nil {
-		e2mParams.Type = cxsdk.E2MTypeSpans2Metrics
-		e2mParams.Query, diags = expandSpansQuery(ctx, spansQuery)
+		params.Type = e2ms.E2MTYPE_E2_M_TYPE_SPANS2_METRICS.Ptr()
+		query, d := expandCreateSpansQuery(ctx, spansQuery)
+		diags.Append(d...)
+		params.SpansQuery = query
 	} else if logsQuery := plan.LogsQuery; logsQuery != nil {
-		e2mParams.Type = cxsdk.E2MTypeLogs2Metrics
-		e2mParams.Query, diags = expandLogsQuery(ctx, logsQuery)
+		params.Type = e2ms.E2MTYPE_E2_M_TYPE_LOGS2_METRICS.Ptr()
+		query, d := expandCreateLogsQuery(ctx, logsQuery)
+		diags.Append(d...)
+		params.LogsQuery = query
 	}
 
 	if diags.HasError() {
-		return nil, diags
+		return e2ms.E2MCreateParams{}, diags
 	}
 
-	return &cxsdk.CreateE2MRequest{
-		E2M: e2mParams,
-	}, nil
+	return params, nil
 }
 
-func expandPermutations(permutations *PermutationsModel) *cxsdk.E2MPermutations {
-	if permutations == nil {
-		return nil
-	}
-	return &cxsdk.E2MPermutations{
-		Limit:            int32(permutations.Limit.ValueInt64()),
-		HasExceededLimit: permutations.HasExceedLimit.ValueBool(),
-	}
-}
+func extractUpdateE2M(ctx context.Context, plan Events2MetricResourceModel) (e2ms.E2M1, diag.Diagnostics) {
+	var diags diag.Diagnostics
 
-func extractUpdateE2M(ctx context.Context, plan Events2MetricResourceModel) (*cxsdk.ReplaceE2MRequest, diag.Diagnostics) {
-	id := wrapperspb.String(plan.ID.ValueString())
-	name := wrapperspb.String(plan.Name.ValueString())
-	description := wrapperspb.String(plan.Description.ValueString())
-	dataSource := utils.TypeStringToWrapperspbString(plan.DataSource)
-	permutations := expandPermutations(plan.Permutations)
-	metricLabels, diags := expandE2MLabels(ctx, plan.MetricLabels)
+	metricLabels, d := expandE2MLabels(ctx, plan.MetricLabels)
+	diags.Append(d...)
+	metricFields, d := expandE2MFields(ctx, plan.MetricFields)
+	diags.Append(d...)
 	if diags.HasError() {
-		return nil, diags
-	}
-	metricFields, diags := expandE2MFields(ctx, plan.MetricFields)
-	if diags.HasError() {
-		return nil, diags
+		return e2ms.E2M1{}, diags
 	}
 
-	e2mParams := &cxsdk.E2M{
-		Id:           id,
-		Name:         name,
-		Description:  description,
-		DataSource:   dataSource,
+	permutations, d := expandPermutations(ctx, plan.Permutations)
+	diags.Append(d...)
+	if diags.HasError() {
+		return e2ms.E2M1{}, diags
+	}
+
+	e2m := e2ms.E2M1{
+		Id:   ptr(plan.ID.ValueString()),
+		Name: plan.Name.ValueString(),
+		// Intentional create/update asymmetry (follow-up): update sends "" when description is null.
+		Description:  ptr(plan.Description.ValueString()),
+		DataSource:   utils.TypeStringToStringPointer(plan.DataSource),
 		Permutations: permutations,
 		MetricLabels: metricLabels,
 		MetricFields: metricFields,
 	}
 
 	if spansQuery := plan.SpansQuery; spansQuery != nil {
-		e2mParams.Type = cxsdk.E2MTypeSpans2Metrics
-		e2mParams.Query, diags = expandUpdateSpansQuery(ctx, spansQuery)
+		e2m.Type = e2ms.E2MTYPE_E2_M_TYPE_SPANS2_METRICS
+		query, d := expandUpdateSpansQuery(ctx, spansQuery)
+		diags.Append(d...)
+		e2m.SpansQuery = query
 	} else if logsQuery := plan.LogsQuery; logsQuery != nil {
-		e2mParams.Type = cxsdk.E2MTypeLogs2Metrics
-		e2mParams.Query, diags = expandUpdateLogsQuery(ctx, logsQuery)
+		e2m.Type = e2ms.E2MTYPE_E2_M_TYPE_LOGS2_METRICS
+		query, d := expandUpdateLogsQuery(ctx, logsQuery)
+		diags.Append(d...)
+		e2m.LogsQuery = query
 	}
 
 	if diags.HasError() {
-		return nil, diags
+		return e2ms.E2M1{}, diags
 	}
 
-	return &cxsdk.ReplaceE2MRequest{
-		E2M: e2mParams,
+	return e2m, nil
+}
+
+func expandPermutations(ctx context.Context, permutations types.Object) (*e2ms.E2MPermutations, diag.Diagnostics) {
+	if permutations.IsNull() || permutations.IsUnknown() {
+		return nil, nil
+	}
+	var model PermutationsModel
+	diags := permutations.As(ctx, &model, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		return nil, diags
+	}
+	return &e2ms.E2MPermutations{
+		Limit:            int32(model.Limit.ValueInt64()),
+		HasExceededLimit: model.HasExceedLimit.ValueBool(),
 	}, nil
 }
 
-func expandE2MLabels(ctx context.Context, labels types.Map) ([]*cxsdk.MetricLabel, diag.Diagnostics) {
+func expandE2MLabels(ctx context.Context, labels types.Map) ([]e2ms.MetricLabel, diag.Diagnostics) {
 	labelsMap := labels.Elements()
-	result := make([]*cxsdk.MetricLabel, 0, len(labelsMap))
+	result := make([]e2ms.MetricLabel, 0, len(labelsMap))
 	var diags diag.Diagnostics
 	for targetField, value := range labelsMap {
-		v, _ := value.ToTerraformValue(ctx)
-		var sourceField string
-		if err := v.As(&sourceField); err != nil {
-			diags.AddError("error expanding metric labels",
-				err.Error())
+		v, err := value.ToTerraformValue(ctx)
+		if err != nil {
+			diags.AddError("error expanding metric labels", err.Error())
 			continue
 		}
-		label := expandE2MLabel(targetField, sourceField)
-		result = append(result, label)
+		var sourceField string
+		if err := v.As(&sourceField); err != nil {
+			diags.AddError("error expanding metric labels", err.Error())
+			continue
+		}
+		result = append(result, e2ms.MetricLabel{
+			TargetLabel: targetField,
+			SourceField: sourceField,
+		})
 	}
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	return result, nil
+	return nilIfEmpty(result), nil
 }
 
-func expandE2MLabel(targetLabel, sourceField string) *cxsdk.MetricLabel {
-	return &cxsdk.MetricLabel{
-		TargetLabel: wrapperspb.String(targetLabel),
-		SourceField: wrapperspb.String(sourceField),
-	}
-}
-
-func expandE2MFields(ctx context.Context, fields types.Map) ([]*cxsdk.MetricField, diag.Diagnostics) {
+func expandE2MFields(ctx context.Context, fields types.Map) ([]e2ms.V2MetricField, diag.Diagnostics) {
 	var fieldsMap map[string]MetricFieldModel
 	var diags diag.Diagnostics
-	d := fields.ElementsAs(ctx, &fieldsMap, true)
-	if d != nil {
-		panic(d)
+	diags.Append(fields.ElementsAs(ctx, &fieldsMap, true)...)
+	if diags.HasError() {
+		return nil, diags
 	}
-	result := make([]*cxsdk.MetricField, 0, len(fieldsMap))
-	for sourceField, metricFieldValue := range fieldsMap {
-		field, dgs := expandE2MField(ctx, sourceField, metricFieldValue)
-		if dgs.HasError() {
-			diags = append(diags, dgs...)
+
+	result := make([]e2ms.V2MetricField, 0, len(fieldsMap))
+	for targetField, metricFieldValue := range fieldsMap {
+		field, d := expandE2MField(ctx, targetField, metricFieldValue)
+		if d.HasError() {
+			diags.Append(d...)
 			continue
 		}
 		result = append(result, field)
 	}
-
-	return result, diags
-}
-
-func expandE2MField(ctx context.Context, targetField string, metricField MetricFieldModel) (*cxsdk.MetricField, diag.Diagnostics) {
-	aggregations, diags := expandE2MAggregations(ctx, metricField.Aggregations)
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	return &cxsdk.MetricField{
-		TargetBaseMetricName: wrapperspb.String(targetField),
-		SourceField:          wrapperspb.String(metricField.SourceField.ValueString()),
+	return nilIfEmpty(result), diags
+}
+
+func expandE2MField(ctx context.Context, targetField string, metricField MetricFieldModel) (e2ms.V2MetricField, diag.Diagnostics) {
+	aggregations, diags := expandE2MAggregations(ctx, metricField.Aggregations)
+	if diags.HasError() {
+		return e2ms.V2MetricField{}, diags
+	}
+
+	return e2ms.V2MetricField{
+		TargetBaseMetricName: targetField,
+		SourceField:          metricField.SourceField.ValueString(),
 		Aggregations:         aggregations,
 	}, nil
 }
 
-func expandE2MAggregations(ctx context.Context, aggregationsModel *AggregationsModel) ([]*cxsdk.E2MAggregation, diag.Diagnostics) {
+func expandE2MAggregations(ctx context.Context, aggregationsModel *AggregationsModel) ([]e2ms.V2Aggregation, diag.Diagnostics) {
+	// OpenAPI requires the aggregations key; always emit a non-nil slice.
 	if aggregationsModel == nil {
-		return nil, nil
+		return []e2ms.V2Aggregation{}, nil
 	}
 
-	aggregations := make([]*cxsdk.E2MAggregation, 0)
+	aggregations := make([]e2ms.V2Aggregation, 0)
 
 	if min := aggregationsModel.Min; min != nil {
-		aggregation := &cxsdk.E2MAggregation{AggType: cxsdk.E2MAggregationTypeMin, Enabled: min.Enable.ValueBool(), TargetMetricName: "min"}
-		aggregations = append(aggregations, aggregation)
+		aggregations = append(aggregations, e2ms.V2Aggregation{
+			AggType:          e2ms.AGGTYPE_AGG_TYPE_MIN.Ptr(),
+			Enabled:          ptr(min.Enable.ValueBool()),
+			TargetMetricName: ptr("min"),
+		})
 	}
 	if max := aggregationsModel.Max; max != nil {
-		aggregation := &cxsdk.E2MAggregation{AggType: cxsdk.E2MAggregationTypeMax, Enabled: max.Enable.ValueBool(), TargetMetricName: "max"}
-		aggregations = append(aggregations, aggregation)
-
+		aggregations = append(aggregations, e2ms.V2Aggregation{
+			AggType:          e2ms.AGGTYPE_AGG_TYPE_MAX.Ptr(),
+			Enabled:          ptr(max.Enable.ValueBool()),
+			TargetMetricName: ptr("max"),
+		})
 	}
 	if count := aggregationsModel.Count; count != nil {
-		aggregation := &cxsdk.E2MAggregation{AggType: cxsdk.E2MAggregationTypeCount, Enabled: count.Enable.ValueBool(), TargetMetricName: "count"}
-		aggregations = append(aggregations, aggregation)
+		aggregations = append(aggregations, e2ms.V2Aggregation{
+			AggType:          e2ms.AGGTYPE_AGG_TYPE_COUNT.Ptr(),
+			Enabled:          ptr(count.Enable.ValueBool()),
+			TargetMetricName: ptr("count"),
+		})
 	}
 	if avg := aggregationsModel.AVG; avg != nil {
-		aggregation := &cxsdk.E2MAggregation{AggType: cxsdk.E2MAggregationTypeAvg, Enabled: avg.Enable.ValueBool(), TargetMetricName: "avg"}
-		aggregations = append(aggregations, aggregation)
-
+		aggregations = append(aggregations, e2ms.V2Aggregation{
+			AggType:          e2ms.AGGTYPE_AGG_TYPE_AVG.Ptr(),
+			Enabled:          ptr(avg.Enable.ValueBool()),
+			TargetMetricName: ptr("avg"),
+		})
 	}
 	if sum := aggregationsModel.Sum; sum != nil {
-		aggregation := &cxsdk.E2MAggregation{AggType: cxsdk.E2MAggregationTypeSum, Enabled: sum.Enable.ValueBool(), TargetMetricName: "sum"}
-		aggregations = append(aggregations, aggregation)
-
+		aggregations = append(aggregations, e2ms.V2Aggregation{
+			AggType:          e2ms.AGGTYPE_AGG_TYPE_SUM.Ptr(),
+			Enabled:          ptr(sum.Enable.ValueBool()),
+			TargetMetricName: ptr("sum"),
+		})
 	}
 	if samples := aggregationsModel.Samples; samples != nil {
-		samplesType := schemaToProtoAggregationSampleType[samples.Type.ValueString()]
-		aggregation := &cxsdk.E2MAggregation{AggType: cxsdk.E2MAggregationTypeSamples, Enabled: samples.Enable.ValueBool(), TargetMetricName: "samples", AggMetadata: &cxsdk.E2MAggregationSamples{Samples: &cxsdk.E2MAggSamples{SampleType: samplesType}}}
-		aggregations = append(aggregations, aggregation)
+		sampleType := schemaToAPIAggregationSampleType[samples.Type.ValueString()]
+		aggregations = append(aggregations, e2ms.V2Aggregation{
+			AggType:          e2ms.AGGTYPE_AGG_TYPE_SAMPLES.Ptr(),
+			Enabled:          ptr(samples.Enable.ValueBool()),
+			TargetMetricName: ptr("samples"),
+			Samples: &e2ms.E2MAggSamples{
+				SampleType: sampleType.Ptr(),
+			},
+		})
 	}
 	if histogram := aggregationsModel.Histogram; histogram != nil {
 		buckets, diags := utils.AttrSliceToFloat32Slice(ctx, histogram.Buckets.Elements())
 		if diags.HasError() {
 			return nil, diags
 		}
-		aggregation := &cxsdk.E2MAggregation{AggType: cxsdk.E2MAggregationTypeHistogram, Enabled: histogram.Enable.ValueBool(), TargetMetricName: "histogram", AggMetadata: &cxsdk.E2MAggregationHistogram{Histogram: &cxsdk.E2MAggHistogram{Buckets: buckets}}}
-		aggregations = append(aggregations, aggregation)
-
+		aggregations = append(aggregations, e2ms.V2Aggregation{
+			AggType:          e2ms.AGGTYPE_AGG_TYPE_HISTOGRAM.Ptr(),
+			Enabled:          ptr(histogram.Enable.ValueBool()),
+			TargetMetricName: ptr("histogram"),
+			Histogram: &e2ms.E2MAggHistogram{
+				Buckets: buckets,
+			},
+		})
 	}
 
 	return aggregations, nil
 }
 
-func expandSpansQuery(ctx context.Context, spansQuery *SpansQueryModel) (*cxsdk.E2MCreateParamsSpansQuery, diag.Diagnostics) {
-	lucene := utils.TypeStringToWrapperspbString(spansQuery.Lucene)
-	applications, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, spansQuery.Applications.Elements())
+func expandCreateSpansQuery(ctx context.Context, spansQuery *SpansQueryModel) (*e2ms.V2SpansQuery, diag.Diagnostics) {
+	applications, diags := utils.TypeStringElementsToStringSlice(ctx, spansQuery.Applications.Elements())
 	if diags.HasError() {
 		return nil, diags
 	}
-	subsystems, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, spansQuery.Subsystems.Elements())
-	if diags.HasError() {
-		return nil, diags
-	}
-	actions, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, spansQuery.Actions.Elements())
-	if diags.HasError() {
-		return nil, diags
-	}
-	services, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, spansQuery.Services.Elements())
+	subsystems, d := utils.TypeStringElementsToStringSlice(ctx, spansQuery.Subsystems.Elements())
+	diags.Append(d...)
+	actions, d := utils.TypeStringElementsToStringSlice(ctx, spansQuery.Actions.Elements())
+	diags.Append(d...)
+	services, d := utils.TypeStringElementsToStringSlice(ctx, spansQuery.Services.Elements())
+	diags.Append(d...)
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	return &cxsdk.E2MCreateParamsSpansQuery{
-		SpansQuery: &cxsdk.S2MSpansQuery{
-			Lucene:                 lucene,
-			ApplicationnameFilters: applications,
-			SubsystemnameFilters:   subsystems,
-			ActionFilters:          actions,
-			ServiceFilters:         services,
-		},
+	return &e2ms.V2SpansQuery{
+		Lucene:                 utils.TypeStringToStringPointer(spansQuery.Lucene),
+		ApplicationnameFilters: nilIfEmpty(applications),
+		SubsystemnameFilters:   nilIfEmpty(subsystems),
+		ActionFilters:          nilIfEmpty(actions),
+		ServiceFilters:         nilIfEmpty(services),
 	}, nil
 }
 
-func expandLogsQuery(ctx context.Context, logsQuery *LogsQueryModel) (*cxsdk.E2MCreateParamsLogsQuery, diag.Diagnostics) {
-	searchQuery := utils.TypeStringToWrapperspbString(logsQuery.Lucene)
-	applications, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, logsQuery.Applications.Elements())
+func expandCreateLogsQuery(ctx context.Context, logsQuery *LogsQueryModel) (*e2ms.V2LogsQuery, diag.Diagnostics) {
+	applications, diags := utils.TypeStringElementsToStringSlice(ctx, logsQuery.Applications.Elements())
 	if diags.HasError() {
 		return nil, diags
 	}
-	subsystems, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, logsQuery.Subsystems.Elements())
-	if diags.HasError() {
-		return nil, diags
-	}
-	severities, diags := expandLogsQuerySeverities(ctx, logsQuery.Severities.Elements())
+	subsystems, d := utils.TypeStringElementsToStringSlice(ctx, logsQuery.Subsystems.Elements())
+	diags.Append(d...)
+	severities, d := expandLogsQuerySeverities(ctx, logsQuery.Severities.Elements())
+	diags.Append(d...)
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	return &cxsdk.E2MCreateParamsLogsQuery{
-		LogsQuery: &cxsdk.L2MLogsQuery{
-			Lucene:                 searchQuery,
-			ApplicationnameFilters: applications,
-			SubsystemnameFilters:   subsystems,
-			SeverityFilters:        severities,
-		},
+	return &e2ms.V2LogsQuery{
+		Lucene:                 utils.TypeStringToStringPointer(logsQuery.Lucene),
+		ApplicationnameFilters: nilIfEmpty(applications),
+		SubsystemnameFilters:   nilIfEmpty(subsystems),
+		SeverityFilters:        nilIfEmpty(severities),
 	}, nil
 }
 
-func expandUpdateSpansQuery(ctx context.Context, spansQuery *SpansQueryModel) (*cxsdk.E2MSpansQuery, diag.Diagnostics) {
-	lucene := utils.TypeStringToWrapperspbString(spansQuery.Lucene)
-	applications, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, spansQuery.Applications.Elements())
-	if diags != nil {
+func expandUpdateSpansQuery(ctx context.Context, spansQuery *SpansQueryModel) (*e2ms.V2SpansQuery, diag.Diagnostics) {
+	applications, diags := utils.TypeStringElementsToStringSlice(ctx, spansQuery.Applications.Elements())
+	if diags.HasError() {
 		return nil, diags
 	}
-	subsystems, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, spansQuery.Subsystems.Elements())
-	if diags != nil {
-		return nil, diags
-	}
-	actions, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, spansQuery.Actions.Elements())
-	if diags != nil {
-		return nil, diags
-	}
-	services, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, spansQuery.Services.Elements())
-	if diags != nil {
+	subsystems, d := utils.TypeStringElementsToStringSlice(ctx, spansQuery.Subsystems.Elements())
+	diags.Append(d...)
+	actions, d := utils.TypeStringElementsToStringSlice(ctx, spansQuery.Actions.Elements())
+	diags.Append(d...)
+	services, d := utils.TypeStringElementsToStringSlice(ctx, spansQuery.Services.Elements())
+	diags.Append(d...)
+	if diags.HasError() {
 		return nil, diags
 	}
 
-	return &cxsdk.E2MSpansQuery{
-		SpansQuery: &cxsdk.S2MSpansQuery{
-			Lucene:                 lucene,
-			ApplicationnameFilters: applications,
-			SubsystemnameFilters:   subsystems,
-			ActionFilters:          actions,
-			ServiceFilters:         services,
-		},
+	return &e2ms.V2SpansQuery{
+		Lucene:                 utils.TypeStringToStringPointer(spansQuery.Lucene),
+		ApplicationnameFilters: nilIfEmpty(applications),
+		SubsystemnameFilters:   nilIfEmpty(subsystems),
+		ActionFilters:          nilIfEmpty(actions),
+		ServiceFilters:         nilIfEmpty(services),
 	}, nil
 }
 
-func expandUpdateLogsQuery(ctx context.Context, logsQuery *LogsQueryModel) (*cxsdk.E2MLogsQuery, diag.Diagnostics) {
-	searchQuery := wrapperspb.String(logsQuery.Lucene.ValueString())
-	applications, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, logsQuery.Applications.Elements())
+func expandUpdateLogsQuery(ctx context.Context, logsQuery *LogsQueryModel) (*e2ms.V2LogsQuery, diag.Diagnostics) {
+	applications, diags := utils.TypeStringElementsToStringSlice(ctx, logsQuery.Applications.Elements())
 	if diags.HasError() {
 		return nil, diags
 	}
-	subsystems, diags := utils.TypeStringSliceToWrappedStringSlice(ctx, logsQuery.Subsystems.Elements())
-	if diags.HasError() {
-		return nil, diags
-	}
-	severities, diags := expandLogsQuerySeverities(ctx, logsQuery.Severities.Elements())
+	subsystems, d := utils.TypeStringElementsToStringSlice(ctx, logsQuery.Subsystems.Elements())
+	diags.Append(d...)
+	severities, d := expandLogsQuerySeverities(ctx, logsQuery.Severities.Elements())
+	diags.Append(d...)
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	return &cxsdk.E2MLogsQuery{
-		LogsQuery: &cxsdk.L2MLogsQuery{
-			Lucene:                 searchQuery,
-			ApplicationnameFilters: applications,
-			SubsystemnameFilters:   subsystems,
-			SeverityFilters:        severities,
-		},
+	return &e2ms.V2LogsQuery{
+		// Intentional create/update asymmetry (follow-up): update sends "" when lucene is null.
+		Lucene:                 ptr(logsQuery.Lucene.ValueString()),
+		ApplicationnameFilters: nilIfEmpty(applications),
+		SubsystemnameFilters:   nilIfEmpty(subsystems),
+		SeverityFilters:        nilIfEmpty(severities),
 	}, nil
 }
 
-func expandLogsQuerySeverities(ctx context.Context, severities []attr.Value) ([]cxsdk.L2MSeverity, diag.Diagnostics) {
-	result := make([]cxsdk.L2MSeverity, 0, len(severities))
+func expandLogsQuerySeverities(ctx context.Context, severities []attr.Value) ([]e2ms.Logs2metricsV2Severity, diag.Diagnostics) {
+	result := make([]e2ms.Logs2metricsV2Severity, 0, len(severities))
 	var diags diag.Diagnostics
 	for _, s := range severities {
 		v, err := s.ToTerraformValue(ctx)
 		if err != nil {
-			diags.AddError("error expanding logs query severities",
-				err.Error())
+			diags.AddError("error expanding logs query severities", err.Error())
 			continue
 		}
 		var str string
 		if err = v.As(&str); err != nil {
-			diags.AddError("error expanding logs query severities",
-				err.Error())
+			diags.AddError("error expanding logs query severities", err.Error())
 			continue
 		}
-		severity := cxsdk.L2MSeverity(severitySchemaToProto[str])
-		result = append(result, severity)
+		result = append(result, severitySchemaToAPI[str])
 	}
 
 	if diags.HasError() {
@@ -1361,65 +1408,85 @@ func expandLogsQuerySeverities(ctx context.Context, severities []attr.Value) ([]
 	return result, nil
 }
 
-func flattenE2MPermutations(permutations *cxsdk.E2MPermutations) *PermutationsModel {
-	if permutations == nil {
-		return nil
+func flattenE2MPermutations(ctx context.Context, permutations *e2ms.E2MPermutations, ok bool) (types.Object, diag.Diagnostics) {
+	if !ok || permutations == nil {
+		return types.ObjectNull(permutationsModelAttr()), nil
 	}
-	return &PermutationsModel{
+	return types.ObjectValueFrom(ctx, permutationsModelAttr(), PermutationsModel{
 		Limit:          types.Int64Value(int64(permutations.GetLimit())),
 		HasExceedLimit: types.BoolValue(permutations.GetHasExceededLimit()),
-	}
+	})
 }
 
-func flattenE2MMetricFields(ctx context.Context, fields []*cxsdk.MetricField) types.Map {
+func flattenE2MMetricFields(ctx context.Context, fields []e2ms.V2MetricField) (types.Map, diag.Diagnostics) {
 	if len(fields) == 0 {
-		return types.MapNull(types.ObjectType{AttrTypes: metricFieldModelAttr()})
+		return types.MapNull(types.ObjectType{AttrTypes: metricFieldModelAttr()}), nil
 	}
 
+	var diags diag.Diagnostics
 	elements := make(map[string]attr.Value)
 	for _, f := range fields {
-		target, field := flattenE2MMetricField(ctx, f)
-		element, _ := types.ObjectValueFrom(ctx, metricFieldModelAttr(), field)
+		target, field, d := flattenE2MMetricField(ctx, f)
+		diags.Append(d...)
+		if d.HasError() {
+			continue
+		}
+		element, d := types.ObjectValueFrom(ctx, metricFieldModelAttr(), field)
+		diags.Append(d...)
 		elements[target] = element
 	}
-	return types.MapValueMust(types.ObjectType{AttrTypes: metricFieldModelAttr()}, elements)
-}
-
-func flattenE2MMetricField(ctx context.Context, field *cxsdk.MetricField) (string, MetricFieldModel) {
-	aggregations := flattenE2MAggregations(ctx, field.GetAggregations())
-	return field.GetTargetBaseMetricName().GetValue(), MetricFieldModel{
-		SourceField:  types.StringValue(field.GetSourceField().GetValue()),
-		Aggregations: aggregations,
+	if diags.HasError() {
+		return types.MapNull(types.ObjectType{AttrTypes: metricFieldModelAttr()}), diags
 	}
+	return types.MapValueMust(types.ObjectType{AttrTypes: metricFieldModelAttr()}, elements), diags
 }
 
-func flattenE2MAggregations(ctx context.Context, aggregations []*cxsdk.E2MAggregation) *AggregationsModel {
+func flattenE2MMetricField(ctx context.Context, field e2ms.V2MetricField) (string, MetricFieldModel, diag.Diagnostics) {
+	aggregations, diags := flattenE2MAggregations(ctx, field.GetAggregations())
+	return field.GetTargetBaseMetricName(), MetricFieldModel{
+		SourceField:  types.StringValue(field.GetSourceField()),
+		Aggregations: aggregations,
+	}, diags
+}
+
+func flattenE2MAggregations(ctx context.Context, aggregations []e2ms.V2Aggregation) (*AggregationsModel, diag.Diagnostics) {
 	aggregationsSchema := AggregationsModel{}
+	var diags diag.Diagnostics
 
 	for _, aggregation := range aggregations {
-		aggTypeStr := protoToSchemaAggregationType[aggregation.GetAggType()]
+		aggType, ok := aggregation.GetAggTypeOk()
+		if !ok || aggType == nil {
+			// Match pre-REST behavior: skip unknown/absent aggregation types.
+			continue
+		}
+		aggTypeStr, ok := apiToSchemaAggregationType[*aggType]
+		if !ok {
+			continue
+		}
 		switch aggTypeStr {
 		case "min":
-			aggregationsSchema.Min = flattenE2MCommonAggregation(aggregation)
+			aggregationsSchema.Min = flattenE2MCommonAggregation(&aggregation)
 		case "max":
-			aggregationsSchema.Max = flattenE2MCommonAggregation(aggregation)
+			aggregationsSchema.Max = flattenE2MCommonAggregation(&aggregation)
 		case "avg":
-			aggregationsSchema.AVG = flattenE2MCommonAggregation(aggregation)
+			aggregationsSchema.AVG = flattenE2MCommonAggregation(&aggregation)
 		case "sum":
-			aggregationsSchema.Sum = flattenE2MCommonAggregation(aggregation)
+			aggregationsSchema.Sum = flattenE2MCommonAggregation(&aggregation)
 		case "count":
-			aggregationsSchema.Count = flattenE2MCommonAggregation(aggregation)
+			aggregationsSchema.Count = flattenE2MCommonAggregation(&aggregation)
 		case "samples":
-			aggregationsSchema.Samples = flattenE2MSamplesAggregation(aggregation)
+			aggregationsSchema.Samples = flattenE2MSamplesAggregation(&aggregation)
 		case "histogram":
-			aggregationsSchema.Histogram = flattenE2MHistogramAggregation(ctx, aggregation)
+			histogram, d := flattenE2MHistogramAggregation(ctx, &aggregation)
+			diags.Append(d...)
+			aggregationsSchema.Histogram = histogram
 		}
 	}
 
-	return &aggregationsSchema
+	return &aggregationsSchema, diags
 }
 
-func flattenE2MCommonAggregation(aggregation *cxsdk.E2MAggregation) *CommonAggregationModel {
+func flattenE2MCommonAggregation(aggregation *e2ms.V2Aggregation) *CommonAggregationModel {
 	if aggregation == nil {
 		return nil
 	}
@@ -1430,12 +1497,17 @@ func flattenE2MCommonAggregation(aggregation *cxsdk.E2MAggregation) *CommonAggre
 	}
 }
 
-func flattenE2MSamplesAggregation(aggregation *cxsdk.E2MAggregation) *SamplesAggregationModel {
+func flattenE2MSamplesAggregation(aggregation *e2ms.V2Aggregation) *SamplesAggregationModel {
 	if aggregation == nil {
 		return nil
 	}
 
-	samplesType := protoToSchemaAggregationSampleType[aggregation.GetSamples().GetSampleType()]
+	samplesType := ""
+	if samples, ok := aggregation.GetSamplesOk(); ok && samples != nil {
+		if sampleType, ok := samples.GetSampleTypeOk(); ok && sampleType != nil {
+			samplesType = apiToSchemaAggregationSampleType[*sampleType]
+		}
+	}
 	return &SamplesAggregationModel{
 		Enable:           types.BoolValue(aggregation.GetEnabled()),
 		TargetMetricName: types.StringValue(aggregation.GetTargetMetricName()),
@@ -1443,70 +1515,71 @@ func flattenE2MSamplesAggregation(aggregation *cxsdk.E2MAggregation) *SamplesAgg
 	}
 }
 
-func flattenE2MHistogramAggregation(ctx context.Context, aggregation *cxsdk.E2MAggregation) *HistogramAggregationModel {
+func flattenE2MHistogramAggregation(ctx context.Context, aggregation *e2ms.V2Aggregation) (*HistogramAggregationModel, diag.Diagnostics) {
 	if aggregation == nil {
-		return nil
+		return nil, nil
 	}
 
-	buckets, diags := utils.Float32SliceTypeList(ctx, aggregation.GetHistogram().GetBuckets())
+	var bucketsList []float32
+	if histogram, ok := aggregation.GetHistogramOk(); ok && histogram != nil {
+		bucketsList = histogram.GetBuckets()
+	}
+	buckets, diags := utils.Float32SliceTypeList(ctx, bucketsList)
 	if diags.HasError() {
-		return nil
+		return nil, diags
 	}
 	return &HistogramAggregationModel{
 		Enable:           types.BoolValue(aggregation.GetEnabled()),
 		TargetMetricName: types.StringValue(aggregation.GetTargetMetricName()),
 		Buckets:          buckets,
-	}
+	}, nil
 }
 
-func flattenE2MMetricLabels(labels []*cxsdk.MetricLabel) types.Map {
+func flattenE2MMetricLabels(labels []e2ms.MetricLabel) types.Map {
 	if len(labels) == 0 {
 		return types.MapNull(types.StringType)
 	}
 
 	elements := make(map[string]attr.Value)
 	for _, l := range labels {
-		key, value := l.GetTargetLabel().GetValue(), l.GetSourceField().GetValue()
-		elements[key] = types.StringValue(value)
+		elements[l.GetTargetLabel()] = types.StringValue(l.GetSourceField())
 	}
 
 	return types.MapValueMust(types.StringType, elements)
 }
 
-func flattenSpansQuery(query *cxsdk.S2MSpansQuery) *SpansQueryModel {
+func flattenSpansQuery(query *e2ms.V2SpansQuery) *SpansQueryModel {
 	if query == nil {
 		return nil
 	}
 	return &SpansQueryModel{
-		Lucene:       utils.WrapperspbStringToTypeString(query.GetLucene()),
-		Applications: utils.WrappedStringSliceToTypeStringSet(query.GetApplicationnameFilters()),
-		Subsystems:   utils.WrappedStringSliceToTypeStringSet(query.GetSubsystemnameFilters()),
-		Actions:      utils.WrappedStringSliceToTypeStringSet(query.GetActionFilters()),
-		Services:     utils.WrappedStringSliceToTypeStringSet(query.GetServiceFilters()),
+		Lucene:       utils.StringPointerToTypeString(query.Lucene),
+		Applications: utils.StringSliceToTypeStringSet(query.GetApplicationnameFilters()),
+		Subsystems:   utils.StringSliceToTypeStringSet(query.GetSubsystemnameFilters()),
+		Actions:      utils.StringSliceToTypeStringSet(query.GetActionFilters()),
+		Services:     utils.StringSliceToTypeStringSet(query.GetServiceFilters()),
 	}
 }
 
-func flattenLogsQuery(query *cxsdk.L2MLogsQuery) *LogsQueryModel {
+func flattenLogsQuery(query *e2ms.V2LogsQuery) *LogsQueryModel {
 	if query == nil {
 		return nil
 	}
 	return &LogsQueryModel{
-		Lucene:       utils.WrapperspbStringToTypeString(query.GetLucene()),
-		Applications: utils.WrappedStringSliceToTypeStringSet(query.GetApplicationnameFilters()),
-		Subsystems:   utils.WrappedStringSliceToTypeStringSet(query.GetSubsystemnameFilters()),
+		Lucene:       utils.StringPointerToTypeString(query.Lucene),
+		Applications: utils.StringSliceToTypeStringSet(query.GetApplicationnameFilters()),
+		Subsystems:   utils.StringSliceToTypeStringSet(query.GetSubsystemnameFilters()),
 		Severities:   flattenLogQuerySeverities(query.GetSeverityFilters()),
 	}
 }
 
-func flattenLogQuerySeverities(severities []cxsdk.L2MSeverity) types.Set {
+func flattenLogQuerySeverities(severities []e2ms.Logs2metricsV2Severity) types.Set {
 	if len(severities) == 0 {
 		return types.SetNull(types.StringType)
 	}
 	elements := make([]attr.Value, 0, len(severities))
 	for _, v := range severities {
-		log.Println("severity: ", severityProtoToSchema[cxsdk.L2MSeverity(v)])
-		severity := types.StringValue(severityProtoToSchema[cxsdk.L2MSeverity(v)])
-		elements = append(elements, severity)
+		elements = append(elements, types.StringValue(severityAPIToSchema[v]))
 	}
 	return types.SetValueMust(types.StringType, elements)
 }

--- a/internal/provider/events2metrics/resource_coralogix_events2metric.go
+++ b/internal/provider/events2metrics/resource_coralogix_events2metric.go
@@ -289,28 +289,31 @@ func (r *Events2MetricResource) Schema(_ context.Context, _ resource.SchemaReque
 						"aggregations": schema.SingleNestedAttribute{
 							Optional: true,
 							Computed: true,
+							// UseNonNullStateForUnknown: API expands omitted aggregations on write.
+							// UseStateForUnknown would copy null prior state onto new metric_fields
+							// keys and cause "inconsistent result after apply".
 							PlanModifiers: []planmodifier.Object{
-								objectplanmodifier.UseStateForUnknown(),
+								objectplanmodifier.UseNonNullStateForUnknown(),
 							},
 							Attributes: map[string]schema.Attribute{
 								"min": schema.SingleNestedAttribute{
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []planmodifier.Object{
-										objectplanmodifier.UseStateForUnknown(),
+										objectplanmodifier.UseNonNullStateForUnknown(),
 									},
 									Attributes: map[string]schema.Attribute{
 										"enable": schema.BoolAttribute{
 											Optional: true,
 											Computed: true,
 											PlanModifiers: []planmodifier.Bool{
-												boolplanmodifier.UseStateForUnknown(),
+												boolplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"target_metric_name": schema.StringAttribute{
 											Computed: true,
 											PlanModifiers: []planmodifier.String{
-												stringplanmodifier.UseStateForUnknown(),
+												stringplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 									},
@@ -319,20 +322,20 @@ func (r *Events2MetricResource) Schema(_ context.Context, _ resource.SchemaReque
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []planmodifier.Object{
-										objectplanmodifier.UseStateForUnknown(),
+										objectplanmodifier.UseNonNullStateForUnknown(),
 									},
 									Attributes: map[string]schema.Attribute{
 										"enable": schema.BoolAttribute{
 											Optional: true,
 											Computed: true,
 											PlanModifiers: []planmodifier.Bool{
-												boolplanmodifier.UseStateForUnknown(),
+												boolplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"target_metric_name": schema.StringAttribute{
 											Computed: true,
 											PlanModifiers: []planmodifier.String{
-												stringplanmodifier.UseStateForUnknown(),
+												stringplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 									},
@@ -341,20 +344,20 @@ func (r *Events2MetricResource) Schema(_ context.Context, _ resource.SchemaReque
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []planmodifier.Object{
-										objectplanmodifier.UseStateForUnknown(),
+										objectplanmodifier.UseNonNullStateForUnknown(),
 									},
 									Attributes: map[string]schema.Attribute{
 										"enable": schema.BoolAttribute{
 											Optional: true,
 											Computed: true,
 											PlanModifiers: []planmodifier.Bool{
-												boolplanmodifier.UseStateForUnknown(),
+												boolplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"target_metric_name": schema.StringAttribute{
 											Computed: true,
 											PlanModifiers: []planmodifier.String{
-												stringplanmodifier.UseStateForUnknown(),
+												stringplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 									},
@@ -363,20 +366,20 @@ func (r *Events2MetricResource) Schema(_ context.Context, _ resource.SchemaReque
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []planmodifier.Object{
-										objectplanmodifier.UseStateForUnknown(),
+										objectplanmodifier.UseNonNullStateForUnknown(),
 									},
 									Attributes: map[string]schema.Attribute{
 										"enable": schema.BoolAttribute{
 											Optional: true,
 											Computed: true,
 											PlanModifiers: []planmodifier.Bool{
-												boolplanmodifier.UseStateForUnknown(),
+												boolplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"target_metric_name": schema.StringAttribute{
 											Computed: true,
 											PlanModifiers: []planmodifier.String{
-												stringplanmodifier.UseStateForUnknown(),
+												stringplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 									},
@@ -385,20 +388,20 @@ func (r *Events2MetricResource) Schema(_ context.Context, _ resource.SchemaReque
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []planmodifier.Object{
-										objectplanmodifier.UseStateForUnknown(),
+										objectplanmodifier.UseNonNullStateForUnknown(),
 									},
 									Attributes: map[string]schema.Attribute{
 										"enable": schema.BoolAttribute{
 											Optional: true,
 											Computed: true,
 											PlanModifiers: []planmodifier.Bool{
-												boolplanmodifier.UseStateForUnknown(),
+												boolplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"target_metric_name": schema.StringAttribute{
 											Computed: true,
 											PlanModifiers: []planmodifier.String{
-												stringplanmodifier.UseStateForUnknown(),
+												stringplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 									},
@@ -407,20 +410,20 @@ func (r *Events2MetricResource) Schema(_ context.Context, _ resource.SchemaReque
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []planmodifier.Object{
-										objectplanmodifier.UseStateForUnknown(),
+										objectplanmodifier.UseNonNullStateForUnknown(),
 									},
 									Attributes: map[string]schema.Attribute{
 										"enable": schema.BoolAttribute{
 											Optional: true,
 											Computed: true,
 											PlanModifiers: []planmodifier.Bool{
-												boolplanmodifier.UseStateForUnknown(),
+												boolplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"target_metric_name": schema.StringAttribute{
 											Computed: true,
 											PlanModifiers: []planmodifier.String{
-												stringplanmodifier.UseStateForUnknown(),
+												stringplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"type": schema.StringAttribute{
@@ -436,20 +439,20 @@ func (r *Events2MetricResource) Schema(_ context.Context, _ resource.SchemaReque
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []planmodifier.Object{
-										objectplanmodifier.UseStateForUnknown(),
+										objectplanmodifier.UseNonNullStateForUnknown(),
 									},
 									Attributes: map[string]schema.Attribute{
 										"enable": schema.BoolAttribute{
 											Optional: true,
 											Computed: true,
 											PlanModifiers: []planmodifier.Bool{
-												boolplanmodifier.UseStateForUnknown(),
+												boolplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"target_metric_name": schema.StringAttribute{
 											Computed: true,
 											PlanModifiers: []planmodifier.String{
-												stringplanmodifier.UseStateForUnknown(),
+												stringplanmodifier.UseNonNullStateForUnknown(),
 											},
 										},
 										"buckets": schema.ListAttribute{

--- a/internal/provider/events2metrics/resource_coralogix_events2metric.go
+++ b/internal/provider/events2metrics/resource_coralogix_events2metric.go
@@ -987,6 +987,13 @@ func (r *Events2MetricResource) Read(ctx context.Context, req resource.ReadReque
 		)
 		return
 	}
+	if getResp == nil {
+		resp.Diagnostics.AddError(
+			"Error reading Events2Metric",
+			"Read response did not include an Events2Metric",
+		)
+		return
+	}
 
 	state, diags = flattenE2M(ctx, &getResp.E2m)
 	if diags.HasError() {
@@ -1024,6 +1031,13 @@ func (r *Events2MetricResource) Update(ctx context.Context, req resource.UpdateR
 		resp.Diagnostics.AddError(
 			"Error updating Events2Metric",
 			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Replace", e2m),
+		)
+		return
+	}
+	if replaceResp == nil {
+		resp.Diagnostics.AddError(
+			"Error updating Events2Metric",
+			"Replace response did not include an Events2Metric",
 		)
 		return
 	}

--- a/internal/provider/events2metrics/resource_coralogix_events2metric.go
+++ b/internal/provider/events2metrics/resource_coralogix_events2metric.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
@@ -621,12 +622,19 @@ func upgradeE2MStateV0ToV1(ctx context.Context, req resource.UpgradeStateRequest
 		return
 	}
 
+	permutations, permutationsDiags := upgradeE2MPermutationsV0ToV1(ctx, priorStateData.Permutations)
+	resp.Diagnostics.Append(permutationsDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	upgradedStateData := Events2MetricResourceModel{
 		ID:           priorStateData.ID,
+		Name:         priorStateData.Name,
 		Description:  priorStateData.Description,
 		MetricFields: upgradeE2MMetricFieldsV0ToV1(ctx, priorStateData.MetricFields),
 		MetricLabels: upgradeE2MMetricLabelsV0ToV1(ctx, priorStateData.MetricLabels),
-		Permutations: upgradeE2MPermutationsV0ToV1(ctx, priorStateData.Permutations),
+		Permutations: permutations,
 		SpansQuery:   upgradeE2MSpansQueryV0ToV1(ctx, priorStateData.SpansQuery),
 		LogsQuery:    upgradeE2MLogsQueryV0ToV1(ctx, priorStateData.LogsQuery),
 	}
@@ -658,13 +666,52 @@ func upgradeE2MSpansQueryV0ToV1(ctx context.Context, spansQuery types.List) *Spa
 	return &spansQueryObject
 }
 
-func upgradeE2MPermutationsV0ToV1(ctx context.Context, permutations types.List) types.Object {
+func upgradeE2MPermutationsV0ToV1(ctx context.Context, permutations types.List) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	var permutationsObjects []types.Object
-	permutations.ElementsAs(ctx, &permutationsObjects, true)
-	if len(permutationsObjects) == 0 {
-		return types.ObjectNull(permutationsModelAttr())
+	diags.Append(permutations.ElementsAs(ctx, &permutationsObjects, true)...)
+	if diags.HasError() {
+		return types.ObjectNull(permutationsModelAttr()), diags
 	}
-	return permutationsObjects[0]
+	if len(permutationsObjects) == 0 {
+		return types.ObjectNull(permutationsModelAttr()), diags
+	}
+
+	// Schema v0 stored limit as a string; v1 uses Int64. Rebuild so State.Set accepts the object.
+	type PermutationsV0Model struct {
+		Limit          types.String `tfsdk:"limit"`
+		HasExceedLimit types.Bool   `tfsdk:"has_exceed_limit"`
+	}
+	var prior PermutationsV0Model
+	diags.Append(permutationsObjects[0].As(ctx, &prior, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return types.ObjectNull(permutationsModelAttr()), diags
+	}
+
+	var limit types.Int64
+	switch {
+	case prior.Limit.IsNull():
+		limit = types.Int64Null()
+	case prior.Limit.IsUnknown():
+		limit = types.Int64Unknown()
+	default:
+		parsed, err := strconv.ParseInt(prior.Limit.ValueString(), 10, 64)
+		if err != nil {
+			diags.AddError(
+				"Invalid permutations.limit in prior state",
+				fmt.Sprintf("could not parse %q as int64: %s", prior.Limit.ValueString(), err),
+			)
+			return types.ObjectNull(permutationsModelAttr()), diags
+		}
+		limit = types.Int64Value(parsed)
+	}
+
+	obj, objDiags := types.ObjectValueFrom(ctx, permutationsModelAttr(), PermutationsModel{
+		Limit:          limit,
+		HasExceedLimit: prior.HasExceedLimit,
+	})
+	diags.Append(objDiags...)
+	return obj, diags
 }
 
 func upgradeE2MMetricLabelsV0ToV1(ctx context.Context, labels types.Set) types.Map {

--- a/internal/provider/events2metrics/resource_coralogix_events2metric_expand_test.go
+++ b/internal/provider/events2metrics/resource_coralogix_events2metric_expand_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events2metrics
+
+import (
+	"context"
+	"testing"
+
+	e2ms "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/events2metrics_service"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestExpandE2MAggregationsSimple(t *testing.T) {
+	aggs, diags := expandE2MAggregations(context.Background(), &AggregationsModel{
+		Min:   &CommonAggregationModel{Enable: types.BoolValue(true)},
+		Max:   &CommonAggregationModel{Enable: types.BoolValue(false)},
+		Count: &CommonAggregationModel{Enable: types.BoolValue(true)},
+		AVG:   &CommonAggregationModel{Enable: types.BoolValue(false)},
+		Sum:   &CommonAggregationModel{Enable: types.BoolValue(true)},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(aggs) != 5 {
+		t.Fatalf("expected 5 aggregations, got %d", len(aggs))
+	}
+
+	byType := map[e2ms.AggType]e2ms.V2Aggregation{}
+	for _, agg := range aggs {
+		if agg.AggType == nil {
+			t.Fatal("expected aggType to be set")
+		}
+		if agg.None != nil || agg.Samples != nil || agg.Histogram != nil {
+			t.Fatalf("simple aggregations must leave none/samples/histogram unset, got %+v", agg)
+		}
+		if agg.Enabled == nil {
+			t.Fatal("expected enabled pointer to be set")
+		}
+		byType[*agg.AggType] = agg
+	}
+
+	assertEnabled(t, byType[e2ms.AGGTYPE_AGG_TYPE_MIN], true, "min")
+	assertEnabled(t, byType[e2ms.AGGTYPE_AGG_TYPE_MAX], false, "max")
+	assertEnabled(t, byType[e2ms.AGGTYPE_AGG_TYPE_COUNT], true, "count")
+	assertEnabled(t, byType[e2ms.AGGTYPE_AGG_TYPE_AVG], false, "avg")
+	assertEnabled(t, byType[e2ms.AGGTYPE_AGG_TYPE_SUM], true, "sum")
+	assertTarget(t, byType[e2ms.AGGTYPE_AGG_TYPE_MIN], "min")
+	assertTarget(t, byType[e2ms.AGGTYPE_AGG_TYPE_MAX], "max")
+	assertTarget(t, byType[e2ms.AGGTYPE_AGG_TYPE_COUNT], "count")
+	assertTarget(t, byType[e2ms.AGGTYPE_AGG_TYPE_AVG], "avg")
+	assertTarget(t, byType[e2ms.AGGTYPE_AGG_TYPE_SUM], "sum")
+}
+
+func TestExpandE2MAggregationsSamples(t *testing.T) {
+	aggs, diags := expandE2MAggregations(context.Background(), &AggregationsModel{
+		Samples: &SamplesAggregationModel{
+			Enable: types.BoolValue(true),
+			Type:   types.StringValue("Min"),
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(aggs) != 1 {
+		t.Fatalf("expected 1 aggregation, got %d", len(aggs))
+	}
+	agg := aggs[0]
+	if agg.AggType == nil || *agg.AggType != e2ms.AGGTYPE_AGG_TYPE_SAMPLES {
+		t.Fatalf("expected samples aggType, got %v", agg.AggType)
+	}
+	if agg.None != nil || agg.Histogram != nil {
+		t.Fatalf("samples aggregation must leave none/histogram unset, got %+v", agg)
+	}
+	if agg.Samples == nil || agg.Samples.SampleType == nil || *agg.Samples.SampleType != e2ms.SAMPLETYPE_SAMPLE_TYPE_MIN {
+		t.Fatalf("expected samples.sampleType=Min, got %+v", agg.Samples)
+	}
+	assertTarget(t, agg, "samples")
+}
+
+func TestExpandE2MAggregationsHistogram(t *testing.T) {
+	buckets, diags := types.ListValue(types.Float64Type, []attr.Value{
+		types.Float64Value(0.1),
+		types.Float64Value(5.5),
+		types.Float64Value(100),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	aggs, diags := expandE2MAggregations(context.Background(), &AggregationsModel{
+		Histogram: &HistogramAggregationModel{
+			Enable:  types.BoolValue(true),
+			Buckets: buckets,
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(aggs) != 1 {
+		t.Fatalf("expected 1 aggregation, got %d", len(aggs))
+	}
+	agg := aggs[0]
+	if agg.AggType == nil || *agg.AggType != e2ms.AGGTYPE_AGG_TYPE_HISTOGRAM {
+		t.Fatalf("expected histogram aggType, got %v", agg.AggType)
+	}
+	if agg.None != nil || agg.Samples != nil {
+		t.Fatalf("histogram aggregation must leave none/samples unset, got %+v", agg)
+	}
+	if agg.Histogram == nil || len(agg.Histogram.Buckets) != 3 {
+		t.Fatalf("expected 3 buckets, got %+v", agg.Histogram)
+	}
+	assertTarget(t, agg, "histogram")
+}
+
+func TestExpandE2MAggregationsEmpty(t *testing.T) {
+	aggs, diags := expandE2MAggregations(context.Background(), nil)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if aggs == nil {
+		t.Fatal("expected non-nil empty aggregations slice")
+	}
+	if len(aggs) != 0 {
+		t.Fatalf("expected empty aggregations, got %d", len(aggs))
+	}
+}
+
+func TestExpandE2MAggregationsMixed(t *testing.T) {
+	buckets, diags := types.ListValue(types.Float64Type, []attr.Value{types.Float64Value(1)})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	aggs, diags := expandE2MAggregations(context.Background(), &AggregationsModel{
+		AVG: &CommonAggregationModel{Enable: types.BoolValue(true)},
+		Samples: &SamplesAggregationModel{
+			Enable: types.BoolValue(false),
+			Type:   types.StringValue("Max"),
+		},
+		Histogram: &HistogramAggregationModel{
+			Enable:  types.BoolValue(true),
+			Buckets: buckets,
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(aggs) != 3 {
+		t.Fatalf("expected 3 aggregations, got %d", len(aggs))
+	}
+
+	byType := map[e2ms.AggType]e2ms.V2Aggregation{}
+	for _, agg := range aggs {
+		byType[*agg.AggType] = agg
+	}
+	if byType[e2ms.AGGTYPE_AGG_TYPE_AVG].Samples != nil || byType[e2ms.AGGTYPE_AGG_TYPE_AVG].Histogram != nil || byType[e2ms.AGGTYPE_AGG_TYPE_AVG].None != nil {
+		t.Fatalf("avg must leave metadata unset, got %+v", byType[e2ms.AGGTYPE_AGG_TYPE_AVG])
+	}
+	if byType[e2ms.AGGTYPE_AGG_TYPE_SAMPLES].Samples == nil || byType[e2ms.AGGTYPE_AGG_TYPE_SAMPLES].Histogram != nil {
+		t.Fatalf("samples must set only samples metadata, got %+v", byType[e2ms.AGGTYPE_AGG_TYPE_SAMPLES])
+	}
+	if byType[e2ms.AGGTYPE_AGG_TYPE_HISTOGRAM].Histogram == nil || byType[e2ms.AGGTYPE_AGG_TYPE_HISTOGRAM].Samples != nil {
+		t.Fatalf("histogram must set only histogram metadata, got %+v", byType[e2ms.AGGTYPE_AGG_TYPE_HISTOGRAM])
+	}
+}
+
+func TestExtractCreateUpdateOptionalStringAsymmetry(t *testing.T) {
+	ctx := context.Background()
+	plan := Events2MetricResourceModel{
+		ID:          types.StringValue("11111111-1111-1111-1111-111111111111"),
+		Name:        types.StringValue("tf_e2m"),
+		Description: types.StringNull(),
+		LogsQuery: &LogsQueryModel{
+			Lucene:       types.StringNull(),
+			Applications: types.SetNull(types.StringType),
+			Subsystems:   types.SetNull(types.StringType),
+			Severities:   types.SetNull(types.StringType),
+		},
+		MetricFields: types.MapNull(types.ObjectType{AttrTypes: metricFieldModelAttr()}),
+		MetricLabels: types.MapNull(types.StringType),
+		Permutations: types.ObjectNull(permutationsModelAttr()),
+	}
+
+	createParams, diags := extractCreateE2M(ctx, plan)
+	if diags.HasError() {
+		t.Fatalf("unexpected create diagnostics: %v", diags)
+	}
+	if createParams.Description != nil {
+		t.Fatalf("create must omit null description, got %q", *createParams.Description)
+	}
+	if createParams.LogsQuery == nil || createParams.LogsQuery.Lucene != nil {
+		t.Fatalf("create must omit null lucene, got %+v", createParams.LogsQuery)
+	}
+	if createParams.PermutationsLimit == nil || *createParams.PermutationsLimit != 0 {
+		t.Fatalf("create must send permutationsLimit=0 when block absent, got %v", createParams.PermutationsLimit)
+	}
+
+	replaceParams, diags := extractUpdateE2M(ctx, plan)
+	if diags.HasError() {
+		t.Fatalf("unexpected update diagnostics: %v", diags)
+	}
+	if replaceParams.Description == nil || *replaceParams.Description != "" {
+		t.Fatalf("update must send empty description pointer for null, got %v", replaceParams.Description)
+	}
+	if replaceParams.LogsQuery == nil || replaceParams.LogsQuery.Lucene == nil || *replaceParams.LogsQuery.Lucene != "" {
+		t.Fatalf("update must send empty lucene pointer for null, got %+v", replaceParams.LogsQuery)
+	}
+}
+
+func TestFlattenE2MAggregationsUnknownType(t *testing.T) {
+	unknown := e2ms.AggType("AGG_TYPE_UNSPECIFIED")
+	minType := e2ms.AGGTYPE_AGG_TYPE_MIN
+	flattened, diags := flattenE2MAggregations(context.Background(), []e2ms.V2Aggregation{
+		{AggType: &unknown, Enabled: ptr(true), TargetMetricName: ptr("x")},
+		{AggType: &minType, Enabled: ptr(true), TargetMetricName: ptr("min")},
+	})
+	if diags.HasError() {
+		t.Fatalf("unrecognized aggregation types must be skipped, not fail: %v", diags)
+	}
+	if flattened == nil || flattened.Min == nil {
+		t.Fatal("expected known min aggregation to flatten")
+	}
+	if flattened.Max != nil || flattened.Histogram != nil || flattened.Samples != nil {
+		t.Fatalf("unrecognized aggregation must be skipped, got %+v", flattened)
+	}
+}
+
+func TestFlattenE2MHistogramAggregationEmptyBuckets(t *testing.T) {
+	aggType := e2ms.AGGTYPE_AGG_TYPE_HISTOGRAM
+	flattened, diags := flattenE2MAggregations(context.Background(), []e2ms.V2Aggregation{
+		{
+			AggType:          &aggType,
+			Enabled:          ptr(false),
+			TargetMetricName: ptr("cx_bucket"),
+			Histogram: &e2ms.E2MAggHistogram{
+				Buckets: []float32{},
+			},
+		},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if flattened == nil || flattened.Histogram == nil {
+		t.Fatal("expected histogram aggregation")
+	}
+	if flattened.Histogram.Buckets.IsNull() {
+		t.Fatal("empty buckets must flatten to an empty list, not null")
+	}
+	if flattened.Histogram.Buckets.IsUnknown() {
+		t.Fatal("empty buckets must be known")
+	}
+	if len(flattened.Histogram.Buckets.Elements()) != 0 {
+		t.Fatalf("expected empty buckets list, got %v", flattened.Histogram.Buckets.Elements())
+	}
+}
+
+func assertEnabled(t *testing.T, agg e2ms.V2Aggregation, want bool, name string) {
+	t.Helper()
+	if agg.Enabled == nil || *agg.Enabled != want {
+		t.Fatalf("%s: expected enabled=%v, got %v", name, want, agg.Enabled)
+	}
+}
+
+func assertTarget(t *testing.T, agg e2ms.V2Aggregation, want string) {
+	t.Helper()
+	if agg.TargetMetricName == nil || *agg.TargetMetricName != want {
+		t.Fatalf("expected target_metric_name=%q, got %v", want, agg.TargetMetricName)
+	}
+}

--- a/internal/provider/events2metrics/resource_coralogix_events2metric_upgrade_test.go
+++ b/internal/provider/events2metrics/resource_coralogix_events2metric_upgrade_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events2metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestUpgradeE2MPermutationsV0ToV1ConvertsLimitStringToInt64(t *testing.T) {
+	ctx := context.Background()
+	prior := permutationsV0List(t, "42", false)
+
+	upgraded, diags := upgradeE2MPermutationsV0ToV1(ctx, prior)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if upgraded.IsNull() {
+		t.Fatal("expected non-null permutations object")
+	}
+
+	var model PermutationsModel
+	diags = upgraded.As(ctx, &model, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		t.Fatalf("decode upgraded permutations: %v", diags)
+	}
+	if model.Limit.ValueInt64() != 42 {
+		t.Fatalf("limit = %d, want 42", model.Limit.ValueInt64())
+	}
+	if model.HasExceedLimit.ValueBool() {
+		t.Fatal("has_exceed_limit = true, want false")
+	}
+}
+
+func TestUpgradeE2MPermutationsV0ToV1EmptyList(t *testing.T) {
+	ctx := context.Background()
+	prior := types.ListValueMust(
+		types.ObjectType{AttrTypes: permutationsV0AttrTypes()},
+		[]attr.Value{},
+	)
+
+	upgraded, diags := upgradeE2MPermutationsV0ToV1(ctx, prior)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !upgraded.IsNull() {
+		t.Fatalf("expected null permutations, got %#v", upgraded)
+	}
+}
+
+func TestUpgradeE2MPermutationsV0ToV1InvalidLimit(t *testing.T) {
+	ctx := context.Background()
+	prior := permutationsV0List(t, "not-a-number", false)
+
+	_, diags := upgradeE2MPermutationsV0ToV1(ctx, prior)
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics for invalid limit string")
+	}
+}
+
+func TestUpgradeE2MStateV0ToV1AcceptsStringPermutationsLimit(t *testing.T) {
+	ctx := context.Background()
+	priorSchema := e2mSchemaV0()
+
+	var schemaResp resource.SchemaResponse
+	(&Events2MetricResource{}).Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	currentSchema := schemaResp.Schema
+
+	priorState := tfsdk.State{
+		Raw:    e2mV0StateWithPermutations(ctx, priorSchema, "e2m-id", "metric_name", "100", false),
+		Schema: priorSchema,
+	}
+	resp := resource.UpgradeStateResponse{State: tfsdk.State{Schema: currentSchema}}
+
+	upgradeE2MStateV0ToV1(ctx, resource.UpgradeStateRequest{State: &priorState}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("state upgrade diagnostics = %v", resp.Diagnostics)
+	}
+
+	var limit types.Int64
+	diags := resp.State.GetAttribute(ctx, path.Root("permutations").AtName("limit"), &limit)
+	if diags.HasError() {
+		t.Fatalf("read upgraded permutations.limit: %v", diags)
+	}
+	if limit.ValueInt64() != 100 {
+		t.Fatalf("permutations.limit = %d, want 100", limit.ValueInt64())
+	}
+
+	var name types.String
+	diags = resp.State.GetAttribute(ctx, path.Root("name"), &name)
+	if diags.HasError() {
+		t.Fatalf("read upgraded name: %v", diags)
+	}
+	if name.ValueString() != "metric_name" {
+		t.Fatalf("name = %q, want metric_name", name.ValueString())
+	}
+}
+
+func permutationsV0AttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"limit":            types.StringType,
+		"has_exceed_limit": types.BoolType,
+	}
+}
+
+func permutationsV0List(t *testing.T, limit string, hasExceed bool) types.List {
+	t.Helper()
+	obj, diags := types.ObjectValue(permutationsV0AttrTypes(), map[string]attr.Value{
+		"limit":            types.StringValue(limit),
+		"has_exceed_limit": types.BoolValue(hasExceed),
+	})
+	if diags.HasError() {
+		t.Fatalf("build v0 permutations object: %v", diags)
+	}
+	list, diags := types.ListValue(types.ObjectType{AttrTypes: permutationsV0AttrTypes()}, []attr.Value{obj})
+	if diags.HasError() {
+		t.Fatalf("build v0 permutations list: %v", diags)
+	}
+	return list
+}
+
+func e2mV0StateWithPermutations(ctx context.Context, resourceSchema schema.Schema, id, name, limit string, hasExceed bool) tftypes.Value {
+	terraformType := resourceSchema.Type().TerraformType(ctx)
+	objectType, ok := terraformType.(tftypes.Object)
+	if !ok {
+		panic("e2m schema Terraform type is not an object")
+	}
+
+	attributes := make(map[string]tftypes.Value, len(objectType.AttributeTypes))
+	for attrName, attributeType := range objectType.AttributeTypes {
+		attributes[attrName] = tftypes.NewValue(attributeType, nil)
+	}
+	attributes["id"] = tftypes.NewValue(objectType.AttributeTypes["id"], id)
+	attributes["name"] = tftypes.NewValue(objectType.AttributeTypes["name"], name)
+
+	permutationsType := objectType.AttributeTypes["permutations"].(tftypes.List)
+	permutationsElem := permutationsType.ElementType.(tftypes.Object)
+	attributes["permutations"] = tftypes.NewValue(permutationsType, []tftypes.Value{
+		tftypes.NewValue(permutationsElem, map[string]tftypes.Value{
+			"limit":            tftypes.NewValue(permutationsElem.AttributeTypes["limit"], limit),
+			"has_exceed_limit": tftypes.NewValue(permutationsElem.AttributeTypes["has_exceed_limit"], hasExceed),
+		}),
+	})
+
+	return tftypes.NewValue(terraformType, attributes)
+}

--- a/internal/provider/resource_coralogix_events2metric_migration_test.go
+++ b/internal/provider/resource_coralogix_events2metric_migration_test.go
@@ -1,0 +1,778 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+const (
+	events2MetricMigrationAcceptanceEnv  = "CORALOGIX_EVENTS2METRIC_MIGRATION_ACC"
+	events2MetricMigrationProviderSource = "registry.terraform.io/coralogix/coralogix"
+	events2MetricMigrationGRPCVersion    = "= 3.8.0"
+)
+
+func TestAccCoralogixResourceEvents2MetricMigration(t *testing.T) {
+	requireEvents2MetricMigrationAcceptance(t)
+
+	cases := []struct {
+		name          string
+		initialConfig func(name, metricField string) string
+		updatedConfig func(name, metricField string) string
+		extraChecks   func(metricField string) []resource.TestCheckFunc
+		updateChecks  func(metricField string) []resource.TestCheckFunc
+		skipImport    bool
+	}{
+		{
+			name:          "logs-baseline",
+			initialConfig: events2MetricMigrationLogsBaseline,
+			updatedConfig: events2MetricMigrationLogsBaselineUpdated,
+		},
+		{
+			name:          "spans-baseline",
+			initialConfig: events2MetricMigrationSpansBaseline,
+			updatedConfig: events2MetricMigrationSpansBaselineUpdated,
+		},
+		{
+			name:          "no-permutations",
+			initialConfig: events2MetricMigrationNoPermutations,
+			updatedConfig: events2MetricMigrationNoPermutationsUpdated,
+		},
+		{
+			name:          "empty-aggregations",
+			initialConfig: events2MetricMigrationEmptyAggregations,
+			updatedConfig: events2MetricMigrationEmptyAggregationsUpdated,
+		},
+		{
+			name:          "data-source-set",
+			initialConfig: events2MetricMigrationDataSourceSet,
+			updatedConfig: events2MetricMigrationDataSourceRemoved,
+			updateChecks: func(string) []resource.TestCheckFunc {
+				return []resource.TestCheckFunc{
+					resource.TestCheckNoResourceAttr(events2metricResourceName, "data_source"),
+				}
+			},
+		},
+		{
+			name:          "histogram-buckets",
+			initialConfig: events2MetricMigrationHistogramBuckets,
+			updatedConfig: events2MetricMigrationHistogramBucketsUpdated,
+			extraChecks: func(metricField string) []resource.TestCheckFunc {
+				return []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+metricField+".aggregations.histogram.buckets.0", "0.1"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+metricField+".aggregations.histogram.buckets.1", "5.5"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+metricField+".aggregations.histogram.buckets.2", "100"),
+				}
+			},
+		},
+		{
+			name:          "samples-oneof",
+			initialConfig: events2MetricMigrationSamplesMin,
+			updatedConfig: events2MetricMigrationSamplesMinUpdated,
+		},
+		{
+			name:          "samples-oneof-max",
+			initialConfig: events2MetricMigrationSamplesMax,
+			updatedConfig: events2MetricMigrationSamplesMaxUpdated,
+		},
+		{
+			name:          "enable-false",
+			initialConfig: events2MetricMigrationEnableFalse,
+			updatedConfig: events2MetricMigrationEnableFalseUpdated,
+			extraChecks: func(metricField string) []resource.TestCheckFunc {
+				return []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+metricField+".aggregations.min.enable", "false"),
+				}
+			},
+		},
+		{
+			name:          "description-set",
+			initialConfig: events2MetricMigrationDescriptionSet,
+			updatedConfig: events2MetricMigrationDescriptionSetUpdated,
+			extraChecks: func(string) []resource.TestCheckFunc {
+				return []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr(events2metricResourceName, "description", "Created by the gRPC-backed provider"),
+				}
+			},
+		},
+		{
+			name:          "description-omitted",
+			initialConfig: events2MetricMigrationDescriptionOmitted,
+			updatedConfig: events2MetricMigrationDescriptionOmittedUpdated,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			name := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012346789_:")
+			metricField := "tf_" + acctest.RandStringFromCharSet(12, "abcdefghijklmnopqrstuvwxyz0123456789_")
+			initial := tc.initialConfig(name, metricField)
+			updated := tc.updatedConfig(name, metricField)
+			var extraChecks, updateChecks []resource.TestCheckFunc
+			if tc.extraChecks != nil {
+				extraChecks = tc.extraChecks(metricField)
+			}
+			if tc.updateChecks != nil {
+				updateChecks = tc.updateChecks(metricField)
+			}
+
+			steps := []resource.TestStep{
+				{
+					Config:            initial,
+					ExternalProviders: events2MetricMigrationExternalProvider(events2MetricMigrationGRPCVersion),
+					Check:             resource.ComposeAggregateTestCheckFunc(extraChecks...),
+				},
+				{
+					Config:                   initial,
+					ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(events2metricResourceName, plancheck.ResourceActionNoop),
+						},
+						PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(extraChecks...),
+				},
+				{
+					Config:                   updated,
+					ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(events2metricResourceName, plancheck.ResourceActionUpdate),
+						},
+						PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(updateChecks...),
+				},
+			}
+			if !tc.skipImport {
+				steps = append(steps, resource.TestStep{
+					ResourceName:             events2metricResourceName,
+					ImportState:              true,
+					ImportStateVerify:        true,
+					ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				})
+			}
+
+			resource.ParallelTest(t, resource.TestCase{
+				PreCheck:     func() { testAccPreCheck(t) },
+				CheckDestroy: testAccCheckEvents2MetricDestroy,
+				Steps:        steps,
+			})
+		})
+	}
+}
+
+func requireEvents2MetricMigrationAcceptance(t *testing.T) {
+	t.Helper()
+	if os.Getenv(events2MetricMigrationAcceptanceEnv) == "" {
+		t.Skipf("set %s=1 to run registry-backed events2metric migration tests", events2MetricMigrationAcceptanceEnv)
+	}
+	if namespace := os.Getenv(resource.EnvTfAccProviderNamespace); namespace != "coralogix" {
+		t.Fatalf("set %s=coralogix to run registry-backed events2metric migration tests", resource.EnvTfAccProviderNamespace)
+	}
+}
+
+func events2MetricMigrationExternalProvider(version string) map[string]resource.ExternalProvider {
+	return map[string]resource.ExternalProvider{
+		"coralogix": {
+			Source:            events2MetricMigrationProviderSource,
+			VersionConstraint: version,
+		},
+	}
+}
+
+func events2MetricMigrationLogsBaseline(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        min = { enable = false }
+        max = { enable = false }
+        avg = { enable = true }
+        sum = { enable = true }
+        count = { enable = true }
+      }
+    }
+  }
+  metric_labels = {
+    Status = "status"
+    Path   = "http_referer"
+  }
+  permutations = {
+    limit = 1000
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationLogsBaselineUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        min = { enable = false }
+        max = { enable = false }
+        avg = { enable = true }
+        sum = { enable = true }
+        count = { enable = true }
+      }
+    }
+  }
+  metric_labels = {
+    Status = "status"
+    Path   = "http_referer"
+  }
+  permutations = {
+    limit = 1000
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationSpansBaseline(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  spans_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    actions      = ["action-name"]
+    services     = ["service-name"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        min = { enable = false }
+        max = { enable = false }
+        avg = { enable = true }
+        sum = { enable = true }
+        count = { enable = true }
+      }
+    }
+  }
+  metric_labels = {
+    Status = "status"
+    Path   = "http_referer"
+  }
+  permutations = {
+    limit = 1000
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationSpansBaselineUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  spans_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    actions      = ["action-name"]
+    services     = ["service-name"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        min = { enable = false }
+        max = { enable = false }
+        avg = { enable = true }
+        sum = { enable = true }
+        count = { enable = true }
+      }
+    }
+  }
+  metric_labels = {
+    Status = "status"
+    Path   = "http_referer"
+  }
+  permutations = {
+    limit = 1000
+  }
+}
+`, name, metricField)
+}
+
+// Registry 3.8.0 cannot create when permutations is omitted (*PermutationsModel
+// cannot hold unknown). Use limit=0 as the pre-fix "absent" equivalent.
+func events2MetricMigrationNoPermutations(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = { enable = true }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationNoPermutationsUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = { enable = true }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationEmptyAggregations(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "method"
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationEmptyAggregationsUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "method"
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationDataSourceSet(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  data_source = "default/logs"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = { enable = true }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationDataSourceRemoved(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = { enable = true }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationHistogramBuckets(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        histogram = {
+          enable  = true
+          buckets = [0.1, 5.5, 100]
+        }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationHistogramBucketsUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        histogram = {
+          enable  = true
+          buckets = [0.1, 5.5, 100]
+        }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationSamplesMin(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        samples = {
+          enable = true
+          type   = "Min"
+        }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationSamplesMinUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        samples = {
+          enable = true
+          type   = "Min"
+        }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationSamplesMax(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        samples = {
+          enable = true
+          type   = "Max"
+        }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationSamplesMaxUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        samples = {
+          enable = true
+          type   = "Max"
+        }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationEnableFalse(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        min = { enable = false }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationEnableFalseUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        min = { enable = false }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationDescriptionSet(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Created by the gRPC-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = { enable = true }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationDescriptionSetUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = { enable = true }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationDescriptionOmitted(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name = %q
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = { enable = true }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}
+
+func events2MetricMigrationDescriptionOmittedUpdated(name, metricField string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = "Updated by the REST-backed provider"
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = { enable = true }
+      }
+    }
+  }
+  permutations = {
+    limit = 0
+  }
+}
+`, name, metricField)
+}

--- a/internal/provider/resource_coralogix_events2metric_test.go
+++ b/internal/provider/resource_coralogix_events2metric_test.go
@@ -17,20 +17,18 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"testing"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 type events2MetricTestFields struct {
-	name, description string
-	limit             int
+	name, description, metricField string
+	limit                          int
 }
 
 var events2metricResourceName = "coralogix_events2metric.test"
@@ -52,19 +50,19 @@ func TestAccCoralogixResourceLogs2Metric(t *testing.T) {
 					resource.TestCheckResourceAttr(events2metricResourceName, "logs_query.applications.0", "nginx"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "logs_query.severities.0", "Debug"),
 
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.source_field", "duration"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.count.target_metric_name", "cx_count"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.count.enable", "true"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.histogram.target_metric_name", "cx_bucket"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.histogram.enable", "false"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.max.target_metric_name", "cx_max"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.max.enable", "false"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.min.target_metric_name", "cx_min"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.min.enable", "false"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.sum.target_metric_name", "cx_sum"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.sum.enable", "true"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.avg.target_metric_name", "cx_avg"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.avg.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".source_field", "duration"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.count.target_metric_name", "cx_count"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.count.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.histogram.target_metric_name", "cx_bucket"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.histogram.enable", "false"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.max.target_metric_name", "cx_max"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.max.enable", "false"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.min.target_metric_name", "cx_min"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.min.enable", "false"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.sum.target_metric_name", "cx_sum"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.sum.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.avg.target_metric_name", "cx_avg"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.avg.enable", "true"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "metric_labels.Status", "status"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "metric_labels.Path", "http_referer"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "permutations.limit", strconv.Itoa(events2Metric.limit)),
@@ -111,19 +109,19 @@ func TestAccCoralogixResourceSpans2Metric(t *testing.T) {
 					resource.TestCheckResourceAttr(events2metricResourceName, "spans_query.actions.0", "action-name"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "spans_query.services.0", "service-name"),
 
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.source_field", "duration"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.count.target_metric_name", "cx_count"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.count.enable", "true"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.histogram.target_metric_name", "cx_bucket"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.histogram.enable", "false"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.max.target_metric_name", "cx_max"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.max.enable", "false"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.min.target_metric_name", "cx_min"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.min.enable", "false"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.sum.target_metric_name", "cx_sum"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.sum.enable", "true"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.avg.target_metric_name", "cx_avg"),
-					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields.methodtwo.aggregations.avg.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".source_field", "duration"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.count.target_metric_name", "cx_count"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.count.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.histogram.target_metric_name", "cx_bucket"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.histogram.enable", "false"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.max.target_metric_name", "cx_max"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.max.enable", "false"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.min.target_metric_name", "cx_min"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.min.enable", "false"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.sum.target_metric_name", "cx_sum"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.sum.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.avg.target_metric_name", "cx_avg"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+events2Metric.metricField+".aggregations.avg.enable", "true"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "metric_labels.Status", "status"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "metric_labels.Path", "http_referer"),
 					resource.TestCheckResourceAttr(events2metricResourceName, "permutations.limit", strconv.Itoa(events2Metric.limit)),
@@ -134,6 +132,138 @@ func TestAccCoralogixResourceSpans2Metric(t *testing.T) {
 				ResourceName:      events2metricResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceEvents2MetricFractionalBuckets(t *testing.T) {
+	events2Metric := getRandomEvents2Metric()
+	mf := events2Metric.metricField
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEvents2MetricDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceEvents2MetricHistogram(events2Metric),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.histogram.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.histogram.buckets.0", "0.1"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.histogram.buckets.1", "5.5"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.histogram.buckets.2", "100"),
+				),
+			},
+			{
+				Config:   testAccCoralogixResourceEvents2MetricHistogram(events2Metric),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceEvents2MetricSamples(t *testing.T) {
+	events2Metric := getRandomEvents2Metric()
+	mf := events2Metric.metricField
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEvents2MetricDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceEvents2MetricSamples(events2Metric, "Min"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.samples.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.samples.type", "Min"),
+				),
+			},
+			{
+				Config:   testAccCoralogixResourceEvents2MetricSamples(events2Metric, "Min"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// Full aggregations oneOf: every aggregation branch on one metric field
+// (simple/none + histogram + samples), matching the API contract shape.
+func TestAccCoralogixResourceEvents2MetricFullAggregations(t *testing.T) {
+	events2Metric := getRandomEvents2Metric()
+	mf := events2Metric.metricField
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEvents2MetricDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceEvents2MetricFullAggregations(events2Metric),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".source_field", "duration"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.avg.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.avg.target_metric_name", "cx_avg"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.histogram.enable", "false"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.histogram.target_metric_name", "cx_bucket"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.count.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.count.target_metric_name", "cx_count"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.max.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.max.target_metric_name", "cx_max"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.min.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.min.target_metric_name", "cx_min"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.sum.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.sum.target_metric_name", "cx_sum"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.samples.enable", "true"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.samples.type", "Max"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.samples.target_metric_name", "cx_value"),
+				),
+			},
+			{
+				Config:   testAccCoralogixResourceEvents2MetricFullAggregations(events2Metric),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceEvents2MetricEnableFalse(t *testing.T) {
+	events2Metric := getRandomEvents2Metric()
+	mf := events2Metric.metricField
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEvents2MetricDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceEvents2MetricEnableFalse(events2Metric),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.min.enable", "false"),
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".aggregations.max.enable", "false"),
+				),
+			},
+			{
+				Config:   testAccCoralogixResourceEvents2MetricEnableFalse(events2Metric),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCoralogixResourceEvents2MetricEmptyAggregations(t *testing.T) {
+	events2Metric := getRandomEvents2Metric()
+	mf := events2Metric.metricField
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEvents2MetricDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceEvents2MetricEmptyAggregations(events2Metric),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(events2metricResourceName, "metric_fields."+mf+".source_field", "method"),
+				),
+			},
+			{
+				Config:   testAccCoralogixResourceEvents2MetricEmptyAggregations(events2Metric),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -153,15 +283,15 @@ func testAccCheckEvents2MetricDestroy(s *terraform.State) error {
 			continue
 		}
 
-		req := &cxsdk.GetE2MRequest{
-			Id: wrapperspb.String(rs.Primary.ID),
-		}
-
-		resp, err := client.Get(ctx, req)
+		resp, httpResponse, err := client.Events2MetricServiceGetE2M(ctx, rs.Primary.ID).Execute()
 		if err == nil {
-			if resp.GetE2M().GetId().GetValue() == rs.Primary.ID {
+			if resp != nil && resp.E2m.GetId() == rs.Primary.ID {
 				return fmt.Errorf("events2metric still exists: %s", rs.Primary.ID)
 			}
+			continue
+		}
+		if httpResponse == nil || httpResponse.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("error checking events2metric destroy for %s: %w", rs.Primary.ID, err)
 		}
 	}
 
@@ -169,9 +299,12 @@ func testAccCheckEvents2MetricDestroy(s *terraform.State) error {
 }
 
 func getRandomEvents2Metric() *events2MetricTestFields {
+	// Metric field keys are unique account-wide; randomize to avoid collisions
+	// with leftovers and parallel tests.
 	return &events2MetricTestFields{
 		name:        acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012346789_:"),
 		description: acctest.RandomWithPrefix("tf-acc-test"),
+		metricField: "tf_" + acctest.RandStringFromCharSet(12, "abcdefghijklmnopqrstuvwxyz0123456789_"),
 		limit:       acctest.RandIntRange(0, 500000),
 	}
 }
@@ -191,7 +324,7 @@ description = "%s"
 }
 
 metric_fields = {
-    methodtwo = {
+    %s = {
         source_field = "duration"
         aggregations = {
             max = {
@@ -217,7 +350,7 @@ permutations = {
 }
 }
 `,
-		l.name, l.description, dataSourceAttr, l.limit)
+		l.name, l.description, dataSourceAttr, l.metricField, l.limit)
 }
 
 func testAccCoralogixResourceSpans2Metric(l *events2MetricTestFields) string {
@@ -232,7 +365,7 @@ spans_query = {
 }
 
 metric_fields = {
-    methodtwo = {
+    %s = {
         source_field = "duration"
         aggregations = {
             max = {
@@ -258,5 +391,140 @@ metric_fields = {
   }
 }
 `,
-		l.name, l.description, l.limit)
+		l.name, l.description, l.metricField, l.limit)
+}
+
+func testAccCoralogixResourceEvents2MetricHistogram(l *events2MetricTestFields) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = %q
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        histogram = {
+          enable  = true
+          buckets = [0.1, 5.5, 100]
+        }
+      }
+    }
+  }
+}
+`, l.name, l.description, l.metricField)
+}
+
+func testAccCoralogixResourceEvents2MetricSamples(l *events2MetricTestFields, sampleType string) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = %q
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        samples = {
+          enable = true
+          type   = %q
+        }
+      }
+    }
+  }
+}
+`, l.name, l.description, l.metricField, sampleType)
+}
+
+func testAccCoralogixResourceEvents2MetricFullAggregations(l *events2MetricTestFields) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = %q
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        avg = {
+          enable = true
+        }
+        histogram = {
+          enable  = false
+          buckets = []
+        }
+        count = {
+          enable = true
+        }
+        max = {
+          enable = true
+        }
+        min = {
+          enable = true
+        }
+        sum = {
+          enable = true
+        }
+        samples = {
+          enable = true
+          type   = "Max"
+        }
+      }
+    }
+  }
+}
+`, l.name, l.description, l.metricField)
+}
+
+func testAccCoralogixResourceEvents2MetricEnableFalse(l *events2MetricTestFields) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = %q
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "duration"
+      aggregations = {
+        min = {
+          enable = false
+        }
+        max = {
+          enable = false
+        }
+      }
+    }
+  }
+}
+`, l.name, l.description, l.metricField)
+}
+
+func testAccCoralogixResourceEvents2MetricEmptyAggregations(l *events2MetricTestFields) string {
+	return fmt.Sprintf(`resource "coralogix_events2metric" "test" {
+  name        = %q
+  description = %q
+  logs_query = {
+    lucene       = "remote_addr_enriched:/.*/"
+    applications = ["nginx"]
+    severities   = ["Debug"]
+  }
+  metric_fields = {
+    %s = {
+      source_field = "method"
+    }
+  }
+}
+`, l.name, l.description, l.metricField)
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -154,71 +154,111 @@ func ConvertAttributes(attributes map[string]resourceschema.Attribute) map[strin
 }
 
 func ConvertAttribute(resourceAttribute resourceschema.Attribute) datasourceschema.Attribute {
+	if attr, ok := convertPrimitiveAttribute(resourceAttribute); ok {
+		return attr
+	}
+	if attr, ok := convertCollectionAttribute(resourceAttribute); ok {
+		return attr
+	}
+	if attr, ok := convertNestedAttribute(resourceAttribute); ok {
+		return attr
+	}
+	panic(fmt.Sprintf("unknown resource attribute type: %T", resourceAttribute))
+}
+
+func convertPrimitiveAttribute(resourceAttribute resourceschema.Attribute) (datasourceschema.Attribute, bool) {
 	switch attr := resourceAttribute.(type) {
 	case resourceschema.BoolAttribute:
 		return datasourceschema.BoolAttribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
-		}
+		}, true
 	case resourceschema.Float32Attribute:
 		return datasourceschema.Float32Attribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
-		}
+		}, true
 	case resourceschema.Float64Attribute:
 		return datasourceschema.Float64Attribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
-		}
+		}, true
 	case resourceschema.Int64Attribute:
 		return datasourceschema.Int64Attribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
-		}
+		}, true
 	case resourceschema.Int32Attribute:
 		return datasourceschema.Int32Attribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
-		}
+		}, true
 	case resourceschema.NumberAttribute:
 		return datasourceschema.NumberAttribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
-		}
+		}, true
 	case resourceschema.StringAttribute:
 		return datasourceschema.StringAttribute{
 			Computed:            true,
 			CustomType:          attr.CustomType,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
-		}
+		}, true
+	case resourceschema.DynamicAttribute:
+		return datasourceschema.DynamicAttribute{
+			Computed:            true,
+			Description:         attr.Description,
+			MarkdownDescription: attr.MarkdownDescription,
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func convertCollectionAttribute(resourceAttribute resourceschema.Attribute) (datasourceschema.Attribute, bool) {
+	switch attr := resourceAttribute.(type) {
 	case resourceschema.MapAttribute:
 		return datasourceschema.MapAttribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
 			ElementType:         attr.ElementType,
-		}
+		}, true
 	case resourceschema.ObjectAttribute:
 		return datasourceschema.ObjectAttribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
 			AttributeTypes:      attr.AttributeTypes,
-		}
+		}, true
 	case resourceschema.SetAttribute:
 		return datasourceschema.SetAttribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
 			ElementType:         attr.ElementType,
-		}
+		}, true
+	case resourceschema.ListAttribute:
+		return datasourceschema.ListAttribute{
+			Computed:            true,
+			Description:         attr.Description,
+			MarkdownDescription: attr.MarkdownDescription,
+			ElementType:         attr.ElementType,
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func convertNestedAttribute(resourceAttribute resourceschema.Attribute) (datasourceschema.Attribute, bool) {
+	switch attr := resourceAttribute.(type) {
 	case resourceschema.ListNestedAttribute:
 		return datasourceschema.ListNestedAttribute{
 			Computed:            true,
@@ -227,14 +267,7 @@ func ConvertAttribute(resourceAttribute resourceschema.Attribute) datasourcesche
 			NestedObject: datasourceschema.NestedAttributeObject{
 				Attributes: ConvertAttributes(attr.NestedObject.Attributes),
 			},
-		}
-	case resourceschema.ListAttribute:
-		return datasourceschema.ListAttribute{
-			Computed:            true,
-			Description:         attr.Description,
-			MarkdownDescription: attr.MarkdownDescription,
-			ElementType:         attr.ElementType,
-		}
+		}, true
 	case resourceschema.MapNestedAttribute:
 		return datasourceschema.MapNestedAttribute{
 			Computed:            true,
@@ -243,7 +276,7 @@ func ConvertAttribute(resourceAttribute resourceschema.Attribute) datasourcesche
 			NestedObject: datasourceschema.NestedAttributeObject{
 				Attributes: ConvertAttributes(attr.NestedObject.Attributes),
 			},
-		}
+		}, true
 	case resourceschema.SetNestedAttribute:
 		return datasourceschema.SetNestedAttribute{
 			Computed:            true,
@@ -252,22 +285,16 @@ func ConvertAttribute(resourceAttribute resourceschema.Attribute) datasourcesche
 			NestedObject: datasourceschema.NestedAttributeObject{
 				Attributes: ConvertAttributes(attr.NestedObject.Attributes),
 			},
-		}
+		}, true
 	case resourceschema.SingleNestedAttribute:
 		return datasourceschema.SingleNestedAttribute{
 			Computed:            true,
 			Description:         attr.Description,
 			MarkdownDescription: attr.MarkdownDescription,
 			Attributes:          ConvertAttributes(attr.Attributes),
-		}
-	case resourceschema.DynamicAttribute:
-		return datasourceschema.DynamicAttribute{
-			Computed:            true,
-			Description:         attr.Description,
-			MarkdownDescription: attr.MarkdownDescription,
-		}
+		}, true
 	default:
-		panic(fmt.Sprintf("unknown resource attribute type: %T", resourceAttribute))
+		return nil, false
 	}
 }
 
@@ -301,7 +328,8 @@ func AttrSliceToFloat32Slice(ctx context.Context, arr []attr.Value) ([]float32, 
 
 func Float32SliceTypeList(ctx context.Context, arr []float32) (types.List, diag.Diagnostics) {
 	if len(arr) == 0 {
-		return types.ListNull(types.Float64Type), nil
+		// Keep empty as [] so configured buckets = [] round-trips after apply.
+		return types.ListValueMust(types.Float64Type, []attr.Value{}), nil
 	}
 	result := make([]attr.Value, 0, len(arr))
 	for _, v := range arr {


### PR DESCRIPTION
### Description

## Summary
Migrate `coralogix_events2metric` from the legacy gRPC client to the OpenAPI REST client, and fix related plan/state bugs uncovered by that migration.

## Backward compatibility
- **Not a breaking change** for existing HCL. Resource and data-source schema stay the same.
- Existing state continues to work. Schema v0→v1 upgrade now converts `permutations.limit` from string to int64 so older state loads cleanly.
- Resources created with the previous provider version can be managed by this branch (create → upgrade provider → read/update/import covered by the migration acceptance test).

## Changes (high level)
- Switch CRUD for the resource and data source to the OpenAPI `Events2MetricsService` client.
- Fix create when `permutations` is omitted (unknown Optional+Computed nested object).
- Fix empty histogram `buckets` becoming null after apply.
- Guard nil API responses on CRUD paths.
- Add a skill for the Optional+Computed nested-object unknown-on-create pattern.

## Test plan
- [x] Unit tests for expand/flatten aggregations and empty histogram buckets
- [x] Unit tests for schema v0→v1 `permutations.limit` upgrade
- [x] Acceptance tests for logs/spans/aggregations/enable/empty aggregations (`TestAccCoralogixResourceLogs2Metric`, `TestAccCoralogixResourceSpans2Metric`, and related)
- [x] Cross-version migration acceptance test (`TestAccCoralogixResourceEvents2MetricMigration`) — create with provider 3.8.0 (gRPC), then manage with this branch

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

### Manual tests
Created 3 E2Ms on **master (gRPC)**, switched to **REST binary**, updated, destroyed.

#### Shape

| Resource | Type | Create highlights | Update highlights |
|----------|------|-------------------|-------------------|
| `logs_complex` | logs | 2 fields (`lc_duration` full aggs+histogram, `lc_method` samples-only); labels; limit 2000 | Rename fields `*_v2`; partial samples; +label; limit 3000 |
| `spans_complex` | spans | 1 field (`sc_duration` avg+samples only); limit 1000 | Rename `*_v2`; flip sample type; +label; limit 1500 |
| `logs_datasource` | logs | `data_source=default/logs`; 1 field, no aggs; limit 500 | Drop `data_source`; rename field; **partial `avg` only**; limit 800 |

Unique metric field names across resources (REST uniqueness). Update **renames** `metric_fields` keys with **partial** `aggregations` — the path that previously failed with inconsistent result after apply.

#### Results

- [x] Create on gRPC + empty plan  
- [x] REST binary, same config → empty plan (no upgrade drift)  
- [x] Update apply OK (no inconsistent-result / field-collision errors)  
- [x] Empty plan after update  
- [x] Destroy

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
resource/coralogix_events2metric: Migrate operations from the legacy gRPC client to the REST client; fix create when `permutations` is omitted; fix empty histogram buckets becoming null; fix schema v0→v1 upgrade for `permutations.limit` string→int64.
```