### PR TITLE
Fix members = [] on coralogix_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_group
+- FIX: `members = []` no longer fails with "Provider produced inconsistent result after apply". An empty member list from the API was always flattened to null, so an explicitly empty set could never round-trip; the members were removed but every apply reported a failure, on the first attempt and on every retry. Emptiness is now reported as whichever the configuration asked for, so `members = []` and omitting the attribute both work.
+
 #### resource/coralogix_dashboard
 - CHORE: Use the shared SDK `dashboardjson.Unmarshal` helper for `content_json` (snake_case aliases, unknown-key discard) instead of a local copy. Create/replace no longer re-strip unknowns; that happens in Unmarshal, as in the operator.
 - FIX: Adding a section, row, widget or annotation without an `id` no longer fails with "Provider produced inconsistent result after apply". Generated `id` fields (section, row, widget, line-chart `query_definitions[].id`, data-table aggregation, annotation) and widget `width` now use `UseNonNullStateForUnknown` so new nested elements stay `(known after apply)` instead of planning as null.

--- a/internal/provider/aaa/data_source_coralogix_group.go
+++ b/internal/provider/aaa/data_source_coralogix_group.go
@@ -32,6 +32,7 @@ import (
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ datasource.DataSourceWithConfigure = &GroupDataSource{}
@@ -142,7 +143,10 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	data, diags = flattenSCIMGroup(getGroupResp)
+	// A data source has nothing to echo back: every attribute is read-only, so Terraform never compares
+	// the result against a configured value. Passing a null set keeps a member-less group reporting
+	// members as null, which is what this data source has always done.
+	data, diags = flattenSCIMGroup(getGroupResp, types.SetNull(types.StringType))
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/aaa/resource_coralogix_group.go
+++ b/internal/provider/aaa/resource_coralogix_group.go
@@ -145,7 +145,7 @@ func (r *GroupResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	groupStr, _ = json.Marshal(getResp)
 	log.Printf("[INFO] Getting group: %s", groupStr)
-	state, diags := flattenSCIMGroup(getResp)
+	state, diags := flattenSCIMGroup(getResp, plan.Members)
 
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -182,8 +182,12 @@ func (r *GroupResource) getGroupWithScopeRetry(ctx context.Context, groupID, exp
 	)
 }
 
-func flattenSCIMGroup(group *clientset.SCIMGroup) (*GroupResourceModel, diag.Diagnostics) {
-	members, diags := flattenSCIMGroupMembers(group.Members)
+// flattenSCIMGroup builds the resource model from an API response. configuredMembers is the members
+// value the caller already holds — the plan on create and update, the prior state on read — and is
+// needed because the API cannot express the difference between "this group has no members" and
+// "membership is not set here". See flattenSCIMGroupMembers.
+func flattenSCIMGroup(group *clientset.SCIMGroup, configuredMembers types.Set) (*GroupResourceModel, diag.Diagnostics) {
+	members, diags := flattenSCIMGroupMembers(group.Members, configuredMembers)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -202,9 +206,22 @@ func flattenSCIMGroup(group *clientset.SCIMGroup) (*GroupResourceModel, diag.Dia
 	}, nil
 }
 
-func flattenSCIMGroupMembers(members []clientset.SCIMGroupMember) (types.Set, diag.Diagnostics) {
+// flattenSCIMGroupMembers converts the API's member list into the members attribute.
+//
+// An empty list from the API is ambiguous: it is what a group with no members looks like, and equally
+// what a group whose membership is not managed here looks like. Terraform draws a hard line between
+// those two — an empty set and a null set are different values, and the value returned from an apply
+// must equal the one that was planned. Returning a null set unconditionally therefore made
+// `members = []` impossible to apply: the empty set in the configuration came back as null and
+// Terraform rejected the result with "Provider produced inconsistent result after apply", on every
+// attempt, even though the members had in fact been removed. Echoing whichever the caller already had
+// keeps both configurations working: an explicit empty set stays empty, an absent attribute stays null.
+func flattenSCIMGroupMembers(members []clientset.SCIMGroupMember, configuredMembers types.Set) (types.Set, diag.Diagnostics) {
 	if len(members) == 0 {
-		return types.SetNull(types.StringType), nil
+		if configuredMembers.IsNull() || configuredMembers.IsUnknown() {
+			return types.SetNull(types.StringType), nil
+		}
+		return types.SetValue(types.StringType, []attr.Value{})
 	}
 	var diags diag.Diagnostics
 	membersIDs := make([]attr.Value, 0, len(members))
@@ -249,7 +266,7 @@ func (r *GroupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	respStr, _ := json.Marshal(getGroupResp)
 	log.Printf("[INFO] Received Group: %s", string(respStr))
 
-	state, diags = flattenSCIMGroup(getGroupResp)
+	state, diags = flattenSCIMGroup(getGroupResp, state.Members)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -311,7 +328,7 @@ func (r *GroupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	groupStr, _ = json.Marshal(getGroupResp)
 	log.Printf("[INFO] Received Group: %s", string(groupStr))
 
-	state, diags := flattenSCIMGroup(getGroupResp)
+	state, diags := flattenSCIMGroup(getGroupResp, plan.Members)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/aaa/resource_coralogix_group_members_test.go
+++ b/internal/provider/aaa/resource_coralogix_group_members_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aaa
+
+import (
+	"testing"
+
+	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// An empty member list from the API has to come back as whichever emptiness the caller asked for.
+// Terraform requires the value returned from an apply to equal the value that was planned, and an
+// empty set is not a null set, so getting this wrong makes one of the two configurations impossible
+// to apply. Both directions are covered because fixing either one in isolation breaks the other.
+func TestFlattenSCIMGroupMembersEmptyList(t *testing.T) {
+	emptySet, diags := types.SetValue(types.StringType, []attr.Value{})
+	if diags.HasError() {
+		t.Fatalf("building an empty set: %v", diags)
+	}
+	populatedSet, diags := types.SetValue(types.StringType, []attr.Value{types.StringValue("user-1")})
+	if diags.HasError() {
+		t.Fatalf("building a populated set: %v", diags)
+	}
+
+	for _, tc := range []struct {
+		name       string
+		configured types.Set
+		wantNull   bool
+	}{
+		{
+			// `members = []`: the configuration says "no members", so state must say the same.
+			name:       "explicit empty set stays empty",
+			configured: emptySet,
+			wantNull:   false,
+		},
+		{
+			// The attribute is absent, which is a different value from an empty set.
+			name:       "absent attribute stays null",
+			configured: types.SetNull(types.StringType),
+			wantNull:   true,
+		},
+		{
+			// Unknown at plan time (a member id computed elsewhere) resolves like an absent value:
+			// there is nothing to echo back yet.
+			name:       "unknown attribute becomes null",
+			configured: types.SetUnknown(types.StringType),
+			wantNull:   true,
+		},
+		{
+			// The group was emptied outside Terraform. Refresh must report the emptiness rather than
+			// keep the stale member, so the next plan can propose the change.
+			name:       "members removed elsewhere are reported as empty",
+			configured: populatedSet,
+			wantNull:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, diags := flattenSCIMGroupMembers(nil, tc.configured)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if got.IsNull() != tc.wantNull {
+				t.Fatalf("IsNull() = %t, want %t (value: %s)", got.IsNull(), tc.wantNull, got)
+			}
+			if !tc.wantNull && len(got.Elements()) != 0 {
+				t.Fatalf("expected an empty set, got %s", got)
+			}
+		})
+	}
+}
+
+// A non-empty list is unambiguous and must be returned as-is whatever the caller had.
+func TestFlattenSCIMGroupMembersPopulatedList(t *testing.T) {
+	members := []clientset.SCIMGroupMember{{Value: "user-1"}, {Value: "user-2"}}
+
+	for name, configured := range map[string]types.Set{
+		"from null":  types.SetNull(types.StringType),
+		"from empty": types.SetValueMust(types.StringType, []attr.Value{}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, diags := flattenSCIMGroupMembers(members, configured)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if got.IsNull() {
+				t.Fatal("a group with members must not flatten to null")
+			}
+			if len(got.Elements()) != 2 {
+				t.Fatalf("expected 2 members, got %s", got)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_coralogix_group_test.go
+++ b/internal/provider/resource_coralogix_group_test.go
@@ -112,3 +112,69 @@ func testAccCoralogixResourceGroup(userName, displayName, scopeName string) stri
 	}
 `, scopeName, userName, displayName)
 }
+
+// A group's member list must be emptiable with `members = []`, not only by deleting the attribute.
+// Both configurations send the same request, so before the fix the empty set removed the members and
+// then failed with "Provider produced inconsistent result after apply" — on that apply and on every
+// retry, because state kept null while the configuration kept `[]`.
+func TestAccCoralogixResourceGroupEmptyMembers(t *testing.T) {
+	userName := randUserName()
+	displayName := acctest.RandomWithPrefix("tf-acc-test-group")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceGroupWithMember(userName, displayName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(groupResourceName, "members.#", "1"),
+					resource.TestCheckResourceAttrPair(groupResourceName, "members.0", "coralogix_user.test", "id"),
+				),
+			},
+			{
+				// Emptying the set: an update, and the plan afterwards has to be empty.
+				Config: testAccCoralogixResourceGroupEmptyMembers(userName, displayName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(groupResourceName, "members.#", "0"),
+				),
+			},
+			{
+				// Creating a group that starts with no members fails the same way, so it is covered too.
+				Taint:  []string{groupResourceName},
+				Config: testAccCoralogixResourceGroupEmptyMembers(userName, displayName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(groupResourceName, "members.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceGroupWithMember(userName, displayName string) string {
+	return fmt.Sprintf(`
+	resource "coralogix_user" "test" {
+		user_name = "%s"
+	}
+
+	resource "coralogix_group" "test" {
+		display_name = "%s"
+		role         = "Read Only"
+		members      = [coralogix_user.test.id]
+	}
+`, userName, displayName)
+}
+
+func testAccCoralogixResourceGroupEmptyMembers(userName, displayName string) string {
+	return fmt.Sprintf(`
+	resource "coralogix_user" "test" {
+		user_name = "%s"
+	}
+
+	resource "coralogix_group" "test" {
+		display_name = "%s"
+		role         = "Read Only"
+		members      = []
+	}
+`, userName, displayName)
+}


### PR DESCRIPTION
### Description

`members = []` on `coralogix_group` cannot be applied. It fails with:

```
Error: Provider produced inconsistent result after apply

When applying changes to coralogix_group.g, provider
"provider[\"registry.terraform.io/coralogix/coralogix\"]" produced an
unexpected new value: .members: was cty.SetValEmpty(cty.String), but now null.
```

`flattenSCIMGroupMembers` returned `types.SetNull` whenever the API reported no members, so an explicitly empty set in the configuration could never round-trip.

Two things make this worse than a rejected apply:

1. **The members are removed anyway.** A null set and an empty set both extract to the same empty request, so the write succeeds and only the value handed back to Terraform differs.
2. **The configuration can never converge.** State ends up holding `null` against a configuration holding `[]`, so every later plan proposes `+ members = []` and every apply fails identically — over a change that already happened on the first attempt. Deleting the attribute is the only way out, which is not obvious from the error.

Creating a group that starts with `members = []` fails the same way.

The API cannot distinguish "this group has no members" from "membership is not managed here", but Terraform draws a hard line between an empty set and a null set. `flattenSCIMGroupMembers` now takes the value the caller already holds — the plan on create and update, the prior state on read — and echoes whichever emptiness it finds: an explicit empty set stays empty, an absent attribute stays null. A group emptied outside Terraform still refreshes to empty, so drift is still reported. The group data source passes a null set and keeps reporting `null` for a member-less group, exactly as before.

<details>
<summary><b>Reproducer</b> (terraform + curl, against the released 3.8.0)</summary>

Set `CORALOGIX_API_KEY`, `CORALOGIX_DOMAIN` and `CORALOGIX_USER_ID` (any user on the team — `curl -s -H "Authorization: Bearer $CORALOGIX_API_KEY" "https://ng-api-http.$CORALOGIX_DOMAIN/scim/Users"`), then:

```bash
#!/usr/bin/env bash
set -uo pipefail
: "${CORALOGIX_API_KEY:?}" "${CORALOGIX_DOMAIN:?}" "${CORALOGIX_USER_ID:?}"
cd "$(mktemp -d)" || exit 1

members_in_backend() {
  curl -s -H "Authorization: Bearer $CORALOGIX_API_KEY" \
    "https://ng-api-http.$CORALOGIX_DOMAIN/scim/Groups/$1" \
  | python3 -c 'import json,sys; print([m["value"] for m in (json.load(sys.stdin).get("members") or [])])'
}

cat > main.tf <<EOF
terraform {
  required_providers {
    coralogix = { source = "coralogix/coralogix", version = "3.8.0" }
  }
}
provider "coralogix" {}

resource "coralogix_group" "g" {
  display_name = "tf-repro-empty-members"
  role         = "Read Only"
  members      = ["$CORALOGIX_USER_ID"]
}
EOF

terraform init -no-color -input=false >/dev/null || exit 1

echo "## 1. create the group with one member"
terraform apply -no-color -input=false -auto-approve >/dev/null || exit 1
GROUP_ID=$(terraform show -json | python3 -c 'import json,sys; print(json.load(sys.stdin)["values"]["root_module"]["resources"][0]["values"]["id"])')
echo "group $GROUP_ID, members in the backend: $(members_in_backend "$GROUP_ID")"

echo "## 2. empty the list with members = []"
sed -i 's/members      = \[".*"\]/members      = []/' main.tf
terraform apply -no-color -input=false -auto-approve 2>&1 | grep -A4 "^Error:" || true

echo "## 3. the members were removed anyway"
echo "members in the backend: $(members_in_backend "$GROUP_ID")"
echo "members in state:       $(terraform show -json | python3 -c 'import json,sys; print(json.load(sys.stdin)["values"]["root_module"]["resources"][0]["values"]["members"])')"

echo "## 4. so the configuration can never converge"
terraform plan -no-color -input=false 2>&1 | grep -E "members|Plan:" | head -3
terraform apply -no-color -input=false -auto-approve 2>&1 | grep "^Error:" | head -1

echo "## 5. deleting the attribute instead works, which is the only way out"
sed -i '/members      = \[\]/d' main.tf
terraform apply -no-color -input=false -auto-approve >/dev/null 2>&1 && echo "   apply succeeded"
terraform plan -no-color -input=false 2>&1 | grep -E "No changes|Plan:" | head -1

terraform destroy -no-color -input=false -auto-approve 2>&1 | tail -1
```

**Output on 3.8.0** — note step 3: the members are gone, but state says `None`:

```
## 1. create the group with one member
group 161126, members in the backend: ['7860e35b-f93e-462d-93af-e01507984d2a']

## 2. empty the list with members = []
Error: Provider produced inconsistent result after apply

When applying changes to coralogix_group.g, provider
"provider[\"registry.terraform.io/coralogix/coralogix\"]" produced an
unexpected new value: .members: was cty.SetValEmpty(cty.String), but now

## 3. the members were removed anyway
members in the backend: []
members in state:       None

## 4. so the configuration can never converge
      + members      = []
Plan: 0 to add, 1 to change, 0 to destroy.
Error: Provider produced inconsistent result after apply

## 5. deleting the attribute instead works, which is the only way out
   apply succeeded
No changes. Your infrastructure matches the configuration.
```

**Output on this branch** (same script, provider built from source and served from a filesystem mirror). The headings are written for the failing case, so steps 2 and 4 print nothing under them — there is no error to grep and no diff to show. State now matches the configuration:

```
## 1. create the group with one member
group 161127, members in the backend: ['7860e35b-f93e-462d-93af-e01507984d2a']

## 2. empty the list with members = []

## 3. the members were removed anyway
members in the backend: []
members in state:       []

## 4. so the configuration can never converge: plan still proposes the change
   and applying it fails again:

## 5. deleting the attribute instead works, which is the only way out
   apply succeeded
No changes. Your infrastructure matches the configuration.
```

Step 5 matters as much as step 2: omitting the attribute still works, so the null path did not regress.

</details>

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

`TestAccCoralogixResourceGroupEmptyMembers` covers emptying an existing member list and creating a group that starts empty. It fails on `master` with the error above and passes here.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceGroupEmptyMembers'
=== RUN   TestAccCoralogixResourceGroupEmptyMembers
--- PASS: TestAccCoralogixResourceGroupEmptyMembers (3.98s)
PASS
ok  	github.com/coralogix/terraform-provider-coralogix/internal/provider	3.997s
```

The same test with the fix reverted, to show it has teeth:

```
        Error: Provider produced inconsistent result after apply
        unexpected new value: .members: was cty.SetValEmpty(cty.String), but now
--- FAIL: TestAccCoralogixResourceGroupEmptyMembers (2.50s)
FAIL
```

There are also unit tests for the helper (`TestFlattenSCIMGroupMembers*`) covering both directions — empty stays empty, absent stays null — because fixing either one alone breaks the other.

### Release Note

```release-note
resource/coralogix_group: `members = []` no longer fails with "Provider produced inconsistent result after apply"
```

### References

Found by an end-to-end suite that runs the released provider against a staging team.

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
