### PR TITLE
Move group name lookup to OpenAPI and fix REST NotFound handling

### DIFF
--- a/.claude/skills/rest-client-not-found-detection/SKILL.md
+++ b/.claude/skills/rest-client-not-found-detection/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: rest-client-not-found-detection
+description: "Use when a REST-backed resource (SCIM group/user, Grafana) fails to soft-delete on 404, or when cxsdk.Code returns Unknown for a status.Error from rest/client.go. Check with status.Code, not cxsdk.Code. Do NOT wrap REST errors in SdkAPIError just to force cxsdk.Code."
+---
+
+# REST clients return bare status errors — use status.Code
+
+**Trigger:** A read/delete path for SCIM groups, SCIM users, or Grafana uses `cxsdk.Code(err) == codes.NotFound`, but the branch never runs for a real 404.
+
+**Fix:** Keep `rest/client.go` returning a bare status error, and check with `status.Code`:
+
+```go
+// internal/clientset/rest/client.go
+return "", status.Error(codes.NotFound, "Not found")
+
+// call site
+if status.Code(err) == codes.NotFound { ... RemoveResource }
+```
+
+**Why:** `cxsdk.Code` only unwraps `*cxsdk.SdkAPIError` (SDK gRPC clients). The hand-rolled REST client returns a plain `status.Error`. Matching pair is `status.Code`. Wrapping REST errors in `SdkAPIError` only to keep `cxsdk.Code` is unnecessary.
+
+**Trap:** Do not mix them. After a wrap, `status.Code` returns `Unknown`. After no wrap, `cxsdk.Code` returns `Unknown`. OpenAPI facade clients are separate — use `cxsdkOpenapi.IsNotFound`.

--- a/.claude/skills/rest-client-not-found-detection/SKILL.md
+++ b/.claude/skills/rest-client-not-found-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rest-client-not-found-detection
-description: "Use when a REST-backed resource (SCIM group/user, Grafana) fails to soft-delete on 404, or when cxsdk.Code returns Unknown for a status.Error from rest/client.go. Check with status.Code, not cxsdk.Code. Do NOT wrap REST errors in SdkAPIError just to force cxsdk.Code."
+description: "Use when a REST-backed resource (SCIM group/user, Grafana) fails to soft-delete on 404, or when cxsdk.Code returns Unknown for a status.Error from rest/client.go."
 ---
 
 # REST clients return bare status errors — use status.Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,22 @@
 - FIX: Schema v0→v1 state upgrade converts `permutations.limit` from string to int64 so pre-v1 state loads.
 - FIX: Omitted `metric_fields.*.aggregations` children no longer fail after apply when the API returns the full aggregation set. Those attributes now use `UseNonNullStateForUnknown`.
 
+#### data-source/coralogix_group
+- CHORE: Lookup by `display_name` no longer uses the gRPC API.
+- FIX: A group that is not on the first page of results can now be found by `display_name`.
+
+#### resource/coralogix_group
+- FIX: A group deleted outside Terraform is now removed from state on read instead of failing with an error.
+
+#### resource/coralogix_user
+- FIX: A user deleted outside Terraform is now removed from state on read instead of failing with an error.
+
+#### resource/coralogix_grafana_folder
+- FIX: A folder that is already gone is treated as deleted instead of failing with an error.
+
 #### provider
 - CHORE: Bump `terraform-plugin-framework` to v1.17.0.
+- CHORE: SCIM users and groups now use `api.<domain>` instead of `ng-api-http.<domain>`.
 
 # Release 3.8.0
 

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -48,6 +48,7 @@ import (
 	prgs "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/rule_groups_service"
 	scopess "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/scopes_service"
 	archiveLogs "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/target_service"
+	teamGroupss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/team_groups_management_service"
 
 	slos "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/slos_service"
 )
@@ -59,7 +60,6 @@ type ClientSet struct {
 	ruleGroups     *cxsdk.RuleGroupsClient
 	users          *UsersClient
 	events2Metrics *e2ms.Events2MetricsServiceAPIService
-	groupGrpc      *cxsdk.GroupsClient
 	teams          *cxsdk.TeamsClient
 
 	dahboardsFolders      *dbfs.DashboardFoldersServiceAPIService
@@ -90,6 +90,7 @@ type ClientSet struct {
 	aiEvaluations         *aievaluations.AIEvaluationsServiceAPIService
 	grafana               *GrafanaClient
 	groups                *GroupsClient
+	teamGroups            *teamGroupss.TeamGroupsManagementServiceAPIService
 }
 
 func (c *ClientSet) ParsingRuleGroups() *prgs.RuleGroupsServiceAPIService {
@@ -204,8 +205,8 @@ func (c *ClientSet) IpAccess() *ipaccess.IPAccessServiceAPIService {
 	return c.ipaccess
 }
 
-func (c *ClientSet) GroupGrpc() *cxsdk.GroupsClient {
-	return c.groupGrpc
+func (c *ClientSet) TeamGroups() *teamGroupss.TeamGroupsManagementServiceAPIService {
+	return c.teamGroups
 }
 
 func (c *ClientSet) GetNotifications() (*connectors.ConnectorsServiceAPIService, *globalRouters.GlobalRoutersServiceAPIService, *presets.PresetsServiceAPIService) {
@@ -260,7 +261,6 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 		users: NewUsersClient(region, apiKey),
 
 		events2Metrics: cs.Events2Metrics(),
-		groupGrpc:      cxsdk.NewGroupsClient(grpcCreator),
 
 		dahboardsFolders:      cs.DashboardFolders(),
 		parsingRuleGroups:     cs.RuleGroups(),
@@ -290,5 +290,6 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 		alertScheduler:        cs.AlertScheduler(),
 		grafana:               NewGrafanaClient(apikeyCPC),
 		groups:                NewGroupsClient(region, apiKey),
+		teamGroups:            cs.Groups(),
 	}
 }

--- a/internal/clientset/clientset_test.go
+++ b/internal/clientset/clientset_test.go
@@ -26,7 +26,10 @@ func TestNewClientSet_UsersClientNotNil(t *testing.T) {
 	if cs.Dashboards() == nil {
 		t.Fatal("Dashboards() must not be nil")
 	}
-	if cs.Users().BaseURL() != "https://ng-api-http.eu2.coralogix.com/scim/Users" {
+	if cs.TeamGroups() == nil {
+		t.Fatal("TeamGroups() must not be nil")
+	}
+	if cs.Users().BaseURL() != "https://api.eu2.coralogix.com/scim/Users" {
 		t.Fatalf("Users().BaseURL() = %q", cs.Users().BaseURL())
 	}
 

--- a/internal/clientset/endpoints.go
+++ b/internal/clientset/endpoints.go
@@ -35,7 +35,8 @@ func GrpcTargetFromDomain(domain string) string {
 
 // ScimRestBaseURL returns the HTTPS base URL for SCIM REST APIs (users, groups) for the
 // given provider env or domain. PrivateLink management hosts use api.private.* directly;
-// public regions use ng-api-http.* (matching coralogix-management-sdk CoralogixRestEndpointFromRegion).
+// public regions use api.* (same host family as the OpenAPI management clients).
+// Note: CoralogixRestEndpointFromRegion still returns ng-api-http.*; SCIM is on api.*.
 func ScimRestBaseURL(regionOrDomain string) string {
 	regionOrDomain = normalizeProviderDomain(regionOrDomain)
 	if strings.HasPrefix(regionOrDomain, "api.private.") {
@@ -44,23 +45,25 @@ func ScimRestBaseURL(regionOrDomain string) string {
 
 	switch strings.ToLower(regionOrDomain) {
 	case "us1", "usa1":
-		return "https://ng-api-http.coralogix.us"
+		return "https://api.coralogix.us"
 	case "us2", "usa2":
-		return "https://ng-api-http.cx498.coralogix.com"
+		return "https://api.cx498.coralogix.com"
 	case "us3", "usa3":
-		return "https://ng-api-http.us3.coralogix.com"
+		return "https://api.us3.coralogix.com"
 	case "eu1", "europe1":
-		return "https://ng-api-http.coralogix.com"
+		return "https://api.coralogix.com"
 	case "eu2", "europe2":
-		return "https://ng-api-http.eu2.coralogix.com"
+		return "https://api.eu2.coralogix.com"
 	case "ap1", "apac1":
-		return "https://ng-api-http.app.coralogix.in"
+		return "https://api.app.coralogix.in"
 	case "ap2", "apac2":
-		return "https://ng-api-http.coralogixsg.com"
+		return "https://api.coralogixsg.com"
 	case "ap3", "apac3":
-		return "https://ng-api-http.ap3.coralogix.com"
+		return "https://api.ap3.coralogix.com"
 	default:
-		return fmt.Sprintf("https://ng-api-http.%s", regionOrDomain)
+		// Mirrors the SDK's normalizeCoralogixDomain: a domain that already carries the
+		// api. prefix must not become api.api.<domain>.
+		return fmt.Sprintf("https://api.%s", strings.TrimPrefix(regionOrDomain, "api."))
 	}
 }
 

--- a/internal/clientset/endpoints_test.go
+++ b/internal/clientset/endpoints_test.go
@@ -58,14 +58,36 @@ func TestScimRestBaseURL(t *testing.T) {
 		regionOrDomain string
 		want           string
 	}{
-		{
-			regionOrDomain: "api.private.eu2.coralogix.com",
-			want:           "https://api.private.eu2.coralogix.com",
-		},
-		{
-			regionOrDomain: "EU2",
-			want:           "https://ng-api-http.eu2.coralogix.com",
-		},
+		// All 8 regions, short and long aliases.
+		{regionOrDomain: "us1", want: "https://api.coralogix.us"},
+		{regionOrDomain: "usa1", want: "https://api.coralogix.us"},
+		{regionOrDomain: "us2", want: "https://api.cx498.coralogix.com"},
+		{regionOrDomain: "usa2", want: "https://api.cx498.coralogix.com"},
+		{regionOrDomain: "us3", want: "https://api.us3.coralogix.com"},
+		{regionOrDomain: "usa3", want: "https://api.us3.coralogix.com"},
+		{regionOrDomain: "eu1", want: "https://api.coralogix.com"},
+		{regionOrDomain: "europe1", want: "https://api.coralogix.com"},
+		{regionOrDomain: "eu2", want: "https://api.eu2.coralogix.com"},
+		{regionOrDomain: "europe2", want: "https://api.eu2.coralogix.com"},
+		{regionOrDomain: "ap1", want: "https://api.app.coralogix.in"},
+		{regionOrDomain: "apac1", want: "https://api.app.coralogix.in"},
+		{regionOrDomain: "ap2", want: "https://api.coralogixsg.com"},
+		{regionOrDomain: "apac2", want: "https://api.coralogixsg.com"},
+		{regionOrDomain: "ap3", want: "https://api.ap3.coralogix.com"},
+		{regionOrDomain: "apac3", want: "https://api.ap3.coralogix.com"},
+		// Region codes are case-insensitive.
+		{regionOrDomain: "EU2", want: "https://api.eu2.coralogix.com"},
+		{regionOrDomain: "EUROPE2", want: "https://api.eu2.coralogix.com"},
+		// Custom domains get the api. prefix.
+		{regionOrDomain: "custom.example.com", want: "https://api.custom.example.com"},
+		// A domain that already carries the prefix must not become api.api.<domain>.
+		{regionOrDomain: "api.eu2.coralogix.com", want: "https://api.eu2.coralogix.com"},
+		// PrivateLink hosts are used as-is.
+		{regionOrDomain: "api.private.eu2.coralogix.com", want: "https://api.private.eu2.coralogix.com"},
+		{regionOrDomain: "api.private.eu1.coralogix.com", want: "https://api.private.eu1.coralogix.com"},
+		// Scheme and trailing slash are trimmed.
+		{regionOrDomain: "https://custom.example.com/", want: "https://api.custom.example.com"},
+		{regionOrDomain: "https://api.private.us1.coralogix.com/", want: "https://api.private.us1.coralogix.com"},
 	}
 
 	for _, tt := range tests {
@@ -75,10 +97,5 @@ func TestScimRestBaseURL(t *testing.T) {
 				t.Fatalf("ScimRestBaseURL(%q) = %q, want %q", tt.regionOrDomain, got, tt.want)
 			}
 		})
-	}
-
-	// SDK default for unknown domain must not be used for PrivateLink hosts.
-	if got := ScimRestBaseURL("api.private.eu1.coralogix.com"); got == "https://ng-api-http.api.private.eu1.coralogix.com" {
-		t.Fatalf("ScimRestBaseURL must not use ng-api-http prefix for api.private.*, got %q", got)
 	}
 }

--- a/internal/clientset/rest/client_test.go
+++ b/internal/clientset/rest/client_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetSuccess(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"1"}`))
+	}))
+	defer server.Close()
+
+	body, err := NewRestClient(server.URL, "api-key").Get(context.Background(), "/1")
+	if err != nil {
+		t.Fatalf("Get() returned error %v, want nil", err)
+	}
+	if body != `{"id":"1"}` {
+		t.Fatalf("Get() = %q, want %q", body, `{"id":"1"}`)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := NewRestClient(server.URL, "api-key").Get(context.Background(), "/missing")
+	if err == nil {
+		t.Fatal("Get() returned nil error, want not-found error")
+	}
+	// REST call sites use status.Code, not cxsdk.Code.
+	if got := status.Code(err); got != codes.NotFound {
+		t.Fatalf("status.Code(%v) = %v, want %v", err, got, codes.NotFound)
+	}
+}

--- a/internal/provider/aaa/data_source_coralogix_group.go
+++ b/internal/provider/aaa/data_source_coralogix_group.go
@@ -16,7 +16,6 @@ package aaa
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -29,7 +28,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	teamGroups "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/team_groups_management_service"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -41,8 +41,8 @@ func NewGroupDataSource() datasource.DataSource {
 }
 
 type GroupDataSource struct {
-	client     *clientset.GroupsClient
-	grpcClient *cxsdk.GroupsClient
+	client          *clientset.GroupsClient
+	teamGroupClient *teamGroups.TeamGroupsManagementServiceAPIService
 }
 
 func (d *GroupDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -64,7 +64,7 @@ func (d *GroupDataSource) Configure(_ context.Context, req datasource.ConfigureR
 	}
 
 	d.client = clientSet.Groups()
-	d.grpcClient = clientSet.GroupGrpc()
+	d.teamGroupClient = clientSet.TeamGroups()
 }
 
 func (d *GroupDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -102,23 +102,25 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	//Get refreshed Group value from Coralogix
 	if displayName := data.DisplayName.ValueString(); displayName != "" {
 		log.Printf("[INFO] Listing Groups to find by display name: %s", displayName)
-		listGroupReq := &cxsdk.GetTeamGroupsRequest{}
-		listGroupResp, err := d.grpcClient.List(ctx, listGroupReq)
+		getByNameResp, httpResponse, err := d.teamGroupClient.
+			GroupsMgmtServiceGetTeamGroupByName(ctx, displayName).
+			Execute()
 		if err != nil {
 			log.Printf("[ERROR] Received error when listing groups: %s", err.Error())
-			listGroupReqStr, _ := json.Marshal(listGroupReq)
-			resp.Diagnostics.AddError(
-				"Error listing Groups",
-				utils.FormatRpcErrors(err, "List", string(listGroupReqStr)),
-			)
+			apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+			if cxsdkOpenapi.IsNotFound(apiErr) {
+				resp.Diagnostics.AddError(fmt.Sprintf("Group with display name %q not found", displayName), "")
+			} else {
+				resp.Diagnostics.AddError(
+					"Error listing Groups",
+					utils.FormatOpenAPIErrors(apiErr, "GetTeamGroupByName", displayName),
+				)
+			}
 			return
 		}
 
-		for _, group := range listGroupResp.Groups {
-			if group.Name == data.DisplayName.ValueString() {
-				groupID = strconv.Itoa(int(group.GroupId.Id))
-				break
-			}
+		if getByNameResp != nil && getByNameResp.Group != nil && getByNameResp.Group.GroupId != nil {
+			groupID = strconv.FormatInt(*getByNameResp.Group.GroupId, 10)
 		}
 
 		if groupID == "" {

--- a/internal/provider/aaa/data_source_coralogix_user.go
+++ b/internal/provider/aaa/data_source_coralogix_user.go
@@ -23,10 +23,10 @@ import (
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var _ datasource.DataSourceWithConfigure = &UserDataSource{}
@@ -81,7 +81,7 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	getUserResp, err := d.client.Get(ctx, id)
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			resp.Diagnostics.AddWarning(
 				err.Error(),
 				fmt.Sprintf("User %q is in state, but no longer exists in Coralogix backend", id),

--- a/internal/provider/aaa/data_source_coralogix_user.go
+++ b/internal/provider/aaa/data_source_coralogix_user.go
@@ -82,10 +82,7 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		if status.Code(err) == codes.NotFound {
-			resp.Diagnostics.AddWarning(
-				err.Error(),
-				fmt.Sprintf("User %q is in state, but no longer exists in Coralogix backend", id),
-			)
+			resp.Diagnostics.AddError(fmt.Sprintf("User %q not found", id), "")
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading User",

--- a/internal/provider/aaa/resource_coralogix_group.go
+++ b/internal/provider/aaa/resource_coralogix_group.go
@@ -25,7 +25,9 @@ import (
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -37,7 +39,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"google.golang.org/grpc/codes"
 )
 
 func NewGroupResource() resource.Resource {
@@ -232,7 +233,7 @@ func (r *GroupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	getGroupResp, err := r.client.GetGroup(ctx, id)
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Group %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
@@ -294,7 +295,7 @@ func (r *GroupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	getGroupResp, err := r.client.GetGroup(ctx, id)
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Group %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),

--- a/internal/provider/aaa/resource_coralogix_user.go
+++ b/internal/provider/aaa/resource_coralogix_user.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func NewUserResource() resource.Resource {
@@ -279,7 +280,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	getUserResp, err := r.client.Get(ctx, id)
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("User %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),
@@ -359,7 +360,7 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	getUserResp, err := r.client.Get(ctx, id)
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("User %q is in state, but no longer exists in Coralogix backend", id),
 				fmt.Sprintf("%s will be recreated when you apply", id),

--- a/internal/provider/data_exploration/resource_grafana_folder.go
+++ b/internal/provider/data_exploration/resource_grafana_folder.go
@@ -24,11 +24,11 @@ import (
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func ResourceGrafanaFolder() *schema.Resource {
@@ -162,7 +162,7 @@ func DeleteFolder(ctx context.Context, d *schema.ResourceData, meta interface{})
 	err := meta.(*clientset.ClientSet).Grafana().DeleteGrafanaFolder(ctx, folder.UID)
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			d.SetId("")
 			return diag.Diagnostics{diag.Diagnostic{
 				Severity: diag.Warning,

--- a/internal/provider/data_source_coralogix_group_test.go
+++ b/internal/provider/data_source_coralogix_group_test.go
@@ -82,7 +82,7 @@ func TestAccCoralogixDataSourceGroupByName_exactMatch(t *testing.T) {
 			{
 				Config: testAccCoralogixResourceGroup(userName, displayName, scopeName) +
 					testAccCoralogixDataSourceGroupPrefixSibling(displayName) +
-					testAccCoralogixDataSourceGroupByName_read(),
+					testAccCoralogixDataSourceGroupByNameExactMatch_read(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(groupDataSourceName, "display_name", displayName),
 					resource.TestCheckResourceAttrPair(groupDataSourceName, "id", groupResourceName, "id"),
@@ -116,6 +116,16 @@ func testAccCoralogixDataSourceGroup_read() string {
 func testAccCoralogixDataSourceGroupByName_read() string {
 	return `data "coralogix_group" "test" {
 	display_name = coralogix_group.test.display_name
+}
+`
+}
+
+// depends_on forces the prefix sibling to exist before lookup; without it the
+// data source can read before the sibling is created and miss the regression.
+func testAccCoralogixDataSourceGroupByNameExactMatch_read() string {
+	return `data "coralogix_group" "test" {
+	display_name = coralogix_group.test.display_name
+	depends_on   = [coralogix_group.prefix_sibling]
 }
 `
 }

--- a/internal/provider/data_source_coralogix_group_test.go
+++ b/internal/provider/data_source_coralogix_group_test.go
@@ -15,6 +15,8 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -55,7 +57,50 @@ func TestAccCoralogixDataSourceGroupByName(t *testing.T) {
 					testAccCoralogixDataSourceGroupByName_read(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(groupDataSourceName, "display_name", displayName),
+					// The id pair is what proves the lookup resolved the right group.
+					resource.TestCheckResourceAttrPair(groupDataSourceName, "id", groupResourceName, "id"),
+					resource.TestCheckResourceAttrPair(groupDataSourceName, "role", groupResourceName, "role"),
+					resource.TestCheckResourceAttrPair(groupDataSourceName, "scope_id", groupResourceName, "scope_id"),
+					resource.TestCheckResourceAttrPair(groupDataSourceName, "members.#", groupResourceName, "members.#"),
+					resource.TestCheckResourceAttrPair(groupDataSourceName, "members.0", groupResourceName, "members.0"),
 				),
+			},
+		},
+	})
+}
+
+// TestAccCoralogixDataSourceGroupByName_exactMatch guards against a prefix match: one group
+// name is a strict prefix of the other, and the lookup must return the shorter one.
+func TestAccCoralogixDataSourceGroupByName_exactMatch(t *testing.T) {
+	userName := randUserName()
+	displayName := acctest.RandomWithPrefix("tf-acc-test-group")
+	scopeName := acctest.RandomWithPrefix("tf-acc-test-scope")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceGroup(userName, displayName, scopeName) +
+					testAccCoralogixDataSourceGroupPrefixSibling(displayName) +
+					testAccCoralogixDataSourceGroupByName_read(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(groupDataSourceName, "display_name", displayName),
+					resource.TestCheckResourceAttrPair(groupDataSourceName, "id", groupResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCoralogixDataSourceGroupByName_notFound(t *testing.T) {
+	displayName := acctest.RandomWithPrefix("tf-acc-test-group-missing")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCoralogixDataSourceGroupByMissingName_read(displayName),
+				ExpectError: regexp.MustCompile("Group with display name .* not found"),
 			},
 		},
 	})
@@ -73,4 +118,20 @@ func testAccCoralogixDataSourceGroupByName_read() string {
 	display_name = coralogix_group.test.display_name
 }
 `
+}
+
+func testAccCoralogixDataSourceGroupPrefixSibling(displayName string) string {
+	return fmt.Sprintf(`
+	resource "coralogix_group" "prefix_sibling" {
+		display_name = "%s-suffix"
+		role         = "Read Only"
+	}
+`, displayName)
+}
+
+func testAccCoralogixDataSourceGroupByMissingName_read(displayName string) string {
+	return fmt.Sprintf(`data "coralogix_group" "missing" {
+	display_name = "%s"
+}
+`, displayName)
 }


### PR DESCRIPTION
### Description

Three related fixes for SCIM/REST-backed resources:

1. **Group data source name lookup** — `display_name` lookup no longer uses gRPC `List` + client-side scan. It calls OpenAPI `GetTeamGroupByName`, so groups past the first list page are found.
2. **REST NotFound soft-delete** — SCIM group/user and Grafana folder read/delete paths checked `cxsdk.Code(err)` for NotFound. The hand-rolled REST client returns a bare `status.Error`, so that check never matched and a 404 failed hard instead of removing the resource from state. Call sites now use `status.Code(err)`.
3. **SCIM host** — SCIM users and groups now call `api.<domain>` instead of `ng-api-http.<domain>`.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing (CI Acceptance Tests run):

```
--- PASS: TestGetNotFound (0.00s)
--- PASS: TestAccCoralogixDataSourceGroup_basic (3.32s)
--- PASS: TestAccCoralogixDataSourceGroupByName (4.00s)
--- PASS: TestAccCoralogixDataSourceGroupByName_exactMatch (3.85s)
--- PASS: TestAccCoralogixDataSourceGroupByName_notFound (0.35s)
--- PASS: TestAccCoralogixDataSourceUser_basic (2.09s)
--- PASS: TestAccCoralogixResourceGroup (3.26s)
--- PASS: TestAccCoralogixResourceUser (1.95s)
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
data-source/coralogix_group: Lookup by display_name uses OpenAPI GetTeamGroupByName (fixes missing groups past the first list page).
resource/coralogix_group, resource/coralogix_user, resource/coralogix_grafana_folder: A resource deleted outside Terraform is removed from state on read/delete when the API returns 404.
provider: SCIM users and groups use api.<domain> instead of ng-api-http.<domain>.
```