### PR TITLE
feat(dashboards): add cross-dashboard widget reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 #### resource/coralogix_dashboard
+- FEAT: Add `reference` on widgets to reuse a widget from another dashboard by `dashboard_id` and `widget_id`. Exactly one of `definition` or `reference` must be set.
 - CHORE: Use the shared SDK `dashboardjson.Unmarshal` helper for `content_json` (snake_case aliases, unknown-key discard) instead of a local copy. Create/replace no longer re-strip unknowns; that happens in Unmarshal, as in the operator.
 - FIX: Adding a section, row, widget or annotation without an `id` no longer fails with "Provider produced inconsistent result after apply". Generated `id` fields (section, row, widget, line-chart `query_definitions[].id`, data-table aggregation, annotation) and widget `width` now use `UseNonNullStateForUnknown` so new nested elements stay `(known after apply)` instead of planning as null.
 - FEAT: Add support for `dataprime` and `event_recurrence` annotation source types. Dashboards using DataPrime queries or recurring calendar events as annotation sources can now be authored and round-tripped through Terraform.

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -651,10 +651,11 @@ Read-Only:
 
 Read-Only:
 
-- `definition` (Attributes) The widget definition. Can contain one of [data_table gauge hexagon line_chart pie_chart bar_chart horizontal_bar_chart markdown] (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition))
+- `definition` (Attributes) Inline widget definition. Can contain one of [data_table gauge hexagon line_chart pie_chart bar_chart horizontal_bar_chart markdown]. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition))
 - `description` (String) Widget description.
 - `id` (String)
-- `title` (String) Widget title. Required for all widgets except markdown.
+- `reference` (Attributes) Reference to a widget on another dashboard. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--reference))
+- `title` (String) Widget title. Required for all inline widgets except markdown.
 - `width` (Number) Deprecated: the widget appearance.width field is ignored by the API and has no effect.
 
 <a id="nestedatt--layout--sections--rows--widgets--definition"></a>
@@ -3598,6 +3599,15 @@ Read-Only:
 - `stack_name_template` (String)
 
 
+
+
+<a id="nestedatt--layout--sections--rows--widgets--reference"></a>
+### Nested Schema for `layout.sections.rows.widgets.reference`
+
+Read-Only:
+
+- `dashboard_id` (String) ID of the dashboard that owns the source widget.
+- `widget_id` (String) ID of the source widget within the referenced dashboard.
 
 
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -762,6 +762,30 @@ resource "coralogix_dashboard" "widgets" {
   }
 }
 
+# Cross-dashboard widget reference: reuse a widget from another dashboard by ID.
+resource "coralogix_dashboard" "dashboard_with_widget_reference" {
+  name        = "portal monitoring shared"
+  description = "Dashboard that reuses a widget from coralogix_dashboard.dashboard"
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+  layout = {
+    sections = [{
+      rows = [{
+        height = 19
+        widgets = [{
+          reference = {
+            dashboard_id = coralogix_dashboard.dashboard.id
+            widget_id    = coralogix_dashboard.dashboard.layout.sections[0].rows[0].widgets[0].id
+          }
+        }]
+      }]
+    }]
+  }
+}
+
 resource "coralogix_dashboard" "dashboard_from_json_with_folder" {
   content_json = file("./dashboard.json")
   folder = {
@@ -1452,15 +1476,13 @@ Optional:
 <a id="nestedatt--layout--sections--rows--widgets"></a>
 ### Nested Schema for `layout.sections.rows.widgets`
 
-Required:
-
-- `definition` (Attributes) The widget definition. Can contain one of [data_table gauge hexagon line_chart pie_chart bar_chart horizontal_bar_chart markdown] (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition))
-
 Optional:
 
+- `definition` (Attributes) Inline widget definition. Can contain one of [data_table gauge hexagon line_chart pie_chart bar_chart horizontal_bar_chart markdown]. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition))
 - `description` (String) Widget description.
 - `id` (String)
-- `title` (String) Widget title. Required for all widgets except markdown.
+- `reference` (Attributes) Reference to a widget on another dashboard. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--reference))
+- `title` (String) Widget title. Required for all inline widgets except markdown.
 - `width` (Number, Deprecated) Deprecated: the widget appearance.width field is ignored by the API and has no effect.
 
 <a id="nestedatt--layout--sections--rows--widgets--definition"></a>
@@ -4719,6 +4741,15 @@ Optional:
 - `stack_name_template` (String)
 
 
+
+
+<a id="nestedatt--layout--sections--rows--widgets--reference"></a>
+### Nested Schema for `layout.sections.rows.widgets.reference`
+
+Required:
+
+- `dashboard_id` (String) ID of the dashboard that owns the source widget.
+- `widget_id` (String) ID of the source widget within the referenced dashboard.
 
 
 

--- a/examples/resources/coralogix_dashboard/resource.tf
+++ b/examples/resources/coralogix_dashboard/resource.tf
@@ -747,6 +747,30 @@ resource "coralogix_dashboard" "widgets" {
   }
 }
 
+# Cross-dashboard widget reference: reuse a widget from another dashboard by ID.
+resource "coralogix_dashboard" "dashboard_with_widget_reference" {
+  name        = "portal monitoring shared"
+  description = "Dashboard that reuses a widget from coralogix_dashboard.dashboard"
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+  layout = {
+    sections = [{
+      rows = [{
+        height = 19
+        widgets = [{
+          reference = {
+            dashboard_id = coralogix_dashboard.dashboard.id
+            widget_id    = coralogix_dashboard.dashboard.layout.sections[0].rows[0].widgets[0].id
+          }
+        }]
+      }]
+    }]
+  }
+}
+
 resource "coralogix_dashboard" "dashboard_from_json_with_folder" {
   content_json = file("./dashboard.json")
   folder = {

--- a/internal/provider/dashboards/dashboard_oneof_validation_test.go
+++ b/internal/provider/dashboards/dashboard_oneof_validation_test.go
@@ -231,8 +231,8 @@ func TestDashboardWidgetDefinitionExactlyOneOfAtFullSchemaLevel(t *testing.T) {
 	if !ok {
 		t.Fatal("widget definition is not a single nested attribute")
 	}
-	if !definition.Required {
-		t.Fatal("widget definition is not Required; the zero-set case below would not be a distinct, reachable state")
+	if !definition.Optional {
+		t.Fatal("widget definition is not Optional; reference widgets omit definition")
 	}
 
 	definitionPath := path.Root("definition")

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -109,7 +109,7 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 													},
 													"title": schema.StringAttribute{
 														Optional:            true,
-														MarkdownDescription: "Widget title. Required for all widgets except markdown.",
+														MarkdownDescription: "Widget title. Required for all inline widgets except markdown.",
 													},
 													"description": schema.StringAttribute{
 														Optional:            true,

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -116,7 +116,7 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 														MarkdownDescription: "Widget description.",
 													},
 													"definition": schema.SingleNestedAttribute{
-														Required: true,
+														Optional: true,
 														Attributes: map[string]schema.Attribute{
 															"line_chart": dashboardwidgets.LineChartSchema(),
 															"hexagon":    dashboardwidgets.HexagonSchema(),
@@ -837,10 +837,24 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																Optional: true,
 															},
 														},
-														MarkdownDescription: fmt.Sprintf("The widget definition. Can contain one of %v", dashboardwidgets.SupportedWidgetTypes),
+														MarkdownDescription: fmt.Sprintf("Inline widget definition. Can contain one of %v. Exactly one of `definition` or `reference` must be set.", dashboardwidgets.SupportedWidgetTypes),
 														Validators: []validator.Object{
 															dashboardwidgets.SupportedWidgetsExactlyOneOfChildren(),
 														},
+													},
+													"reference": schema.SingleNestedAttribute{
+														Optional: true,
+														Attributes: map[string]schema.Attribute{
+															"dashboard_id": schema.StringAttribute{
+																Required:            true,
+																MarkdownDescription: "ID of the dashboard that owns the source widget.",
+															},
+															"widget_id": schema.StringAttribute{
+																Required:            true,
+																MarkdownDescription: "ID of the source widget within the referenced dashboard.",
+															},
+														},
+														MarkdownDescription: "Reference to a widget on another dashboard. Exactly one of `definition` or `reference` must be set.",
 													},
 													"width": schema.Int64Attribute{
 														Optional: true,
@@ -851,6 +865,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 														DeprecationMessage:  "Widget appearance.width is ignored by the API and has no effect.",
 														MarkdownDescription: "Deprecated: the widget appearance.width field is ignored by the API and has no effect.",
 													},
+												},
+												Validators: []validator.Object{
+													dashboardwidgets.ExactlyOneOfChildren("definition", "reference"),
 												},
 											},
 											Validators: []validator.List{

--- a/internal/provider/dashboards/dashboard_widget_reference_test.go
+++ b/internal/provider/dashboards/dashboard_widget_reference_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+	dashboardschema "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema"
+	dashboardwidgets "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_widgets"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestDashboardWidgetDefinitionOrReferenceExactlyOneOf(t *testing.T) {
+	ctx := context.Background()
+	root := dashboardschema.V4()
+	widgetsAttr := dashboardResolveAttribute(t, root.Attributes, "layout", "sections", "rows", "widgets")
+	widgets, ok := widgetsAttr.(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatal("widgets is not a list nested attribute")
+	}
+
+	widgetPath := path.Root("widgets").AtListIndex(0)
+	validators := widgets.NestedObject.Validators
+
+	t.Run("both_definition_and_reference_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, widgets.NestedObject.Type(), "definition", "reference")
+		diagnostics := dashboardValidateObject(t, ctx, cfg, widgetPath, validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		dashboardRequireDetailNames(t, diagnostics[0].detail, "definition", "reference")
+	})
+
+	t.Run("neither_definition_nor_reference_set", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, widgets.NestedObject.Type())
+		diagnostics := dashboardValidateObject(t, ctx, cfg, widgetPath, validators)
+		if len(diagnostics) != 1 {
+			t.Fatalf("diagnostics = %d, want 1: %v", len(diagnostics), diagnostics)
+		}
+		if !strings.Contains(diagnostics[0].detail, "No attribute was configured") {
+			t.Fatalf("unexpected diagnostic: %s", diagnostics[0].detail)
+		}
+	})
+
+	t.Run("reference_only_is_valid", func(t *testing.T) {
+		cfg := dashboardObjectConfig(ctx, t, widgets.NestedObject.Type(), "reference")
+		diagnostics := dashboardValidateObject(t, ctx, cfg, widgetPath, validators)
+		if len(diagnostics) != 0 {
+			t.Fatalf("expected no diagnostics for reference-only widget, got: %v", diagnostics)
+		}
+	})
+}
+
+func TestExpandFlattenWidgetReferenceRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dashboardID := "abcdefghijklmnopqrstu"
+	widgetID := "83aed974-510b-43be-bd19-c92daf56beff"
+	localID := "11111111-2222-3333-4444-555555555555"
+	title := "local-title"
+	description := "local-description"
+
+	expanded, diags := expandWidget(ctx, WidgetModel{
+		ID:          types.StringValue(localID),
+		Title:       types.StringValue(title),
+		Description: types.StringValue(description),
+		Width:       types.Int64Value(4),
+		Reference: &WidgetReferenceModel{
+			DashboardID: types.StringValue(dashboardID),
+			WidgetID:    types.StringValue(widgetID),
+		},
+	})
+	dashboardRequireNoDiags(t, diags, "expandWidget")
+	dashboardRequireExpandedReference(t, expanded, dashboardID, widgetID, title, description)
+
+	flattened, diags := flattenDashboardWidget(ctx, expanded)
+	dashboardRequireNoDiags(t, diags, "flattenDashboardWidget")
+	dashboardRequireFlattenedReference(t, flattened, localID, dashboardID, widgetID, title, description)
+}
+
+func dashboardRequireNoDiags(t *testing.T, diags interface{ HasError() bool }, label string) {
+	t.Helper()
+	if diags.HasError() {
+		t.Fatalf("%s: %v", label, diags)
+	}
+}
+
+func dashboardRequireExpandedReference(t *testing.T, expanded *dashboardservice.Widget, dashboardID, widgetID, title, description string) {
+	t.Helper()
+	if expanded.Definition != nil {
+		t.Fatal("expected Definition to be nil for reference widgets")
+	}
+	if expanded.Title == nil || *expanded.Title != title {
+		t.Fatalf("expected title %q, got %#v", title, expanded.Title)
+	}
+	if expanded.Description == nil || *expanded.Description != description {
+		t.Fatalf("expected description %q, got %#v", description, expanded.Description)
+	}
+	if expanded.Reference == nil || expanded.Reference.GetDashboardId() != dashboardID {
+		t.Fatalf("unexpected reference dashboard id: %#v", expanded.Reference)
+	}
+	if expanded.Reference.WidgetId == nil || expanded.Reference.WidgetId.Value == nil || *expanded.Reference.WidgetId.Value != widgetID {
+		t.Fatalf("unexpected reference widget id: %#v", expanded.Reference.WidgetId)
+	}
+}
+
+func dashboardRequireFlattenedReference(t *testing.T, flattened *WidgetModel, localID, dashboardID, widgetID, title, description string) {
+	t.Helper()
+	if flattened.Definition != nil {
+		t.Fatal("flatten must not invent a definition from a reference")
+	}
+	if flattened.Title.ValueString() != title {
+		t.Fatalf("title = %q, want %q", flattened.Title.ValueString(), title)
+	}
+	if flattened.Description.ValueString() != description {
+		t.Fatalf("description = %q, want %q", flattened.Description.ValueString(), description)
+	}
+	if flattened.Reference == nil {
+		t.Fatal("expected reference in flattened state")
+	}
+	if flattened.Reference.DashboardID.ValueString() != dashboardID {
+		t.Fatalf("dashboard_id = %q, want %q", flattened.Reference.DashboardID.ValueString(), dashboardID)
+	}
+	if flattened.Reference.WidgetID.ValueString() != widgetID {
+		t.Fatalf("widget_id = %q, want %q", flattened.Reference.WidgetID.ValueString(), widgetID)
+	}
+	if flattened.ID.ValueString() != localID {
+		t.Fatalf("local id = %q, want %q", flattened.ID.ValueString(), localID)
+	}
+}
+
+func TestFlattenWidgetReferenceOnly(t *testing.T) {
+	ctx := context.Background()
+	dashboardID := "abcdefghijklmnopqrstu"
+	widgetID := "83aed974-510b-43be-bd19-c92daf56beff"
+	localID := "11111111-2222-3333-4444-555555555555"
+
+	ref := dashboardservice.NewWidgetReference()
+	ref.SetDashboardId(dashboardID)
+	ref.SetWidgetId(dashboardservice.UUID{Value: &widgetID})
+
+	widget := &dashboardservice.Widget{
+		Id:        &dashboardservice.UUID{Value: &localID},
+		Reference: ref,
+	}
+
+	flattened, diags := flattenDashboardWidget(ctx, widget)
+	if diags.HasError() {
+		t.Fatalf("flattenDashboardWidget: %v", diags)
+	}
+	if flattened.Definition != nil {
+		t.Fatal("expected definition nil when API returns only a reference")
+	}
+	if flattened.Reference == nil || flattened.Reference.DashboardID.ValueString() != dashboardID {
+		t.Fatalf("expected reference preserve, got %#v", flattened.Reference)
+	}
+}
+
+func TestExpandFlattenInlineDefinitionStillWorks(t *testing.T) {
+	ctx := context.Background()
+	markdownText := "hello"
+	expanded, diags := expandWidget(ctx, WidgetModel{
+		ID:    types.StringValue("11111111-2222-3333-4444-555555555555"),
+		Title: types.StringNull(),
+		Definition: &dashboardwidgets.WidgetDefinitionModel{
+			Markdown: &dashboardwidgets.MarkdownModel{
+				MarkdownText: types.StringValue(markdownText),
+				TooltipText:  types.StringNull(),
+			},
+		},
+		Width: types.Int64Value(0),
+	})
+	if diags.HasError() {
+		t.Fatalf("expandWidget: %v", diags)
+	}
+	if expanded.Reference != nil {
+		t.Fatal("expected Reference nil for inline definition")
+	}
+	if expanded.Definition == nil || expanded.Definition.Markdown == nil {
+		t.Fatal("expected markdown definition")
+	}
+
+	flattened, diags := flattenDashboardWidget(ctx, expanded)
+	if diags.HasError() {
+		t.Fatalf("flattenDashboardWidget: %v", diags)
+	}
+	if flattened.Reference != nil {
+		t.Fatal("expected Reference nil after flatten of inline widget")
+	}
+	if flattened.Definition == nil || flattened.Definition.Markdown == nil {
+		t.Fatal("expected markdown definition after flatten")
+	}
+	if flattened.Definition.Markdown.MarkdownText.ValueString() != markdownText {
+		t.Fatalf("markdown_text = %q, want %q", flattened.Definition.Markdown.MarkdownText.ValueString(), markdownText)
+	}
+}

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -112,11 +112,17 @@ type RowModel struct {
 	Widgets types.List   `tfsdk:"widgets"` //WidgetModel
 }
 
+type WidgetReferenceModel struct {
+	DashboardID types.String `tfsdk:"dashboard_id"`
+	WidgetID    types.String `tfsdk:"widget_id"`
+}
+
 type WidgetModel struct {
 	ID          types.String                            `tfsdk:"id"`
 	Title       types.String                            `tfsdk:"title"`
 	Description types.String                            `tfsdk:"description"`
 	Definition  *dashboardwidgets.WidgetDefinitionModel `tfsdk:"definition"`
+	Reference   *WidgetReferenceModel                   `tfsdk:"reference"`
 	Width       types.Int64                             `tfsdk:"width"`
 }
 
@@ -2003,13 +2009,23 @@ func expandDashboardWidgets(ctx context.Context, widgets types.List) ([]dashboar
 
 func expandWidget(ctx context.Context, widget WidgetModel) (*dashboardservice.Widget, diag.Diagnostics) {
 	id := dashboardwidgets.ExpandDashboardUUID(widget.ID)
-
 	title := utils.TypeStringToStringPointer(widget.Title)
 	description := utils.TypeStringToStringPointer(widget.Description)
 	appearance := &dashboardservice.WidgetAppearance{
 		Width: typeInt64ToInt32Pointer(widget.Width),
 	}
-	definition, diags := expandWidgetDefinition(ctx, widget.Definition)
+
+	var definition *dashboardservice.WidgetDefinition
+	var diags diag.Diagnostics
+	if widget.Definition != nil {
+		definition, diags = expandWidgetDefinition(ctx, widget.Definition)
+		if diags.HasError() {
+			return nil, diags
+		}
+	}
+
+	reference, refDiags := expandWidgetReference(widget.Reference)
+	diags.Append(refDiags...)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -2020,7 +2036,24 @@ func expandWidget(ctx context.Context, widget WidgetModel) (*dashboardservice.Wi
 		Description: description,
 		Appearance:  appearance,
 		Definition:  definition,
+		Reference:   reference,
 	}, nil
+}
+
+func expandWidgetReference(reference *WidgetReferenceModel) (*dashboardservice.WidgetReference, diag.Diagnostics) {
+	if reference == nil {
+		return nil, nil
+	}
+
+	expanded := dashboardservice.NewWidgetReference()
+	if !reference.DashboardID.IsNull() && !reference.DashboardID.IsUnknown() {
+		expanded.SetDashboardId(reference.DashboardID.ValueString())
+	}
+	if !reference.WidgetID.IsNull() && !reference.WidgetID.IsUnknown() {
+		widgetID := dashboardservice.UUID{Value: reference.WidgetID.ValueStringPointer()}
+		expanded.SetWidgetId(widgetID)
+	}
+	return expanded, nil
 }
 
 func expandWidgetDefinition(ctx context.Context, definition *dashboardwidgets.WidgetDefinitionModel) (*dashboardservice.WidgetDefinition, diag.Diagnostics) {
@@ -4269,6 +4302,12 @@ func widgetModelAttr() map[string]attr.Type {
 				},
 			},
 		},
+		"reference": types.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"dashboard_id": types.StringType,
+				"widget_id":    types.StringType,
+			},
+		},
 		"width": types.Int64Type,
 	}
 }
@@ -4803,7 +4842,18 @@ func flattenDashboardWidget(ctx context.Context, widget *dashboardservice.Widget
 		Description: utils.StringPointerToTypeString(widget.Description),
 		Width:       int32PointerToTypeInt64(widget.GetAppearance().Width),
 		Definition:  definition,
+		Reference:   flattenWidgetReference(widget.Reference),
 	}, nil
+}
+
+func flattenWidgetReference(reference *dashboardservice.WidgetReference) *WidgetReferenceModel {
+	if reference == nil {
+		return nil
+	}
+	return &WidgetReferenceModel{
+		DashboardID: utils.StringPointerToTypeString(reference.DashboardId),
+		WidgetID:    uuidToTypeString(reference.WidgetId),
+	}
 }
 
 func flattenDashboardWidgetDefinition(ctx context.Context, definition *dashboardservice.WidgetDefinition) (*dashboardwidgets.WidgetDefinitionModel, diag.Diagnostics) {

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -550,6 +550,97 @@ EOT
 	})
 }
 
+func TestAccCoralogixResourceDashboardWidgetReference(t *testing.T) {
+	sourceName := dashboardOpenAPIFixtureName(t.Name() + "-source")
+	consumerName := dashboardOpenAPIFixtureName(t.Name() + "-consumer")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceDashboardWidgetReference(sourceName, consumerName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("coralogix_dashboard.source", "id"),
+					resource.TestCheckResourceAttrSet("coralogix_dashboard.source", "layout.sections.0.rows.0.widgets.0.id"),
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.reference.dashboard_id"),
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.reference.widget_id"),
+					resource.TestCheckResourceAttrPair(
+						dashboardResourceName, "layout.sections.0.rows.0.widgets.0.reference.dashboard_id",
+						"coralogix_dashboard.source", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						dashboardResourceName, "layout.sections.0.rows.0.widgets.0.reference.widget_id",
+						"coralogix_dashboard.source", "layout.sections.0.rows.0.widgets.0.id",
+					),
+					resource.TestCheckNoResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:      dashboardResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceDashboardWidgetReference(sourceName, consumerName string) string {
+	return fmt.Sprintf(`resource "coralogix_dashboard" "source" {
+  name        = %q
+  description = "source dashboard for widget reference"
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+  layout = {
+    sections = [{
+      rows = [{
+        height = 19
+        widgets = [{
+          definition = {
+            markdown = {
+              markdown_text = "shared widget"
+            }
+          }
+        }]
+      }]
+    }]
+  }
+}
+
+resource "coralogix_dashboard" "test" {
+  name        = %q
+  description = "consumer dashboard with widget reference"
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+  layout = {
+    sections = [{
+      rows = [{
+        height = 19
+        widgets = [{
+          reference = {
+            dashboard_id = coralogix_dashboard.source.id
+            widget_id    = coralogix_dashboard.source.layout.sections[0].rows[0].widgets[0].id
+          }
+        }]
+      }]
+    }]
+  }
+}
+`, sourceName, consumerName)
+}
+
 func TestAccCoralogixResourceDashboardGaugeWidgetThresholdType(t *testing.T) {
 	name := dashboardOpenAPIFixtureName(t.Name())
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
### Description

Adds support for cross-dashboard widget reuse on `coralogix_dashboard`. A widget can set `reference` with `dashboard_id` and `widget_id` instead of an inline `definition`. Exactly one of those two blocks is required. Local `title` and `description` on the reference widget are supported and round-trip without drift.

### Release Note
```
FEAT: Add `reference` on widgets to reuse a widget from another dashboard by `dashboard_id` and `widget_id`. Exactly one of `definition` or `reference` must be set.
```