### PR TITLE
feat(tco_policies_logs): add targets block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+#### resource/coralogix_tco_policies_logs
+- FEAT: Add `targets` to route matched logs to specific named datasets. Each target requires its own `priority`. Policy-level `priority` is now optional; omit it when `targets` is set.
+- FIX: `targets[*].priority_override.usage_tiers[*].daily_quota_percentage` is validated to `0`–`100`, matching the policy-level field.
+
 #### resource/coralogix_dashboard
 - CHORE: Use the shared SDK `dashboardjson.Unmarshal` helper for `content_json` (snake_case aliases, unknown-key discard) instead of a local copy. Create/replace no longer re-strip unknowns; that happens in Unmarshal, as in the operator.
 - FIX: Adding a section, row, widget or annotation without an `id` no longer fails with "Provider produced inconsistent result after apply". Generated `id` fields (section, row, widget, line-chart `query_definitions[].id`, data-table aggregation, annotation) and widget `width` now use `UseNonNullStateForUnknown` so new nested elements stay `(known after apply)` instead of planning as null.

--- a/docs/data-sources/tco_policies_logs.md
+++ b/docs/data-sources/tco_policies_logs.md
@@ -39,10 +39,11 @@ Read-Only:
 - `id` (String) tco-policy ID.
 - `name` (String) tco-policy name.
 - `order` (Number) The policy's order between the other policies.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
+- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. Priority must be set either here or on every target, not both — set this when `targets` is omitted, and omit it when `targets` is set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
 - `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
+- `targets` (Attributes List) Route matched logs to specific named datasets. Every target must specify its own `priority`. When `targets` is omitted the backend routes the policy to a single default `logs` dataset using the policy-level `priority`; that implicit target is not reflected in Terraform state. (see [below for nested schema](#nestedatt--policies--targets))
 
 <a id="nestedatt--policies--applications"></a>
 ### Nested Schema for `policies.applications`
@@ -77,3 +78,30 @@ Read-Only:
 
 - `names` (Set of String)
 - `rule_type` (String)
+
+
+<a id="nestedatt--policies--targets"></a>
+### Nested Schema for `policies.targets`
+
+Read-Only:
+
+- `archive_retention_id` (String) ID of an archive retention policy to apply to this target.
+- `dataset` (String) Name of the dataset to route matched logs to. Must be non-empty.
+- `dataspace` (String) Dataspace name. Defaults to `default` when unset. Maximum 50 characters.
+- `priority` (String) Per-target priority. Can be one of ["block" "high" "low" "medium"]. Every target must carry its own priority.
+- `priority_override` (Attributes) Dynamically reassign this target's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--targets--priority_override))
+
+<a id="nestedatt--policies--targets--priority_override"></a>
+### Nested Schema for `policies.targets.priority_override`
+
+Read-Only:
+
+- `usage_tiers` (Attributes List) Ordered list of quota-consumption tiers; the target's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached. (see [below for nested schema](#nestedatt--policies--targets--priority_override--usage_tiers))
+
+<a id="nestedatt--policies--targets--priority_override--usage_tiers"></a>
+### Nested Schema for `policies.targets.priority_override.usage_tiers`
+
+Read-Only:
+
+- `daily_quota_percentage` (Number) Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.
+- `priority` (String) The priority to apply when this tier is active. Can be one of ["block" "high" "low" "medium"].

--- a/docs/resources/tco_policies_logs.md
+++ b/docs/resources/tco_policies_logs.md
@@ -57,9 +57,8 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
       }
     },
     {
-      name     = "Example tco_policy from terraform 3"
-      priority = "high"
-
+      name       = "Example tco_policy from terraform 3"
+      priority   = "high"
       severities = ["error", "warning", "critical"]
       applications = {
         rule_type = "starts_with"
@@ -71,9 +70,8 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
       }
     },
     {
-      name     = "Example tco_policy from terraform 4"
-      priority = "high"
-
+      name       = "Example tco_policy from terraform 4"
+      priority   = "high"
       severities = ["error", "warning", "critical"]
       applications = {
         rule_type = "starts_with"
@@ -109,7 +107,27 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
           { daily_quota_percentage = 80, priority = "low" },
         ]
       }
-    }
+    },
+    {
+      name       = "Example tco_policy without targets"
+      priority   = "medium"
+      severities = ["info", "warning"]
+    },
+    {
+      name       = "Example tco_policy with targets"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset   = "dataset-a"
+          dataspace = "default"
+          priority  = "medium"
+        },
+        {
+          dataset  = "dataset-b"
+          priority = "low"
+        },
+      ]
+    },
   ]
 }
 ```
@@ -131,7 +149,6 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
 Required:
 
 - `name` (String) tco-policy name.
-- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
 
 Optional:
 
@@ -140,9 +157,11 @@ Optional:
 - `description` (String) The policy description
 - `dpxl_expression` (String) DataPrime expression to match logs for this policy. Mutually exclusive with `severities` — set exactly one. The expression must include a version prefix, e.g. `<v1> $d.severity == 'INFO'`.
 - `enabled` (Boolean) Determines weather the policy will be enabled. True by default.
+- `priority` (String) The policy priority. Can be one of ["block" "high" "low" "medium"]. Priority must be set either here or on every target, not both — set this when `targets` is omitted, and omit it when `targets` is set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of "Route the remaining quota to" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).
 - `quota_based_priority_override` (Attributes) Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback ("Route the remaining quota to" in the UI), which must be more restrictive than the last tier. (see [below for nested schema](#nestedatt--policies--quota_based_priority_override))
 - `severities` (Set of String) The severities to apply the policy on. Valid severities are ["critical" "debug" "error" "info" "verbose" "warning"].
 - `subsystems` (Attributes) The subsystems to apply the policy on. Applies the policy on all the subsystems by default. (see [below for nested schema](#nestedatt--policies--subsystems))
+- `targets` (Attributes List) Route matched logs to specific named datasets. Every target must specify its own `priority`. When `targets` is omitted the backend routes the policy to a single default `logs` dataset using the policy-level `priority`; that implicit target is not reflected in Terraform state. (see [below for nested schema](#nestedatt--policies--targets))
 
 Read-Only:
 
@@ -188,3 +207,33 @@ Required:
 Optional:
 
 - `rule_type` (String)
+
+
+<a id="nestedatt--policies--targets"></a>
+### Nested Schema for `policies.targets`
+
+Required:
+
+- `dataset` (String) Name of the dataset to route matched logs to. Must be non-empty.
+- `priority` (String) Per-target priority. Can be one of ["block" "high" "low" "medium"]. Every target must carry its own priority.
+
+Optional:
+
+- `archive_retention_id` (String) ID of an archive retention policy to apply to this target.
+- `dataspace` (String) Dataspace name. Defaults to `default` when unset. Maximum 50 characters.
+- `priority_override` (Attributes) Dynamically reassign this target's priority based on daily quota consumption tiers. (see [below for nested schema](#nestedatt--policies--targets--priority_override))
+
+<a id="nestedatt--policies--targets--priority_override"></a>
+### Nested Schema for `policies.targets.priority_override`
+
+Required:
+
+- `usage_tiers` (Attributes List) Ordered list of quota-consumption tiers; the target's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached. (see [below for nested schema](#nestedatt--policies--targets--priority_override--usage_tiers))
+
+<a id="nestedatt--policies--targets--priority_override--usage_tiers"></a>
+### Nested Schema for `policies.targets.priority_override.usage_tiers`
+
+Required:
+
+- `daily_quota_percentage` (Number) Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.
+- `priority` (String) The priority to apply when this tier is active. Can be one of ["block" "high" "low" "medium"].

--- a/examples/resources/coralogix_tco_policies_logs/resource.tf
+++ b/examples/resources/coralogix_tco_policies_logs/resource.tf
@@ -42,9 +42,8 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
       }
     },
     {
-      name     = "Example tco_policy from terraform 3"
-      priority = "high"
-
+      name       = "Example tco_policy from terraform 3"
+      priority   = "high"
       severities = ["error", "warning", "critical"]
       applications = {
         rule_type = "starts_with"
@@ -56,9 +55,8 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
       }
     },
     {
-      name     = "Example tco_policy from terraform 4"
-      priority = "high"
-
+      name       = "Example tco_policy from terraform 4"
+      priority   = "high"
       severities = ["error", "warning", "critical"]
       applications = {
         rule_type = "starts_with"
@@ -94,6 +92,26 @@ resource "coralogix_tco_policies_logs" "tco_policies" {
           { daily_quota_percentage = 80, priority = "low" },
         ]
       }
-    }
+    },
+    {
+      name       = "Example tco_policy without targets"
+      priority   = "medium"
+      severities = ["info", "warning"]
+    },
+    {
+      name       = "Example tco_policy with targets"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset   = "dataset-a"
+          dataspace = "default"
+          priority  = "medium"
+        },
+        {
+          dataset  = "dataset-b"
+          priority = "low"
+        },
+      ]
+    },
   ]
 }

--- a/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
+++ b/internal/provider/dataplans/resource_coralogix_tco_policies_logs.go
@@ -75,9 +75,7 @@ var (
 	}
 	tcoPolicySeverityApiToSchema = utils.ReverseMap(tcoPolicySeveritySchemaToApi)
 	validPolicySeverities        = utils.GetKeys(tcoPolicySeveritySchemaToApi)
-	// overrideTCOPoliciesLogsURL     = tcoPolicys.TCOPoliciesAtomicOverwriteLogPoliciesRPC
-	// getCompanyPoliciesURL          = tcoPolicys.TCOPoliciesGetCompanyPoliciesRPC
-	LogSource = tcoPolicys.V1SOURCETYPE_SOURCE_TYPE_LOGS
+	LogSource                    = tcoPolicys.V1SOURCETYPE_SOURCE_TYPE_LOGS
 )
 
 func NewTCOPoliciesLogsResource() resource.Resource {
@@ -110,6 +108,7 @@ type TCOPolicyLogsModel struct {
 	ArchiveRetentionID         types.String `tfsdk:"archive_retention_id"`
 	DpxlExpression             types.String `tfsdk:"dpxl_expression"`
 	QuotaBasedPriorityOverride types.Object `tfsdk:"quota_based_priority_override"` // QuotaBasedPriorityOverrideModel
+	Targets                    types.List   `tfsdk:"targets"`                       // []V1TargetModel
 }
 
 type TCORuleModel struct {
@@ -124,6 +123,14 @@ type QuotaBasedPriorityOverrideModel struct {
 type UsageTierModel struct {
 	DailyQuotaPercentage types.Float64 `tfsdk:"daily_quota_percentage"`
 	Priority             types.String  `tfsdk:"priority"`
+}
+
+type V1TargetModel struct {
+	Dataset            types.String `tfsdk:"dataset"`
+	Dataspace          types.String `tfsdk:"dataspace"`
+	Priority           types.String `tfsdk:"priority"`
+	ArchiveRetentionID types.String `tfsdk:"archive_retention_id"`
+	PriorityOverride   types.Object `tfsdk:"priority_override"` // QuotaBasedPriorityOverrideModel
 }
 
 func (r *TCOPoliciesLogsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -181,11 +188,11 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 							MarkdownDescription: "Determines weather the policy will be enabled. True by default.",
 						},
 						"priority": schema.StringAttribute{
-							Required: true,
+							Optional: true,
 							Validators: []validator.String{
 								stringvalidator.OneOf(tcoPoliciesValidPriorities...),
 							},
-							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of \"Route the remaining quota to\" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).", tcoPoliciesValidPriorities),
+							MarkdownDescription: fmt.Sprintf("The policy priority. Can be one of %q. Priority must be set either here or on every target, not both — set this when `targets` is omitted, and omit it when `targets` is set. For a quota-based policy (when `quota_based_priority_override` is set) this is also the fallback priority applied once all `usage_tiers` are exhausted — the equivalent of \"Route the remaining quota to\" in the UI — and must be more restrictive than the last tier's priority (most to least restrictive: `block`, `low`, `medium`, `high`).", tcoPoliciesValidPriorities),
 						},
 						"order": schema.Int64Attribute{
 							Computed:            true,
@@ -293,6 +300,78 @@ func (r *TCOPoliciesLogsResource) Schema(_ context.Context, _ resource.SchemaReq
 								},
 							},
 							MarkdownDescription: "Dynamically reassign the policy's priority based on daily quota consumption tiers. Once all `usage_tiers` are exhausted, the policy's top-level `priority` is used as the fallback (\"Route the remaining quota to\" in the UI), which must be more restrictive than the last tier.",
+						},
+						"targets": schema.ListNestedAttribute{
+							Optional: true,
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+							},
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"dataset": schema.StringAttribute{
+										Required: true,
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+										MarkdownDescription: "Name of the dataset to route matched logs to. Must be non-empty.",
+									},
+									"dataspace": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+										Default:  stringdefault.StaticString("default"),
+										Validators: []validator.String{
+											stringvalidator.LengthAtMost(50),
+										},
+										MarkdownDescription: "Dataspace name. Defaults to `default` when unset. Maximum 50 characters.",
+									},
+									"priority": schema.StringAttribute{
+										Required: true,
+										Validators: []validator.String{
+											stringvalidator.OneOf(tcoPoliciesValidPriorities...),
+										},
+										MarkdownDescription: fmt.Sprintf("Per-target priority. Can be one of %q. Every target must carry its own priority.", tcoPoliciesValidPriorities),
+									},
+									"archive_retention_id": schema.StringAttribute{
+										Optional: true,
+										Validators: []validator.String{
+											stringvalidator.LengthAtLeast(1),
+										},
+										MarkdownDescription: "ID of an archive retention policy to apply to this target.",
+									},
+									"priority_override": schema.SingleNestedAttribute{
+										Optional: true,
+										Attributes: map[string]schema.Attribute{
+											"usage_tiers": schema.ListNestedAttribute{
+												Required: true,
+												Validators: []validator.List{
+													listvalidator.SizeAtLeast(1),
+												},
+												NestedObject: schema.NestedAttributeObject{
+													Attributes: map[string]schema.Attribute{
+														"daily_quota_percentage": schema.Float64Attribute{
+															Required: true,
+															Validators: []validator.Float64{
+																float64validator.Between(0, 100),
+															},
+															MarkdownDescription: "Daily quota consumption (in percent) at which this tier becomes active. Must be between 0 and 100.",
+														},
+														"priority": schema.StringAttribute{
+															Required: true,
+															Validators: []validator.String{
+																stringvalidator.OneOf(tcoPoliciesValidPriorities...),
+															},
+															MarkdownDescription: fmt.Sprintf("The priority to apply when this tier is active. Can be one of %q.", tcoPoliciesValidPriorities),
+														},
+													},
+												},
+												MarkdownDescription: "Ordered list of quota-consumption tiers; the target's priority is dynamically reassigned to the matching tier's `priority` once `daily_quota_percentage` is reached.",
+											},
+										},
+										MarkdownDescription: "Dynamically reassign this target's priority based on daily quota consumption tiers.",
+									},
+								},
+							},
+							MarkdownDescription: "Route matched logs to specific named datasets. Every target must specify its own `priority`. When `targets` is omitted the backend routes the policy to a single default `logs` dataset using the policy-level `priority`; that implicit target is not reflected in Terraform state.",
 						},
 					},
 				},
@@ -483,7 +562,7 @@ func (r *TCOPoliciesLogsResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func flattenOverwriteTCOPoliciesLogsList(ctx context.Context, overwriteResp *tcoPolicys.AtomicOverwriteLogPoliciesResponse) (*TCOPoliciesListModel, diag.Diagnostics) {
-	var policies []*TCOPolicyLogsModel
+	policies := make([]*TCOPolicyLogsModel, 0)
 	var diags diag.Diagnostics
 	for _, policy := range overwriteResp.GetCreateResponses() {
 		tcoPolicy, dgs := flattenTCOLogsPolicy(ctx, policy.GetPolicy())
@@ -506,7 +585,7 @@ func flattenOverwriteTCOPoliciesLogsList(ctx context.Context, overwriteResp *tco
 }
 
 func flattenGetTCOPoliciesLogsList(ctx context.Context, getResp *tcoPolicys.GetCompanyPoliciesResponse) (*TCOPoliciesListModel, diag.Diagnostics) {
-	var policies []*TCOPolicyLogsModel
+	policies := make([]*TCOPolicyLogsModel, 0)
 	var diags diag.Diagnostics
 	for _, policy := range getResp.GetPolicies() {
 		tcoPolicy, dgs := flattenTCOLogsPolicy(ctx, policy)
@@ -544,6 +623,23 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 	if diags.HasError() {
 		return nil, diags
 	}
+	var priority types.String
+	policyPriority := logsPolicy.GetPriority()
+	if policyPriority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+		priority = types.StringValue(tcoPoliciesPriorityApiToSchema[policyPriority])
+	} else {
+		priority = types.StringNull()
+	}
+
+	var targets types.List
+	if targetsAreBackendInjected(logsPolicy) {
+		targets = types.ListNull(types.ObjectType{AttrTypes: v1TargetAttributes()})
+	} else {
+		targets, diags = flattenV1Targets(ctx, logsPolicy.Targets)
+		if diags.HasError() {
+			return nil, diags
+		}
+	}
 
 	return &TCOPolicyLogsModel{
 		ID:                         types.StringValue(logsPolicy.GetId()),
@@ -551,13 +647,14 @@ func flattenTCOLogsPolicy(ctx context.Context, policy tcoPolicys.Policy) (*TCOPo
 		Description:                types.StringValue(logsPolicy.GetDescription()),
 		Enabled:                    types.BoolValue(logsPolicy.GetEnabled()),
 		Order:                      types.Int64Value(int64(logsPolicy.GetOrder())),
-		Priority:                   types.StringValue(tcoPoliciesPriorityApiToSchema[logsPolicy.GetPriority()]),
+		Priority:                   priority,
 		Applications:               applications,
 		Subsystems:                 subsystems,
 		ArchiveRetentionID:         flattenArchiveRetention(logsPolicy.ArchiveRetention),
 		Severities:                 flattenTCOPolicySeverities(logRules.GetSeverities()),
 		DpxlExpression:             types.StringPointerValue(logRules.DpxlExpression),
 		QuotaBasedPriorityOverride: quotaBased,
+		Targets:                    targets,
 	}, nil
 }
 
@@ -587,6 +684,54 @@ func flattenQuotaBasedPriorityOverride(ctx context.Context, po *tcoPolicys.Prior
 	})
 }
 
+// targetsAreBackendInjected reports whether a policy's targets were invented by the backend, which
+// adds a default one to every policy created without them. The API takes priority/priorityOverride
+// either policy-level or per-target and never both, so a policy holding either provably has no
+// targets of its own.
+func targetsAreBackendInjected(policy tcoPolicys.Policy) bool {
+	return policy.GetPriority() != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED ||
+		policy.PriorityOverride != nil
+}
+
+func flattenV1Targets(ctx context.Context, targets []tcoPolicys.V1Target) (types.List, diag.Diagnostics) {
+	elemType := types.ObjectType{AttrTypes: v1TargetAttributes()}
+	if len(targets) == 0 {
+		return types.ListNull(elemType), nil
+	}
+
+	items := make([]V1TargetModel, 0, len(targets))
+	for _, t := range targets {
+		priorityOverride, diags := flattenQuotaBasedPriorityOverride(ctx, t.PriorityOverride)
+		if diags.HasError() {
+			return types.ListNull(elemType), diags
+		}
+
+		var priority types.String
+		if t.Priority != nil && *t.Priority != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED {
+			priority = types.StringValue(tcoPoliciesPriorityApiToSchema[*t.Priority])
+		} else {
+			priority = types.StringNull()
+		}
+
+		var dataspace types.String
+		if t.Dataspace != nil {
+			dataspace = types.StringValue(*t.Dataspace)
+		} else {
+			dataspace = types.StringNull()
+		}
+
+		items = append(items, V1TargetModel{
+			Dataset:            types.StringPointerValue(t.Dataset),
+			Dataspace:          dataspace,
+			Priority:           priority,
+			ArchiveRetentionID: flattenArchiveRetention(t.ArchiveRetention),
+			PriorityOverride:   priorityOverride,
+		})
+	}
+
+	return types.ListValueFrom(ctx, elemType, items)
+}
+
 func policiesLogsAttr() map[string]attr.Type {
 	return map[string]attr.Type{
 		"id":                            types.StringType,
@@ -601,6 +746,17 @@ func policiesLogsAttr() map[string]attr.Type {
 		"archive_retention_id":          types.StringType,
 		"dpxl_expression":               types.StringType,
 		"quota_based_priority_override": types.ObjectType{AttrTypes: quotaBasedPriorityOverrideAttributes()},
+		"targets":                       types.ListType{ElemType: types.ObjectType{AttrTypes: v1TargetAttributes()}},
+	}
+}
+
+func v1TargetAttributes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"dataset":              types.StringType,
+		"dataspace":            types.StringType,
+		"priority":             types.StringType,
+		"archive_retention_id": types.StringType,
+		"priority_override":    types.ObjectType{AttrTypes: quotaBasedPriorityOverrideAttributes()},
 	}
 }
 
@@ -662,7 +818,12 @@ func extractOverwriteTcoPoliciesLogs(ctx context.Context, plan *TCOPoliciesListM
 }
 
 func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPolicys.CreateLogPolicyRequest, diag.Diagnostics) {
-	priority := tcoPoliciesPrioritySchemaToApi[plan.Priority.ValueString()]
+	var priority tcoPolicys.QuotaV1Priority
+	if plan.Priority.IsNull() || plan.Priority.IsUnknown() {
+		priority = tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED
+	} else {
+		priority = tcoPoliciesPrioritySchemaToApi[plan.Priority.ValueString()]
+	}
 	applicationRule, diags := expandTCOPolicyRule(ctx, plan.Applications)
 	if diags.HasError() {
 		return nil, diags
@@ -677,6 +838,10 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 		return nil, diags
 	}
 	priorityOverride, diags := expandQuotaBasedPriorityOverride(ctx, plan.QuotaBasedPriorityOverride)
+	if diags.HasError() {
+		return nil, diags
+	}
+	targets, diags := expandV1Targets(ctx, plan.Targets)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -699,6 +864,7 @@ func extractTcoPolicyLog(ctx context.Context, plan TCOPolicyLogsModel) (*tcoPoli
 			ArchiveRetention: archiveRetention,
 			Disabled:         &enabled,
 			PriorityOverride: priorityOverride,
+			Targets:          targets,
 		},
 		LogRules: logRules,
 	}, nil
@@ -740,6 +906,49 @@ func expandQuotaBasedPriorityOverride(ctx context.Context, override types.Object
 			UsageTiers: tiers,
 		},
 	}, nil
+}
+
+func expandV1Targets(ctx context.Context, targets types.List) ([]tcoPolicys.V1Target, diag.Diagnostics) {
+	if targets.IsNull() || targets.IsUnknown() {
+		return nil, nil
+	}
+
+	var targetObjects []types.Object
+	if diags := targets.ElementsAs(ctx, &targetObjects, true); diags.HasError() {
+		return nil, diags
+	}
+
+	result := make([]tcoPolicys.V1Target, 0, len(targetObjects))
+	for _, to := range targetObjects {
+		var m V1TargetModel
+		if diags := to.As(ctx, &m, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return nil, diags
+		}
+
+		target := tcoPolicys.V1Target{
+			Dataset:          m.Dataset.ValueStringPointer(),
+			ArchiveRetention: expandActiveRetention(m.ArchiveRetentionID),
+		}
+
+		if !m.Dataspace.IsNull() && !m.Dataspace.IsUnknown() {
+			target.Dataspace = m.Dataspace.ValueStringPointer()
+		}
+
+		if !m.Priority.IsNull() && !m.Priority.IsUnknown() {
+			p := tcoPoliciesPrioritySchemaToApi[m.Priority.ValueString()]
+			target.Priority = &p
+		}
+
+		priorityOverride, diags := expandQuotaBasedPriorityOverride(ctx, m.PriorityOverride)
+		if diags.HasError() {
+			return nil, diags
+		}
+		target.PriorityOverride = priorityOverride
+
+		result = append(result, target)
+	}
+
+	return result, nil
 }
 
 func expandTCOPolicyRule(ctx context.Context, rule types.Object) (*tcoPolicys.QuotaV1Rule, diag.Diagnostics) {

--- a/internal/provider/resource_coralogix_tco_policies_logs_test.go
+++ b/internal/provider/resource_coralogix_tco_policies_logs_test.go
@@ -53,6 +53,9 @@ func TestAccCoralogixResourceTCOPoliciesLogsCreate(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(tcoPoliciesResourceName, "policies.0.subsystems.names.*", "mobile"),
 					resource.TestCheckTypeSetElemAttr(tcoPoliciesResourceName, "policies.0.subsystems.names.*", "web"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.archive_retention_id", "e1c980d0-c910-4c54-8326-67f3cf95645a"),
+					// No targets were configured, so the default target the backend injects must
+					// not land in state — otherwise every subsequent plan drifts.
+					resource.TestCheckNoResourceAttr(tcoPoliciesResourceName, "policies.0.targets"),
 
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.name", "Example tco_policy from terraform 2"),
 					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.priority", "medium"),
@@ -276,6 +279,157 @@ func testAccCoralogixResourceTCOPoliciesLogsQuotaBasedOverride() string {
           { daily_quota_percentage = 80, priority = "low" },
         ]
       }
+    },
+  ]
+}
+`
+}
+
+// TestAccCoralogixResourceTCOPoliciesLogs_targets covers TCO log policies with the targets
+// block. Every target carries its own priority — the backend requires one on each target — and
+// the policy-level priority is omitted.
+func TestAccCoralogixResourceTCOPoliciesLogs_targets(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "Example tco_policy with per-target priorities"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "2"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority", "medium"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.dataset", "dataset-b"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.1.priority", "low"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsTargetsPerTargetPriority() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name       = "Example tco_policy with per-target priorities"
+      severities = ["info", "warning"]
+      targets = [
+        {
+          dataset  = "dataset-a"
+          priority = "medium"
+        },
+        {
+          dataset  = "dataset-b"
+          priority = "low"
+        },
+      ]
+    },
+  ]
+}
+`
+}
+
+// TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets verifies that policies with targets and
+// policies without targets coexist correctly in the same resource. The policy with targets must
+// have exactly the targets that were configured; the policy without targets must have none in
+// state, even though the backend injects a default target for it.
+func TestAccCoralogixResourceTCOPoliciesLogs_mixedTargets(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceTCOPoliciesLogsMixedTargets(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Policy 0: has targets, each with its own priority.
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.name", "policy-with-targets"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "1"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataset", "dataset-a"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.dataspace", "default"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority", "medium"),
+					// Policy 1: no targets configured — the backend's injected default must not
+					// reach state.
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.name", "policy-without-targets"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.1.priority", "low"),
+					resource.TestCheckNoResourceAttr(tcoPoliciesResourceName, "policies.1.targets"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsMixedTargets() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name       = "policy-with-targets"
+      severities = ["info"]
+      targets = [
+        {
+          dataset  = "dataset-a"
+          priority = "medium"
+        },
+      ]
+    },
+    {
+      name       = "policy-without-targets"
+      priority   = "low"
+      severities = ["warning"]
+    },
+  ]
+}
+`
+}
+
+// TestAccCoralogixResourceTCOPoliciesLogs_targetPriorityOverride covers the per-target
+// priority_override block. Priority lives entirely on the target here, so the policy carries
+// neither a priority nor a policy-level override. Tier priorities must be less restrictive than
+// the target's own priority, hence the `block` base.
+func TestAccCoralogixResourceTCOPoliciesLogs_targetPriorityOverride(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccTCOPoliciesLogsCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceTCOPoliciesLogsTargetPriorityOverride(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.#", "1"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority", "block"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority_override.usage_tiers.#", "2"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority_override.usage_tiers.0.daily_quota_percentage", "50"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority_override.usage_tiers.0.priority", "medium"),
+					resource.TestCheckResourceAttr(tcoPoliciesResourceName, "policies.0.targets.0.priority_override.usage_tiers.1.priority", "low"),
+					// Priority is owned by the target, so neither policy-level field is set.
+					resource.TestCheckNoResourceAttr(tcoPoliciesResourceName, "policies.0.priority"),
+					resource.TestCheckNoResourceAttr(tcoPoliciesResourceName, "policies.0.quota_based_priority_override"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceTCOPoliciesLogsTargetPriorityOverride() string {
+	return `resource "coralogix_tco_policies_logs" "test" {
+  policies = [
+    {
+      name       = "Example tco_policy with per-target priority override"
+      severities = ["info"]
+      targets = [
+        {
+          dataset  = "logs"
+          priority = "block"
+          priority_override = {
+            usage_tiers = [
+              { daily_quota_percentage = 50, priority = "medium" },
+              { daily_quota_percentage = 80, priority = "low" },
+            ]
+          }
+        },
+      ]
     },
   ]
 }


### PR DESCRIPTION
### Description

Add a `targets` list block to `coralogix_tco_policies_logs` to route matched logs to specific named datasets. Every target carries its own `priority`.

**Key behaviours:**
- `targets[*].priority` is **required**. The backend rejects a target without one, so there is no inheritance from the policy-level `priority`.
- Priority is set **either** policy-level **or** per-target, never both, and at least one is required. Both rules are enforced by the backend rather than a `ConflictsWith` validator, in line with the repo's stance on changeable API limits — each 400 names the attribute and says what to do.
- Policy-level `priority` is therefore now `Optional`: set it when `targets` is omitted, omit it when `targets` is set.
- `targets` is plain `Optional` (**not** `Optional+Computed`). The backend injects a default target — `{dataset: "logs", dataspace: "default"}` carrying the policy's priority — into every policy created without explicit targets. That injected target is kept **out** of Terraform state, so a policy configured without targets shows `targets = null` and never drifts.
- `dataspace` defaults to `"default"` when omitted; validated at ≤ 50 chars (proto-backed).
- An explicit `targets = []` is rejected at plan time; without that it would apply and then fail with "Provider produced inconsistent result after apply" once the backend injected its default.
- Validators aligned with [coralogix-operator#545](https://github.com/coralogix/coralogix-operator/pull/545).

**Also fixed here:**
- `targets[*].priority_override.usage_tiers[*].daily_quota_percentage` is bounded to `0`–`100`, matching the policy-level field it was copied from.

**Known backend issue, deliberately not worked around here.** Setting `quota_based_priority_override` without a policy-level `priority` is accepted by the API, which then silently computes `block` as the fallback and returns it. Terraform sees a value on a field the config left null and fails with `Provider produced inconsistent result after apply`. The failure is sticky: the policy is created, so state holds `block` while config holds null, and each subsequent plan fails the same way until `priority` is added to the config. Set `priority` explicitly alongside `quota_based_priority_override` to avoid it. This is being raised with the backend rather than papered over with a provider-side validator, which would block the shape once the API stops mutating it.

<details>
<summary>How the injected default is recognised</summary>

An injected target is shaped exactly like a real one — `{dataset: "logs", dataspace: "default", priority: …}` — and `"logs"` is a perfectly legal dataset for a user to target, so it cannot be identified by inspection.

An earlier revision resolved this by carrying the `targets` value already recorded for each policy (from the plan on create/update, prior state on read) and treating a null as "the user configured none". That matched prior state to the API response **by list position**, which misaligns when policies are inserted or reordered outside Terraform.

The current implementation needs no prior state. The API enforces two rules:

```
priority/priorityOverride must be set either at the policy level or per-target, not both.

A priority is required: set the policy priority (or a quota-based priority override),
or provide targets that each specify a priority.
```

Together they make the policy's own priority a witness — a policy carrying a policy-level priority or override provably has no user-configured targets, and a policy carrying neither must have real ones:

```go
func targetsAreBackendInjected(policy tcoPolicys.Policy) bool {
	return policy.GetPriority() != tcoPolicys.QUOTAV1PRIORITY_PRIORITY_TYPE_UNSPECIFIED ||
		policy.PriorityOverride != nil
}
```

Create, update, read, import and the data source share one path, with no dependence on prior state or ordering.
</details>

<details>
<summary>Why <code>targets</code> is not <code>Optional+Computed</code></summary>

An earlier revision made `targets` `Optional+Computed` with `UseStateForUnknown`, which let the injected default land in state and then re-plan as `(known after apply)`. That failed `TestAccCoralogixDataSourceTCOPoliciesLogs_basic` with a non-empty second plan:

```
~ targets = [{dataset = "logs"}] -> (known after apply)
```

As a plain `Optional` attribute, `targets` takes its planned value straight from config and can never go unknown, regardless of how sibling computed fields (`id`, `order`) plan.

That also removed the machinery the earlier revision had accumulated: `ModifyPlan`, `normalizePlanTargetPriorities`, `policyElementChanged`, and the loop in `extractTcoPolicyLog` that nulled target priorities before sending. The plan modifiers it had added to `id` and `order` are reverted to `master`'s plain `Computed` — those fields are pre-existing and out of scope.
</details>

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? — not on the latest revision locally; relying on CI, plus the manual validation below.

New coverage: per-target `priority_override` (shipped untested by the earlier revision), and assertions that the injected default never reaches state.

<details>
<summary>Manual validation on EU2</summary>

Run against a live EU2 account via `dev_overrides`; the account was left in its original state afterwards.

| Check | Result |
|---|---|
| No-targets policies → apply | `targets = null` in state; second plan `No changes.` |
| Backend injection actually occurs | Data source confirmed `{dataset:"logs", dataspace:"default", priority:<policy priority>}` is stored |
| Targets + no-targets policies in one apply | Both round-trip exactly; second plan clean |
| Change one target's `priority` | Only that change planned; third plan clean |
| Remove the `targets` block | Clears back to null; next plan clean |
| Import (mixed config) | Real targets survive, injected default absent, **plan clean with no reconcile apply** |
| Per-target `priority_override` | Applies and round-trips; second plan clean |
| Policy-level + per-target priority together | `400 FAILED_PRECONDITION: priority/priorityOverride must be set either at the policy level or per-target, not both.` State survived the failed apply intact |
| Neither `priority` nor `targets` | `400 FAILED_PRECONDITION: A priority is required: set the policy priority (or a quota-based priority override), or provide targets that each specify a priority.` |
| Policy-level override **+** targets | Same "not both" 400 — confirms the rule covers `priorityOverride` |
| Target with no `priority` | Rejected at plan time |
| `targets = []` | Rejected at plan time |
| Target tier `daily_quota_percentage = 150` | Rejected at plan time: `value must be between 0.000000 and 100.000000` |
| `quota_based_priority_override` without `priority` | API accepts and returns a computed `block`; apply fails with `Provider produced inconsistent result after apply` — the backend issue noted above, left unmasked |

</details>

### Release Note

```release-note
resource/coralogix_tco_policies_logs: Add `targets` to route matched logs to specific named datasets. Each target requires its own `priority`. Policy-level `priority` is now optional; omit it when `targets` is set.
```

### References
CX-51353

Supersedes #617 (same branch and commits; reopened as a fresh PR to drop a long review thread).

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
