### PR TITLE
feat(dashboards): add the typed dynamic widget with the stat visualization (CX-50151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - FIX: Error diagnostics label the failing call `operation` instead of `url`, matching the value callers pass (`Read`, `Create`, `List`, …).
 #### resource/coralogix_dashboard
 - FEAT: Add typed HCL support for the `dynamic` widget definition: `query_definitions` with the logs/spans/metrics/data_prime query union, a top-level `time_frame` and `interpretation`, and the `stat` visualization at full fidelity. The remaining visualizations follow in later releases; a dynamic widget using one of them still fails the read with a clear diagnostic instead of writing partial state. Previously every `dynamic` widget failed import and data-source reads.
+- DEPRECATION: Mark `dynamic.visualization.stat.value_field` as deprecated, matching the API. Use `value_fields`; the singular form is still read and written so existing dashboards import without losing it.
 - FEAT: Add `variables_v2` with static, textbox, and query-backed dashboard variables.
 - DEPRECATION: Mark `variables` as deprecated. Use `variables_v2` for new dashboard variables.
 - FIX: Schema v2/v3→v4 state upgrade no longer fails with `Missing Upgraded Resource State` when the dashboard was deleted outside Terraform. The upgrader no longer removes the resource from state (illegal inside a state upgrader); it returns a valid v4 state carrying the prior `id`, `name`, `description` and `content_json`, so the following refresh detects the missing dashboard and plans a recreate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - FIX: Error diagnostics no longer echo the request payload, so credentials carried in a request body cannot leak into CLI or CI logs.
 - FIX: Error diagnostics label the failing call `operation` instead of `url`, matching the value callers pass (`Read`, `Create`, `List`, …).
 #### resource/coralogix_dashboard
+- FEAT: Add typed HCL support for the `dynamic` widget definition: `query_definitions` with the logs/spans/metrics/data_prime query union, a top-level `time_frame` and `interpretation`, and the `stat` visualization at full fidelity. The remaining visualizations follow in later releases; a dynamic widget using one of them still fails the read with a clear diagnostic instead of writing partial state. Previously every `dynamic` widget failed import and data-source reads.
 - FEAT: Add `variables_v2` with static, textbox, and query-backed dashboard variables.
 - DEPRECATION: Mark `variables` as deprecated. Use `variables_v2` for new dashboard variables.
 - FIX: Schema v2/v3→v4 state upgrade no longer fails with `Missing Upgraded Resource State` when the dashboard was deleted outside Terraform. The upgrader no longer removes the resource from state (illegal inside a state upgrader); it returns a valid v4 state carrying the prior `id`, `name`, `description` and `content_json`, so the following refresh detects the missing dashboard and plans a recreate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - FIX: Error diagnostics no longer echo the request payload, so credentials carried in a request body cannot leak into CLI or CI logs.
 - FIX: Error diagnostics label the failing call `operation` instead of `url`, matching the value callers pass (`Read`, `Create`, `List`, …).
 #### resource/coralogix_dashboard
-- FEAT: Add typed HCL support for the `dynamic` widget definition: `query_definitions` with the logs/spans/metrics/data_prime query union, a top-level `time_frame` and `interpretation`, and the `stat` visualization at full fidelity. The remaining visualizations follow in later releases; a dynamic widget using one of them still fails the read with a clear diagnostic instead of writing partial state. Previously every `dynamic` widget failed import and data-source reads.
+- FEAT: Add typed HCL support for the `dynamic` widget definition: `query_definitions` with the logs/spans/metrics/data_prime query union, a top-level `time_frame` and `interpretation`, and the `stat` visualization at full fidelity. The remaining visualizations follow in later releases; a dynamic widget using one of them, or using the deprecated top-level `query` instead of `query_definitions`, fails the read with a clear diagnostic instead of writing state that silently drops it. Previously every `dynamic` widget failed import and data-source reads.
 - DEPRECATION: Mark `dynamic.visualization.stat.value_field` as deprecated, matching the API. Use `value_fields`; the singular form is still read and written so existing dashboards import without losing it.
 - FEAT: Add `variables_v2` with static, textbox, and query-backed dashboard variables.
 - DEPRECATION: Mark `variables` as deprecated. Use `variables_v2` for new dashboard variables.

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -1779,7 +1779,7 @@ Read-Only:
 - `allow_abbreviation` (Boolean)
 - `category_fields` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--category_fields))
 - `custom_unit` (String) Custom unit label. Takes effect only when `unit` is `custom`.
-- `decimal_precision` (Number)
+- `decimal_precision` (Number) How many digits to show after the decimal point. Valid values are 0 to 15.
 - `display_series_name` (Boolean)
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--legend))
 - `legend_by` (String) How the legend is grouped. Valid values are: groups, thresholds, unspecified.
@@ -1789,7 +1789,7 @@ Read-Only:
 - `threshold_type` (String) The threshold type. Valid values are: absolute, relative, unspecified.
 - `thresholds` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--thresholds))
 - `unit` (String) The unit. Valid values are: bytes, bytes_iec, custom, euro, euro_cents, gbytes, gibytes, kbytes, kibytes, mbytes, mibytes, microseconds, milliseconds, nanoseconds, percent01, percent100, seconds, unspecified, usd, usd_cents.
-- `value_field` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_field))
+- `value_field` (Attributes) Deprecated: superseded by `value_fields`, which holds the same observation fields. Retained at full fidelity so dashboards that still set it can be imported and updated without losing it. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_field))
 - `value_fields` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_fields))
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--category_fields"></a>

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -652,7 +652,7 @@ Read-Only:
 
 Read-Only:
 
-- `definition` (Attributes) Inline widget definition. Can contain one of [data_table gauge hexagon line_chart pie_chart bar_chart horizontal_bar_chart markdown]. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition))
+- `definition` (Attributes) Inline widget definition. Can contain one of [data_table gauge hexagon line_chart pie_chart bar_chart horizontal_bar_chart markdown dynamic]. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition))
 - `description` (String) Widget description.
 - `id` (String)
 - `reference` (Attributes) Reference to a widget on another dashboard. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--reference))
@@ -666,6 +666,7 @@ Read-Only:
 
 - `bar_chart` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--bar_chart))
 - `data_table` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--data_table))
+- `dynamic` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic))
 - `gauge` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--gauge))
 - `hexagon` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--hexagon))
 - `horizontal_bar_chart` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--horizontal_bar_chart))
@@ -1543,6 +1544,300 @@ Read-Only:
 
 - `duration` (String)
 
+
+
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic`
+
+Read-Only:
+
+- `interpretation` (String) Deprecated: superseded by the `visualization` block. Retained at full fidelity for importing dashboards that still set it. Valid values are: categorical_analysis_horizontal_bars, categorical_analysis_pie_chart, categorical_analysis_vertical_bars, multi_value_kpi, multi_value_kpi_gauge, multi_value_kpi_hexagon_bins, multi_value_kpi_stat, multi_value_kpi_stat_card, raw_data_table, single_value_kpi, single_value_kpi_gauge, single_value_kpi_stat, single_value_kpi_stat_card, trend_over_time_line, unspecified.
+- `query_definitions` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions))
+- `time_frame` (Attributes) Specifies the time frame. Can be either absolute or relative. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame))
+- `visualization` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions`
+
+Read-Only:
+
+- `id` (String)
+- `name` (String)
+- `query` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query`
+
+Read-Only:
+
+- `data_prime` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--data_prime))
+- `logs` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs))
+- `metrics` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--metrics))
+- `spans` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--data_prime"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.data_prime`
+
+Read-Only:
+
+- `data_mode_type` (String) The data mode type. Valid values are: archive, unspecified.
+- `query` (String)
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs`
+
+Read-Only:
+
+- `aggregations` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--aggregations))
+- `data_mode_type` (String) The data mode type. Valid values are: archive, unspecified.
+- `filters` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters))
+- `group_by` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--group_by))
+- `lucene_query` (String)
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--aggregations"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.aggregations`
+
+Read-Only:
+
+- `field` (String)
+- `observation_field` (Attributes) Explicit field reference with scope. Use when the field name contains a literal dot (e.g. `log.level`) or exists in multiple scopes — the bare `field` is resolved by the backend via dot-split, which silently fails to match flat fields whose identifier contains dots. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--aggregations--observation_field))
+- `percent` (Number) The percentage of the aggregation to return. required when type is `percentile`.
+- `type` (String) The type of the aggregation. Can be one of ["count" "count_distinct" "sum" "avg" "min" "max" "percentile"]
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--aggregations--observation_field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.aggregations.observation_field`
+
+Read-Only:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.filters`
+
+Read-Only:
+
+- `field` (String)
+- `observation_field` (Attributes) Explicit field reference with scope. Use when the field name contains a literal dot (e.g. `log.level`) or exists in multiple scopes — the bare `field` is resolved by the backend via dot-split, which silently fails to match flat fields whose identifier contains dots. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--observation_field))
+- `operator` (Attributes) Operator to use for filtering. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--operator))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--observation_field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.filters.observation_field`
+
+Read-Only:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--operator"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.filters.operator`
+
+Read-Only:
+
+- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--group_by"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.group_by`
+
+Read-Only:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--metrics"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.metrics`
+
+Read-Only:
+
+- `editor_mode` (String) The metrics query editor mode. Valid values are: builder, text, unspecified.
+- `promql_query` (String)
+- `promql_query_type` (String) The PromQL query type. Valid values are: instant, range, unspecified.
+- `series_limit_type` (String) The metrics series limit type. Valid values are: by_point_count, by_series_count, unspecified.
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans`
+
+Read-Only:
+
+- `aggregations` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--aggregations))
+- `data_mode_type` (String) The data mode type. Valid values are: archive, unspecified.
+- `filters` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters))
+- `group_by` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--group_by))
+- `lucene_query` (String)
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--aggregations"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.aggregations`
+
+Read-Only:
+
+- `field` (String)
+- `observation_field` (Attributes) Explicit field reference with scope. Use when the field name contains a literal dot (e.g. `log.level`) or exists in multiple scopes — the bare `field` is resolved by the backend via dot-split, which silently fails to match flat fields whose identifier contains dots. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--aggregations--observation_field))
+- `percent` (Number) The percentage of the aggregation to return. required when type is `percentile`.
+- `type` (String) The type of the aggregation. Can be one of ["count" "count_distinct" "sum" "avg" "min" "max" "percentile"]
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--aggregations--observation_field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.aggregations.observation_field`
+
+Read-Only:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.filters`
+
+Read-Only:
+
+- `field` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters--field))
+- `operator` (Attributes) Operator to use for filtering. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters--operator))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters--field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.filters.field`
+
+Read-Only:
+
+- `type` (String) The type of the field. Can be one of ["metadata" "tag" "process_tag"]
+- `value` (String) The value of the field. When the field type is `metadata`, can be one of ["application_name" "operation_name" "service_name" "subsystem_name" "unspecified"]
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters--operator"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.filters.operator`
+
+Read-Only:
+
+- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--group_by"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.group_by`
+
+Read-Only:
+
+- `keypath` (List of String) Ordered path segments identifying the span field.
+- `relation_type` (String) The span relation type. Valid values are: other, parent, root, unspecified.
+- `scope` (String) Where the field lives. Valid values are: label, metadata, unspecified, user_data.
+
+
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.time_frame`
+
+Read-Only:
+
+- `absolute` (Attributes) Absolute time frame specifying a fixed start and end time. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame--absolute))
+- `relative` (Attributes) Relative time frame specifying a duration from the current time. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame--relative))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame--absolute"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.time_frame.absolute`
+
+Read-Only:
+
+- `end` (String)
+- `start` (String)
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame--relative"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.time_frame.relative`
+
+Read-Only:
+
+- `duration` (String)
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization`
+
+Read-Only:
+
+- `stat` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat`
+
+Read-Only:
+
+- `allow_abbreviation` (Boolean)
+- `category_fields` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--category_fields))
+- `custom_unit` (String) Custom unit label. Takes effect only when `unit` is `custom`.
+- `decimal_precision` (Number)
+- `display_series_name` (Boolean)
+- `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--legend))
+- `legend_by` (String) How the legend is grouped. Valid values are: groups, thresholds, unspecified.
+- `max` (Number)
+- `min` (Number)
+- `threshold_by` (String) Which part of the widget the threshold colors. Valid values are: background, unspecified, value.
+- `threshold_type` (String) The threshold type. Valid values are: absolute, relative, unspecified.
+- `thresholds` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--thresholds))
+- `unit` (String) The unit. Valid values are: bytes, bytes_iec, custom, euro, euro_cents, gbytes, gibytes, kbytes, kibytes, mbytes, mibytes, microseconds, milliseconds, nanoseconds, percent01, percent100, seconds, unspecified, usd, usd_cents.
+- `value_field` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_field))
+- `value_fields` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_fields))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--category_fields"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.category_fields`
+
+Read-Only:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--legend"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.legend`
+
+Read-Only:
+
+- `columns` (List of String) The columns to display in the legend. Valid values are: avg, last, max, min, name, sum, unspecified.
+- `group_by_query` (Boolean)
+- `is_visible` (Boolean) Whether to display the legend. True by default.
+- `placement` (String) The placement of the legend. Valid values are: auto, bottom, hidden, side, unspecified.
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--thresholds"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.thresholds`
+
+Read-Only:
+
+- `color` (String)
+- `from` (Number)
+- `label` (String)
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.value_field`
+
+Read-Only:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_fields"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.value_fields`
+
+Read-Only:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
 
 
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -2925,7 +2925,7 @@ Optional:
 - `allow_abbreviation` (Boolean)
 - `category_fields` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--category_fields))
 - `custom_unit` (String) Custom unit label. Takes effect only when `unit` is `custom`.
-- `decimal_precision` (Number)
+- `decimal_precision` (Number) How many digits to show after the decimal point. Valid values are 0 to 15.
 - `display_series_name` (Boolean)
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--legend))
 - `legend_by` (String) How the legend is grouped. Valid values are: groups, thresholds, unspecified.
@@ -2935,7 +2935,7 @@ Optional:
 - `threshold_type` (String) The threshold type. Valid values are: absolute, relative, unspecified.
 - `thresholds` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--thresholds))
 - `unit` (String) The unit. Valid values are: bytes, bytes_iec, custom, euro, euro_cents, gbytes, gibytes, kbytes, kibytes, mbytes, mibytes, microseconds, milliseconds, nanoseconds, percent01, percent100, seconds, unspecified, usd, usd_cents.
-- `value_field` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_field))
+- `value_field` (Attributes, Deprecated) Deprecated: superseded by `value_fields`, which holds the same observation fields. Retained at full fidelity so dashboards that still set it can be imported and updated without losing it. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_field))
 - `value_fields` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_fields))
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--category_fields"></a>

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -909,6 +909,51 @@ resource "coralogix_dashboard" "widgets" {
           }
         }]
       }]
+      },
+      {
+        # A `dynamic` widget pairs one or more `query_definitions` with a single
+        # `visualization`. Each query picks exactly one source (logs here), and the
+        # widget picks exactly one visualization.
+        rows = [{
+          height = 19
+          widgets = [{
+            title = "dynamic stat - error volume"
+            definition = {
+              dynamic = {
+                query_definitions = [{
+                  name = "errors"
+                  query = {
+                    logs = {
+                      lucene_query = "coralogix.metadata.severity=\"5\" OR coralogix.metadata.severity=\"6\""
+                      group_by = [{
+                        keypath = ["subsystemname"]
+                        scope   = "label"
+                      }]
+                      aggregations = [{
+                        type = "count"
+                      }]
+                    }
+                  }
+                }]
+                time_frame = {
+                  relative = {
+                    duration = "seconds:900"
+                  }
+                }
+                visualization = {
+                  stat = {
+                    decimal_precision = 0
+                    threshold_type    = "absolute"
+                    thresholds = [
+                      { from = 0, color = "green" },
+                      { from = 1000, color = "red" },
+                    ]
+                  }
+                }
+              }
+            }
+          }]
+        }]
     }]
   }
 }
@@ -1630,7 +1675,7 @@ Optional:
 
 Optional:
 
-- `definition` (Attributes) Inline widget definition. Can contain one of [data_table gauge hexagon line_chart pie_chart bar_chart horizontal_bar_chart markdown]. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition))
+- `definition` (Attributes) Inline widget definition. Can contain one of [data_table gauge hexagon line_chart pie_chart bar_chart horizontal_bar_chart markdown dynamic]. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition))
 - `description` (String) Widget description.
 - `id` (String)
 - `reference` (Attributes) Reference to a widget on another dashboard. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--reference))
@@ -1644,6 +1689,7 @@ Optional:
 
 - `bar_chart` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--bar_chart))
 - `data_table` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--data_table))
+- `dynamic` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic))
 - `gauge` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--gauge))
 - `hexagon` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--hexagon))
 - `horizontal_bar_chart` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--horizontal_bar_chart))
@@ -2616,6 +2662,330 @@ Optional:
 
 - `field` (String)
 - `order_direction` (String) The order direction. Can be one of ["asc" "desc" "unspecified"].
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic`
+
+Required:
+
+- `query_definitions` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions))
+
+Optional:
+
+- `interpretation` (String, Deprecated) Deprecated: superseded by the `visualization` block. Retained at full fidelity for importing dashboards that still set it. Valid values are: categorical_analysis_horizontal_bars, categorical_analysis_pie_chart, categorical_analysis_vertical_bars, multi_value_kpi, multi_value_kpi_gauge, multi_value_kpi_hexagon_bins, multi_value_kpi_stat, multi_value_kpi_stat_card, raw_data_table, single_value_kpi, single_value_kpi_gauge, single_value_kpi_stat, single_value_kpi_stat_card, trend_over_time_line, unspecified.
+- `time_frame` (Attributes) Specifies the time frame. Can be either absolute or relative. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame))
+- `visualization` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions`
+
+Required:
+
+- `query` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query))
+
+Optional:
+
+- `name` (String)
+
+Read-Only:
+
+- `id` (String)
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query`
+
+Optional:
+
+- `data_prime` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--data_prime))
+- `logs` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs))
+- `metrics` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--metrics))
+- `spans` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--data_prime"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.data_prime`
+
+Optional:
+
+- `data_mode_type` (String) The data mode type. Valid values are: archive, unspecified.
+- `query` (String)
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs`
+
+Optional:
+
+- `aggregations` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--aggregations))
+- `data_mode_type` (String) The data mode type. Valid values are: archive, unspecified.
+- `filters` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters))
+- `group_by` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--group_by))
+- `lucene_query` (String)
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--aggregations"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.aggregations`
+
+Required:
+
+- `type` (String) The type of the aggregation. Can be one of ["count" "count_distinct" "sum" "avg" "min" "max" "percentile"]
+
+Optional:
+
+- `field` (String)
+- `observation_field` (Attributes) Explicit field reference with scope. Use when the field name contains a literal dot (e.g. `log.level`) or exists in multiple scopes — the bare `field` is resolved by the backend via dot-split, which silently fails to match flat fields whose identifier contains dots. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--aggregations--observation_field))
+- `percent` (Number) The percentage of the aggregation to return. required when type is `percentile`.
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--aggregations--observation_field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.aggregations.observation_field`
+
+Required:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.filters`
+
+Required:
+
+- `operator` (Attributes) Operator to use for filtering. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--operator))
+
+Optional:
+
+- `field` (String)
+- `observation_field` (Attributes) Explicit field reference with scope. Use when the field name contains a literal dot (e.g. `log.level`) or exists in multiple scopes — the bare `field` is resolved by the backend via dot-split, which silently fails to match flat fields whose identifier contains dots. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--observation_field))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--operator"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.filters.operator`
+
+Required:
+
+- `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
+
+Optional:
+
+- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--observation_field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.filters.observation_field`
+
+Required:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--group_by"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.logs.group_by`
+
+Required:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--metrics"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.metrics`
+
+Required:
+
+- `promql_query` (String)
+
+Optional:
+
+- `editor_mode` (String) The metrics query editor mode. Valid values are: builder, text, unspecified.
+- `promql_query_type` (String) The PromQL query type. Valid values are: instant, range, unspecified.
+- `series_limit_type` (String) The metrics series limit type. Valid values are: by_point_count, by_series_count, unspecified.
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans`
+
+Optional:
+
+- `aggregations` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--aggregations))
+- `data_mode_type` (String) The data mode type. Valid values are: archive, unspecified.
+- `filters` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters))
+- `group_by` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--group_by))
+- `lucene_query` (String)
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--aggregations"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.aggregations`
+
+Required:
+
+- `type` (String) The type of the aggregation. Can be one of ["count" "count_distinct" "sum" "avg" "min" "max" "percentile"]
+
+Optional:
+
+- `field` (String)
+- `observation_field` (Attributes) Explicit field reference with scope. Use when the field name contains a literal dot (e.g. `log.level`) or exists in multiple scopes — the bare `field` is resolved by the backend via dot-split, which silently fails to match flat fields whose identifier contains dots. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--aggregations--observation_field))
+- `percent` (Number) The percentage of the aggregation to return. required when type is `percentile`.
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--aggregations--observation_field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.aggregations.observation_field`
+
+Required:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.filters`
+
+Required:
+
+- `field` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters--field))
+- `operator` (Attributes) Operator to use for filtering. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters--operator))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters--field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.filters.field`
+
+Required:
+
+- `type` (String) The type of the field. Can be one of ["metadata" "tag" "process_tag"]
+- `value` (String) The value of the field. When the field type is `metadata`, can be one of ["application_name" "operation_name" "service_name" "subsystem_name" "unspecified"]
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--filters--operator"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.filters.operator`
+
+Required:
+
+- `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
+
+Optional:
+
+- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--spans--group_by"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.query_definitions.query.spans.group_by`
+
+Required:
+
+- `keypath` (List of String) Ordered path segments identifying the span field.
+- `scope` (String) Where the field lives. Valid values are: label, metadata, unspecified, user_data.
+
+Optional:
+
+- `relation_type` (String) The span relation type. Valid values are: other, parent, root, unspecified.
+
+
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.time_frame`
+
+Optional:
+
+- `absolute` (Attributes) Absolute time frame specifying a fixed start and end time. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame--absolute))
+- `relative` (Attributes) Relative time frame specifying a duration from the current time. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame--relative))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame--absolute"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.time_frame.absolute`
+
+Required:
+
+- `end` (String)
+- `start` (String)
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--time_frame--relative"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.time_frame.relative`
+
+Required:
+
+- `duration` (String)
+
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization`
+
+Optional:
+
+- `stat` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat`
+
+Optional:
+
+- `allow_abbreviation` (Boolean)
+- `category_fields` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--category_fields))
+- `custom_unit` (String) Custom unit label. Takes effect only when `unit` is `custom`.
+- `decimal_precision` (Number)
+- `display_series_name` (Boolean)
+- `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--legend))
+- `legend_by` (String) How the legend is grouped. Valid values are: groups, thresholds, unspecified.
+- `max` (Number)
+- `min` (Number)
+- `threshold_by` (String) Which part of the widget the threshold colors. Valid values are: background, unspecified, value.
+- `threshold_type` (String) The threshold type. Valid values are: absolute, relative, unspecified.
+- `thresholds` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--thresholds))
+- `unit` (String) The unit. Valid values are: bytes, bytes_iec, custom, euro, euro_cents, gbytes, gibytes, kbytes, kibytes, mbytes, mibytes, microseconds, milliseconds, nanoseconds, percent01, percent100, seconds, unspecified, usd, usd_cents.
+- `value_field` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_field))
+- `value_fields` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_fields))
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--category_fields"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.category_fields`
+
+Required:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--legend"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.legend`
+
+Optional:
+
+- `columns` (List of String) The columns to display in the legend. Valid values are: avg, last, max, min, name, sum, unspecified.
+- `group_by_query` (Boolean)
+- `is_visible` (Boolean) Whether to display the legend. True by default.
+- `placement` (String) The placement of the legend. Valid values are: auto, bottom, hidden, side, unspecified.
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--thresholds"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.thresholds`
+
+Optional:
+
+- `color` (String)
+- `from` (Number)
+- `label` (String)
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_field"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.value_field`
+
+Required:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
+<a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--stat--value_fields"></a>
+### Nested Schema for `layout.sections.rows.widgets.definition.dynamic.visualization.stat.value_fields`
+
+Required:
+
+- `keypath` (List of String) Ordered path segments. Single element for literal-dot identifiers (`["log.level"]`); multiple elements for nested paths (`["meta","responseTime"]`).
+- `scope` (String) Where the field lives. Disambiguates fields with the same name across scopes (e.g. `timestamp` in metadata vs user data).
+
+
 
 
 

--- a/examples/resources/coralogix_dashboard/resource.tf
+++ b/examples/resources/coralogix_dashboard/resource.tf
@@ -894,6 +894,51 @@ resource "coralogix_dashboard" "widgets" {
           }
         }]
       }]
+      },
+      {
+        # A `dynamic` widget pairs one or more `query_definitions` with a single
+        # `visualization`. Each query picks exactly one source (logs here), and the
+        # widget picks exactly one visualization.
+        rows = [{
+          height = 19
+          widgets = [{
+            title = "dynamic stat - error volume"
+            definition = {
+              dynamic = {
+                query_definitions = [{
+                  name = "errors"
+                  query = {
+                    logs = {
+                      lucene_query = "coralogix.metadata.severity=\"5\" OR coralogix.metadata.severity=\"6\""
+                      group_by = [{
+                        keypath = ["subsystemname"]
+                        scope   = "label"
+                      }]
+                      aggregations = [{
+                        type = "count"
+                      }]
+                    }
+                  }
+                }]
+                time_frame = {
+                  relative = {
+                    duration = "seconds:900"
+                  }
+                }
+                visualization = {
+                  stat = {
+                    decimal_precision = 0
+                    threshold_type    = "absolute"
+                    thresholds = [
+                      { from = 0, color = "green" },
+                      { from = 1000, color = "red" },
+                    ]
+                  }
+                }
+              }
+            }
+          }]
+        }]
     }]
   }
 }

--- a/internal/provider/dashboard_openapi_oneof_coverage_test.go
+++ b/internal/provider/dashboard_openapi_oneof_coverage_test.go
@@ -93,6 +93,7 @@ var dashboardStructuredAcceptanceLifecycleTests = []string{
 	dashboardOpenAPIVariablesTestName,
 	dashboardOpenAPIAnnotationsTestName,
 	dashboardOpenAPITransitionTestName,
+	dashboardOpenAPIDynamicStatTestName,
 }
 
 func covered(path, testName string) dashboardOneOfBranchCoverage {
@@ -205,12 +206,23 @@ func dashboardOpenAPIOneOfCoverageManifest() map[string]dashboardOneOfModelCover
 		variable      = "variables[*].definition.multi_select"
 		variableQuery = variable + ".source.query.query"
 		filter        = widget + ".*.query.*.filters[*]"
+		dynamicWidget = widget + ".dynamic"
+		dynamicQuery  = dynamicWidget + ".query_definitions[*].query"
 	)
+
+	visualization := observedAPIOnlyModel(
+		"ast/widgets/dynamic.proto#Dynamic.Visualization.value",
+		"the structured provider models only the stat visualization of WidgetDefinition.dynamic; the remaining branches stay content_json-only, and import and data-source reads reject them instead of writing partial structured state",
+		dashboardContentJSONDynamicQueriesTableTestName,
+		[]string{"table"},
+		"table", "timeSeriesLines", "timeSeriesBars", "gauge", "hexagonBins", "pieChart", "horizontalBars", "verticalBars", "heatmap", "geomap", "timeSeriesLinesMulti", "verticalBarsMulti", "horizontalBarsMulti", "statCard",
+	)
+	visualization.Branches["stat"] = covered(dynamicWidget+".visualization.stat", dashboardOpenAPIDynamicStatTestName)
 
 	return map[string]dashboardOneOfModelCoverage{
 		"ActionDefinition": apiOnlyModel(
 			"common/action.proto#ActionDefinition.type",
-			"action definitions are reachable only below WidgetDefinition.dynamic, which the structured provider does not expose or flatten",
+			"action definitions are reachable only below Dashboard.actions, which is absent from the structured coralogix_dashboard schema and both converters",
 			"customAction", "goToDashboardAction",
 		),
 		"AnnotationSource": {
@@ -293,13 +305,15 @@ func dashboardOpenAPIOneOfCoverageManifest() map[string]dashboardOneOfModelCover
 			"display-name template variables are reachable only below WidgetDefinition.dynamic",
 			"observationField", "mappedValues",
 		),
-		"DynamicQuery": observedAPIOnlyModel(
-			"ast/widgets/dynamic.proto#Dynamic.Query.value",
-			"WidgetDefinition.dynamic is reachable through content_json but is not exposed or flattened by the structured provider; import and data-source reads have no content_json plan to preserve",
-			dashboardContentJSONDynamicQueriesTableTestName,
-			[]string{"logs", "metrics", "spans"},
-			"logs", "spans", "metrics", "dataprime",
-		),
+		"DynamicQuery": {
+			ProtoSource: "ast/widgets/dynamic.proto#Dynamic.Query.value",
+			Branches: map[string]dashboardOneOfBranchCoverage{
+				"logs":      covered(dynamicQuery+".logs", dashboardOpenAPIDynamicStatTestName),
+				"spans":     covered(dynamicQuery+".spans", dashboardOpenAPIDynamicStatTestName),
+				"metrics":   covered(dynamicQuery+".metrics", dashboardOpenAPIDynamicStatTestName),
+				"dataprime": covered(dynamicQuery+".data_prime", dashboardOpenAPIDynamicStatTestName),
+			},
+		},
 		"EqualsSelection": {
 			ProtoSource: "ast/filters/filter.proto#Filter.Equals.Selection.value",
 			Branches: map[string]dashboardOneOfBranchCoverage{
@@ -657,13 +671,7 @@ func dashboardOpenAPIOneOfCoverageManifest() map[string]dashboardOneOfModelCover
 				"interval":      covered("variables_v2[*].value.interval", "TestAccCoralogixResourceDashboardVariablesV2TextboxValueTypes"),
 			},
 		},
-		"Visualization": observedAPIOnlyModel(
-			"ast/widgets/dynamic.proto#Dynamic.Visualization.value",
-			"all Visualization branches are children of WidgetDefinition.dynamic, which is reachable through content_json but absent from the structured schema and flattener; import and data-source reads cannot reconstruct it",
-			dashboardContentJSONDynamicQueriesTableTestName,
-			[]string{"table"},
-			"table", "timeSeriesLines", "timeSeriesBars", "stat", "gauge", "hexagonBins", "pieChart", "horizontalBars", "verticalBars", "heatmap", "geomap", "timeSeriesLinesMulti", "verticalBarsMulti", "horizontalBarsMulti", "statCard",
-		),
+		"Visualization": visualization,
 		"WidgetDefinition": {
 			ProtoSource: "ast/widget.proto#Widget.Definition.value",
 			Branches: map[string]dashboardOneOfBranchCoverage{
@@ -675,8 +683,7 @@ func dashboardOpenAPIOneOfCoverageManifest() map[string]dashboardOneOfModelCover
 				"horizontalBarChart": covered(widget+".horizontal_bar_chart", dashboardOpenAPILogsQueryTestName),
 				"markdown":           covered(widget+".markdown", dashboardOpenAPILogsQueryTestName),
 				"hexagon":            covered(widget+".hexagon", dashboardOpenAPILogsQueryTestName),
-				"dynamic": observedAPIOnly(dashboardNoProviderPath, dashboardContentJSONDynamicQueriesTableTestName, false,
-					"dynamic is supported through content_json, but SupportedWidgetTypes, widgetModelAttr, expandDashboardWidgetDefinition, and flattenDashboardWidgetDefinition omit it; import and data-source reads cannot reconstruct content_json"),
+				"dynamic":            covered(dynamicWidget, dashboardOpenAPIDynamicStatTestName),
 			},
 		},
 		"XAxis": {
@@ -781,7 +788,6 @@ func TestDashboardOpenAPIOneOfCoverageManifest(t *testing.T) {
 		t.Errorf("manifest branches = %d, want 216", manifestBranches)
 	}
 
-	assertDashboardAPIOnlyBranch(t, "WidgetDefinition", "dynamic", false)
 	assertDashboardAPIOnlyBranch(t, "Dashboard", "oneMinute", false)
 	assertDashboardAPIOnlyBranch(t, "Dashboard", "fifteenMinutes", false)
 }
@@ -844,16 +850,10 @@ func TestDashboardProtoAndRESTOneOfReconciliation(t *testing.T) {
 
 func TestDashboardDynamicContentJSONImportAndDataSourceWaiver(t *testing.T) {
 	models := map[string][]string{
-		"WidgetDefinition": {"dynamic"},
-		"DynamicQuery":     {"logs", "metrics", "spans", "dataprime"},
-		"Visualization":    {"table", "timeSeriesLines", "timeSeriesBars", "stat", "gauge", "hexagonBins", "pieChart", "horizontalBars", "verticalBars", "heatmap", "geomap", "timeSeriesLinesMulti", "verticalBarsMulti", "horizontalBarsMulti", "statCard"},
+		"Visualization": {"table", "timeSeriesLines", "timeSeriesBars", "gauge", "hexagonBins", "pieChart", "horizontalBars", "verticalBars", "heatmap", "geomap", "timeSeriesLinesMulti", "verticalBarsMulti", "horizontalBarsMulti", "statCard"},
 	}
 	observed := map[string]struct{}{
-		"WidgetDefinition.dynamic": {},
-		"DynamicQuery.logs":        {},
-		"DynamicQuery.metrics":     {},
-		"DynamicQuery.spans":       {},
-		"Visualization.table":      {},
+		"Visualization.table": {},
 	}
 	for model, branches := range models {
 		for _, branch := range branches {

--- a/internal/provider/dashboards/dashboard_schema/prior_schema_decode_test.go
+++ b/internal/provider/dashboards/dashboard_schema/prior_schema_decode_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Terraform CLI calls UpgradeResourceState even when the stored version matches
+// the current schema version, and the framework then round-trips the raw state
+// through the current schema type with these options. Decoding fixtures the
+// same way means a widening that would break a real upgrade fails here instead
+// of in a customer's plan.
+func priorSchemaUnmarshalOpts() tfprotov6.UnmarshalOpts {
+	return tfprotov6.UnmarshalOpts{
+		ValueFromJSONOpts: tftypes.ValueFromJSONOpts{
+			IgnoreUndefinedAttributes: true,
+		},
+	}
+}
+
+func decodeAgainstSchema(t *testing.T, resourceSchema schema.Schema, stateJSON string) {
+	t.Helper()
+
+	rawState := tfprotov6.RawState{JSON: []byte(stateJSON)}
+	schemaType := resourceSchema.Type().TerraformType(context.Background())
+
+	if _, err := rawState.UnmarshalWithOpts(schemaType, priorSchemaUnmarshalOpts()); err != nil {
+		t.Fatalf("decoding stored state against schema failed: %s", err)
+	}
+}
+
+// A dynamic stat widget as written before the visualization gained its
+// remaining fields and before the widget gained `interpretation`.
+const narrowDynamicStatStateJSON = `{
+  "id": "dashboard-id",
+  "name": "dynamic stat dashboard",
+  "layout": {
+    "sections": [{
+      "id": "section-id",
+      "rows": [{
+        "id": "row-id",
+        "appearance": {"height": 19},
+        "widgets": [{
+          "id": "widget-id",
+          "title": "stat",
+          "definition": {
+            "dynamic": {
+              "query_definitions": [{
+                "id": "query-id",
+                "name": "errors",
+                "query": {
+                  "logs": {
+                    "lucene_query": "*",
+                    "data_mode_type": "unspecified"
+                  }
+                }
+              }],
+              "time_frame": {"relative": {"duration": "seconds:900"}},
+              "visualization": {
+                "stat": {
+                  "unit": "bytes",
+                  "threshold_type": "absolute",
+                  "thresholds": [{"from": 0, "color": "green", "label": null}],
+                  "value_field": {"keypath": ["duration"], "scope": "metadata"},
+                  "legend": {"is_visible": true, "columns": null, "group_by_query": false, "placement": "bottom"}
+                }
+              }
+            }
+          }
+        }]
+      }]
+    }]
+  }
+}`
+
+// Proves the dynamic widget's new attributes need no schema version bump:
+// attributes absent from stored JSON decode to null.
+func TestCurrentSchemaDecodesNarrowDynamicStatState(t *testing.T) {
+	decodeAgainstSchema(t, V4(), narrowDynamicStatStateJSON)
+}
+
+// V1, V2 and V3 are wired as PriorSchema values in the resource's UpgradeState
+// map, so widening a schema helper they share with the current version
+// retroactively changes the type historical state is decoded against. Every

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -121,6 +121,7 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 															"line_chart": dashboardwidgets.LineChartSchema(),
 															"hexagon":    dashboardwidgets.HexagonSchema(),
 															"data_table": dashboardwidgets.DataTableSchema(),
+															"dynamic":    dashboardwidgets.DynamicSchema(),
 															"gauge": schema.SingleNestedAttribute{
 																Attributes: map[string]schema.Attribute{
 																	"query": schema.SingleNestedAttribute{

--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -328,6 +328,7 @@ var (
 		"bar_chart",
 		"horizontal_bar_chart",
 		"markdown",
+		"dynamic",
 	}
 )
 
@@ -466,6 +467,89 @@ type WidgetDefinitionModel struct {
 	BarChart           *BarChartModel           `tfsdk:"bar_chart"`
 	HorizontalBarChart *HorizontalBarChartModel `tfsdk:"horizontal_bar_chart"`
 	Markdown           *MarkdownModel           `tfsdk:"markdown"`
+	Dynamic            *DynamicModel            `tfsdk:"dynamic"`
+}
+
+type DynamicModel struct {
+	QueryDefinitions types.List                 `tfsdk:"query_definitions"` //DynamicQueryDefinitionModel
+	Interpretation   types.String               `tfsdk:"interpretation"`
+	TimeFrame        *TimeFrameModel            `tfsdk:"time_frame"`
+	Visualization    *DynamicVisualizationModel `tfsdk:"visualization"`
+}
+
+type DynamicQueryDefinitionModel struct {
+	ID    types.String       `tfsdk:"id"`
+	Name  types.String       `tfsdk:"name"`
+	Query *DynamicQueryModel `tfsdk:"query"`
+}
+
+type DynamicQueryModel struct {
+	Logs      *DynamicQueryLogsModel      `tfsdk:"logs"`
+	Spans     *DynamicQuerySpansModel     `tfsdk:"spans"`
+	Metrics   *DynamicQueryMetricsModel   `tfsdk:"metrics"`
+	DataPrime *DynamicQueryDataPrimeModel `tfsdk:"data_prime"`
+}
+
+type DynamicQueryLogsModel struct {
+	LuceneQuery  types.String `tfsdk:"lucene_query"`
+	GroupBy      types.List   `tfsdk:"group_by"`     //ObservationFieldModel
+	Aggregations types.List   `tfsdk:"aggregations"` //LogsAggregationModel
+	Filters      types.List   `tfsdk:"filters"`      //LogsFilterModel
+	DataModeType types.String `tfsdk:"data_mode_type"`
+}
+
+type DynamicQuerySpansModel struct {
+	LuceneQuery  types.String `tfsdk:"lucene_query"`
+	GroupBy      types.List   `tfsdk:"group_by"`     //SpanObservationFieldModel
+	Aggregations types.List   `tfsdk:"aggregations"` //LogsAggregationModel
+	Filters      types.List   `tfsdk:"filters"`      //SpansFilterModel
+	DataModeType types.String `tfsdk:"data_mode_type"`
+}
+
+type DynamicQueryMetricsModel struct {
+	PromqlQuery     types.String `tfsdk:"promql_query"`
+	PromqlQueryType types.String `tfsdk:"promql_query_type"`
+	EditorMode      types.String `tfsdk:"editor_mode"`
+	SeriesLimitType types.String `tfsdk:"series_limit_type"`
+}
+
+type DynamicQueryDataPrimeModel struct {
+	Query        types.String `tfsdk:"query"`
+	DataModeType types.String `tfsdk:"data_mode_type"`
+}
+
+type SpanObservationFieldModel struct {
+	Keypath      types.List   `tfsdk:"keypath"` //types.String
+	Scope        types.String `tfsdk:"scope"`
+	RelationType types.String `tfsdk:"relation_type"`
+}
+
+type DynamicVisualizationModel struct {
+	Stat *DynamicStatModel `tfsdk:"stat"`
+}
+
+type DynamicStatModel struct {
+	AllowAbbreviation types.Bool    `tfsdk:"allow_abbreviation"`
+	CategoryFields    types.List    `tfsdk:"category_fields"` //ObservationFieldModel
+	CustomUnit        types.String  `tfsdk:"custom_unit"`
+	DecimalPrecision  types.Int64   `tfsdk:"decimal_precision"`
+	DisplaySeriesName types.Bool    `tfsdk:"display_series_name"`
+	Legend            *LegendModel  `tfsdk:"legend"`
+	LegendBy          types.String  `tfsdk:"legend_by"`
+	Max               types.Float64 `tfsdk:"max"`
+	Min               types.Float64 `tfsdk:"min"`
+	ThresholdBy       types.String  `tfsdk:"threshold_by"`
+	ThresholdType     types.String  `tfsdk:"threshold_type"`
+	Thresholds        types.List    `tfsdk:"thresholds"` //DynamicThresholdModel
+	Unit              types.String  `tfsdk:"unit"`
+	ValueField        types.Object  `tfsdk:"value_field"`  //ObservationFieldModel
+	ValueFields       types.List    `tfsdk:"value_fields"` //ObservationFieldModel
+}
+
+type DynamicThresholdModel struct {
+	From  types.Float64 `tfsdk:"from"`
+	Color types.String  `tfsdk:"color"`
+	Label types.String  `tfsdk:"label"`
 }
 
 type LineChartModel struct {

--- a/internal/provider/dashboards/dashboard_widgets/dynamic.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic.go
@@ -866,6 +866,17 @@ func FlattenDynamic(ctx context.Context, dynamic *dashboardservice.WidgetsDynami
 		return nil, nil
 	}
 
+	// The deprecated top-level query has no typed equivalent, and the API stores
+	// and returns it verbatim rather than migrating it to query_definitions.
+	// Flattening such a widget would drop its only data source, so refuse the
+	// read instead of writing state that silently loses it.
+	if dynamic.Query != nil {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic(
+			"Unsupported Dashboard Widget Definition",
+			"The dynamic widget uses the deprecated top-level `query`, which this provider cannot represent as typed HCL. Manage this dashboard with `content_json`, or move the widget to `query_definitions`, which holds the same queries.",
+		)}
+	}
+
 	queryDefinitions, diags := flattenDynamicQueryDefinitions(ctx, dynamic.GetQueryDefinitions())
 	if diags.HasError() {
 		return nil, diags

--- a/internal/provider/dashboards/dashboard_widgets/dynamic.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic.go
@@ -17,7 +17,6 @@ package dashboard_widgets
 import (
 	"context"
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
@@ -334,8 +333,9 @@ func dynamicStatSchema() schema.Attribute {
 			"decimal_precision": schema.Int64Attribute{
 				Optional: true,
 				Validators: []validator.Int64{
-					int64validator.Between(0, math.MaxInt32),
+					int64validator.Between(0, 15),
 				},
+				MarkdownDescription: "How many digits to show after the decimal point. Valid values are 0 to 15.",
 			},
 			"display_series_name": schema.BoolAttribute{
 				Optional: true,
@@ -395,8 +395,10 @@ func dynamicStatSchema() schema.Attribute {
 			},
 			"unit": UnitSchema(),
 			"value_field": schema.SingleNestedAttribute{
-				Attributes: ObservationFieldSchema(),
-				Optional:   true,
+				Attributes:          ObservationFieldSchema(),
+				Optional:            true,
+				DeprecationMessage:  "Deprecated: superseded by value_fields.",
+				MarkdownDescription: "Deprecated: superseded by `value_fields`, which holds the same observation fields. Retained at full fidelity so dashboards that still set it can be imported and updated without losing it.",
 			},
 			"value_fields": schema.ListNestedAttribute{
 				Optional: true,

--- a/internal/provider/dashboards/dashboard_widgets/dynamic.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic.go
@@ -1,0 +1,1183 @@
+// Copyright 2025 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_widgets
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
+
+	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	dashboardSchemaToProtoMetricsEditorMode = map[string]dashboardservice.MetricsQueryEditorMode{
+		utils.UNSPECIFIED: dashboardservice.METRICSQUERYEDITORMODE_METRICS_QUERY_EDITOR_MODE_UNSPECIFIED,
+		"builder":         dashboardservice.METRICSQUERYEDITORMODE_METRICS_QUERY_EDITOR_MODE_BUILDER,
+		"text":            dashboardservice.METRICSQUERYEDITORMODE_METRICS_QUERY_EDITOR_MODE_TEXT,
+	}
+	dashboardProtoToSchemaMetricsEditorMode = utils.ReverseMap(dashboardSchemaToProtoMetricsEditorMode)
+	dashboardValidMetricsEditorModes        = utils.GetKeys(dashboardSchemaToProtoMetricsEditorMode)
+
+	dashboardSchemaToProtoMetricsSeriesLimitType = map[string]dashboardservice.MetricsSeriesLimitType{
+		utils.UNSPECIFIED: dashboardservice.METRICSSERIESLIMITTYPE_METRICS_SERIES_LIMIT_TYPE_UNSPECIFIED,
+		"by_point_count":  dashboardservice.METRICSSERIESLIMITTYPE_METRICS_SERIES_LIMIT_TYPE_BY_POINT_COUNT,
+		"by_series_count": dashboardservice.METRICSSERIESLIMITTYPE_METRICS_SERIES_LIMIT_TYPE_BY_SERIES_COUNT,
+	}
+	dashboardProtoToSchemaMetricsSeriesLimitType = utils.ReverseMap(dashboardSchemaToProtoMetricsSeriesLimitType)
+	dashboardValidMetricsSeriesLimitTypes        = utils.GetKeys(dashboardSchemaToProtoMetricsSeriesLimitType)
+
+	dashboardSchemaToProtoThresholdBy = map[string]dashboardservice.CommonThresholdBy{
+		utils.UNSPECIFIED: dashboardservice.COMMONTHRESHOLDBY_THRESHOLD_BY_UNSPECIFIED,
+		"value":           dashboardservice.COMMONTHRESHOLDBY_THRESHOLD_BY_VALUE,
+		"background":      dashboardservice.COMMONTHRESHOLDBY_THRESHOLD_BY_BACKGROUND,
+	}
+	dashboardProtoToSchemaThresholdBy = utils.ReverseMap(dashboardSchemaToProtoThresholdBy)
+	dashboardValidThresholdBy         = utils.GetKeys(dashboardSchemaToProtoThresholdBy)
+
+	dashboardSchemaToProtoInterpretation = map[string]dashboardservice.Interpretation{
+		utils.UNSPECIFIED:                      dashboardservice.INTERPRETATION_INTERPRETATION_UNSPECIFIED,
+		"raw_data_table":                       dashboardservice.INTERPRETATION_INTERPRETATION_RAW_DATA_TABLE,
+		"trend_over_time_line":                 dashboardservice.INTERPRETATION_INTERPRETATION_TREND_OVER_TIME_LINE,
+		"single_value_kpi":                     dashboardservice.INTERPRETATION_INTERPRETATION_SINGLE_VALUE_KPI,
+		"multi_value_kpi":                      dashboardservice.INTERPRETATION_INTERPRETATION_MULTI_VALUE_KPI,
+		"categorical_analysis_vertical_bars":   dashboardservice.INTERPRETATION_INTERPRETATION_CATEGORICAL_ANALYSIS_VERTICAL_BARS,
+		"single_value_kpi_stat":                dashboardservice.INTERPRETATION_INTERPRETATION_SINGLE_VALUE_KPI_STAT,
+		"single_value_kpi_gauge":               dashboardservice.INTERPRETATION_INTERPRETATION_SINGLE_VALUE_KPI_GAUGE,
+		"multi_value_kpi_stat":                 dashboardservice.INTERPRETATION_INTERPRETATION_MULTI_VALUE_KPI_STAT,
+		"multi_value_kpi_gauge":                dashboardservice.INTERPRETATION_INTERPRETATION_MULTI_VALUE_KPI_GAUGE,
+		"multi_value_kpi_hexagon_bins":         dashboardservice.INTERPRETATION_INTERPRETATION_MULTI_VALUE_KPI_HEXAGON_BINS,
+		"categorical_analysis_pie_chart":       dashboardservice.INTERPRETATION_INTERPRETATION_CATEGORICAL_ANALYSIS_PIE_CHART,
+		"categorical_analysis_horizontal_bars": dashboardservice.INTERPRETATION_INTERPRETATION_CATEGORICAL_ANALYSIS_HORIZONTAL_BARS,
+		"single_value_kpi_stat_card":           dashboardservice.INTERPRETATION_INTERPRETATION_SINGLE_VALUE_KPI_STAT_CARD,
+		"multi_value_kpi_stat_card":            dashboardservice.INTERPRETATION_INTERPRETATION_MULTI_VALUE_KPI_STAT_CARD,
+	}
+	dashboardProtoToSchemaInterpretation = utils.ReverseMap(dashboardSchemaToProtoInterpretation)
+	dashboardValidInterpretation         = utils.GetKeys(dashboardSchemaToProtoInterpretation)
+
+	dashboardSchemaToProtoSpanRelationType = map[string]dashboardservice.SpanRelationType{
+		utils.UNSPECIFIED: dashboardservice.SPANRELATIONTYPE_SPAN_RELATION_TYPE_NONE_UNSPECIFIED,
+		"other":           dashboardservice.SPANRELATIONTYPE_SPAN_RELATION_TYPE_OTHER,
+		"parent":          dashboardservice.SPANRELATIONTYPE_SPAN_RELATION_TYPE_PARENT,
+		"root":            dashboardservice.SPANRELATIONTYPE_SPAN_RELATION_TYPE_ROOT,
+	}
+	dashboardProtoToSchemaSpanRelationType = utils.ReverseMap(dashboardSchemaToProtoSpanRelationType)
+	dashboardValidSpanRelationTypes        = utils.GetKeys(dashboardSchemaToProtoSpanRelationType)
+)
+
+func DynamicSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"query_definitions": schema.ListNestedAttribute{
+				Required: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseNonNullStateForUnknown(),
+							},
+						},
+						"name": schema.StringAttribute{
+							Optional: true,
+						},
+						"query": schema.SingleNestedAttribute{
+							Required: true,
+							Attributes: map[string]schema.Attribute{
+								"logs":       dynamicLogsQuerySchema(),
+								"spans":      dynamicSpansQuerySchema(),
+								"metrics":    dynamicMetricsQuerySchema(),
+								"data_prime": dynamicDataPrimeQuerySchema(),
+							},
+							Validators: []validator.Object{
+								ExactlyOneOfChildren("logs", "spans", "metrics", "data_prime"),
+							},
+						},
+					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+			},
+			"interpretation": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(utils.UNSPECIFIED),
+				DeprecationMessage:  "Deprecated: superseded by the visualization block.",
+				MarkdownDescription: fmt.Sprintf("Deprecated: superseded by the `visualization` block. Retained at full fidelity for importing dashboards that still set it. Valid values are: %s.", strings.Join(dashboardValidInterpretation, ", ")),
+				Validators: []validator.String{
+					stringvalidator.OneOf(dashboardValidInterpretation...),
+				},
+			},
+			"time_frame": TimeFrameSchema(),
+			"visualization": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"stat": dynamicStatSchema(),
+				},
+				Validators: []validator.Object{
+					ExactlyOneOfChildren("stat"),
+				},
+			},
+		},
+		Validators: []validator.Object{
+			objectvalidator.AlsoRequires(
+				path.MatchRelative().AtParent().AtParent().AtName("title"),
+			),
+		},
+	}
+}
+
+func dynamicLogsQuerySchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"lucene_query": schema.StringAttribute{
+				Optional: true,
+			},
+			"group_by": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: ObservationFieldSchema(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+			},
+			"aggregations":   dynamicAggregationsSchema(),
+			"filters":        LogsFiltersSchema(),
+			"data_mode_type": dynamicDataModeTypeSchema(),
+		},
+	}
+}
+
+func dynamicSpansQuerySchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"lucene_query": schema.StringAttribute{
+				Optional: true,
+			},
+			"group_by": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: spanObservationFieldSchema(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+			},
+			"aggregations":   dynamicAggregationsSchema(),
+			"filters":        SpansFilterSchema(),
+			"data_mode_type": dynamicDataModeTypeSchema(),
+		},
+	}
+}
+
+func dynamicMetricsQuerySchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"promql_query": schema.StringAttribute{
+				Required: true,
+			},
+			"promql_query_type": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+				Validators: []validator.String{
+					stringvalidator.OneOf(DashboardValidPromQLQueryType...),
+				},
+				MarkdownDescription: fmt.Sprintf("The PromQL query type. Valid values are: %s.", strings.Join(DashboardValidPromQLQueryType, ", ")),
+			},
+			"editor_mode": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+				Validators: []validator.String{
+					stringvalidator.OneOf(dashboardValidMetricsEditorModes...),
+				},
+				MarkdownDescription: fmt.Sprintf("The metrics query editor mode. Valid values are: %s.", strings.Join(dashboardValidMetricsEditorModes, ", ")),
+			},
+			"series_limit_type": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+				Validators: []validator.String{
+					stringvalidator.OneOf(dashboardValidMetricsSeriesLimitTypes...),
+				},
+				MarkdownDescription: fmt.Sprintf("The metrics series limit type. Valid values are: %s.", strings.Join(dashboardValidMetricsSeriesLimitTypes, ", ")),
+			},
+		},
+	}
+}
+
+func dynamicDataPrimeQuerySchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"query": schema.StringAttribute{
+				Optional: true,
+			},
+			"data_mode_type": dynamicDataModeTypeSchema(),
+		},
+	}
+}
+
+func dynamicAggregationsSchema() schema.Attribute {
+	return schema.ListNestedAttribute{
+		Optional: true,
+		Validators: []validator.List{
+			listvalidator.SizeAtLeast(1),
+		},
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: LogsAggregationAttributes(),
+			Validators: []validator.Object{
+				logsAggregationValidator{},
+			},
+		},
+	}
+}
+
+func dynamicDataModeTypeSchema() schema.Attribute {
+	return schema.StringAttribute{
+		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+		Validators: []validator.String{
+			stringvalidator.OneOf(DashboardValidDataModeTypes...),
+		},
+		MarkdownDescription: fmt.Sprintf("The data mode type. Valid values are: %s.", strings.Join(DashboardValidDataModeTypes, ", ")),
+	}
+}
+
+func spanObservationFieldSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"keypath": schema.ListAttribute{
+			ElementType: types.StringType,
+			Required:    true,
+			Validators: []validator.List{
+				listvalidator.SizeAtLeast(1),
+			},
+			MarkdownDescription: "Ordered path segments identifying the span field.",
+		},
+		"scope": schema.StringAttribute{
+			Required: true,
+			Validators: []validator.String{
+				stringvalidator.OneOf(DashboardValidObservationFieldScope...),
+			},
+			MarkdownDescription: fmt.Sprintf("Where the field lives. Valid values are: %s.", strings.Join(DashboardValidObservationFieldScope, ", ")),
+		},
+		"relation_type": schema.StringAttribute{
+			Optional: true,
+			Computed: true,
+			Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+			Validators: []validator.String{
+				stringvalidator.OneOf(dashboardValidSpanRelationTypes...),
+			},
+			MarkdownDescription: fmt.Sprintf("The span relation type. Valid values are: %s.", strings.Join(dashboardValidSpanRelationTypes, ", ")),
+		},
+	}
+}
+
+func dynamicStatSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"allow_abbreviation": schema.BoolAttribute{
+				Optional: true,
+			},
+			"category_fields": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: ObservationFieldSchema(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+			},
+			"custom_unit": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Custom unit label. Takes effect only when `unit` is `custom`.",
+			},
+			"decimal_precision": schema.Int64Attribute{
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, math.MaxInt32),
+				},
+			},
+			"display_series_name": schema.BoolAttribute{
+				Optional: true,
+			},
+			"legend": LegendSchema(),
+			"legend_by": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+				Validators: []validator.String{
+					stringvalidator.OneOf(DashboardValidLegendBys...),
+				},
+				MarkdownDescription: fmt.Sprintf("How the legend is grouped. Valid values are: %s.", strings.Join(DashboardValidLegendBys, ", ")),
+			},
+			"max": schema.Float64Attribute{
+				Optional: true,
+			},
+			"min": schema.Float64Attribute{
+				Optional: true,
+			},
+			"threshold_by": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+				Validators: []validator.String{
+					stringvalidator.OneOf(dashboardValidThresholdBy...),
+				},
+				MarkdownDescription: fmt.Sprintf("Which part of the widget the threshold colors. Valid values are: %s.", strings.Join(dashboardValidThresholdBy, ", ")),
+			},
+			"threshold_type": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+				Validators: []validator.String{
+					stringvalidator.OneOf(DashboardValidThresholdTypes...),
+				},
+				MarkdownDescription: fmt.Sprintf("The threshold type. Valid values are: %s.", strings.Join(DashboardValidThresholdTypes, ", ")),
+			},
+			"thresholds": schema.ListNestedAttribute{
+				Optional: true,
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"from": schema.Float64Attribute{
+							Optional: true,
+						},
+						"color": schema.StringAttribute{
+							Optional: true,
+						},
+						"label": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			"unit": UnitSchema(),
+			"value_field": schema.SingleNestedAttribute{
+				Attributes: ObservationFieldSchema(),
+				Optional:   true,
+			},
+			"value_fields": schema.ListNestedAttribute{
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: ObservationFieldSchema(),
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+			},
+		},
+	}
+}
+
+func DynamicType() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: dynamicModelAttr(),
+	}
+}
+
+func dynamicModelAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"query_definitions": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: dynamicQueryDefinitionModelAttr(),
+			},
+		},
+		"interpretation": types.StringType,
+		"time_frame": types.ObjectType{
+			AttrTypes: TimeFrameModelAttr(),
+		},
+		"visualization": types.ObjectType{
+			AttrTypes: dynamicVisualizationModelAttr(),
+		},
+	}
+}
+
+func dynamicQueryDefinitionModelAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":   types.StringType,
+		"name": types.StringType,
+		"query": types.ObjectType{
+			AttrTypes: dynamicQueryModelAttr(),
+		},
+	}
+}
+
+func dynamicQueryModelAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"logs":       types.ObjectType{AttrTypes: dynamicLogsQueryAttr()},
+		"spans":      types.ObjectType{AttrTypes: dynamicSpansQueryAttr()},
+		"metrics":    types.ObjectType{AttrTypes: dynamicMetricsQueryAttr()},
+		"data_prime": types.ObjectType{AttrTypes: dynamicDataPrimeQueryAttr()},
+	}
+}
+
+func dynamicLogsQueryAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"lucene_query": types.StringType,
+		"group_by": types.ListType{
+			ElemType: ObservationFieldsObject(),
+		},
+		"aggregations": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: AggregationModelAttr()},
+		},
+		"filters": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: LogsFilterModelAttr()},
+		},
+		"data_mode_type": types.StringType,
+	}
+}
+
+func dynamicSpansQueryAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"lucene_query": types.StringType,
+		"group_by": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: spanObservationFieldAttr()},
+		},
+		"aggregations": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: AggregationModelAttr()},
+		},
+		"filters": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: SpansFilterModelAttr()},
+		},
+		"data_mode_type": types.StringType,
+	}
+}
+
+func dynamicMetricsQueryAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"promql_query":      types.StringType,
+		"promql_query_type": types.StringType,
+		"editor_mode":       types.StringType,
+		"series_limit_type": types.StringType,
+	}
+}
+
+func dynamicDataPrimeQueryAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"query":          types.StringType,
+		"data_mode_type": types.StringType,
+	}
+}
+
+func spanObservationFieldAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"keypath": types.ListType{
+			ElemType: types.StringType,
+		},
+		"scope":         types.StringType,
+		"relation_type": types.StringType,
+	}
+}
+
+func dynamicVisualizationModelAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"stat": types.ObjectType{AttrTypes: dynamicStatModelAttr()},
+	}
+}
+
+func dynamicStatModelAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"allow_abbreviation": types.BoolType,
+		"category_fields": types.ListType{
+			ElemType: ObservationFieldsObject(),
+		},
+		"custom_unit":         types.StringType,
+		"decimal_precision":   types.Int64Type,
+		"display_series_name": types.BoolType,
+		"legend": types.ObjectType{
+			AttrTypes: LegendAttr(),
+		},
+		"legend_by":      types.StringType,
+		"max":            types.Float64Type,
+		"min":            types.Float64Type,
+		"threshold_by":   types.StringType,
+		"threshold_type": types.StringType,
+		"thresholds": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: dynamicThresholdAttr()},
+		},
+		"unit":        types.StringType,
+		"value_field": ObservationFieldsObject(),
+		"value_fields": types.ListType{
+			ElemType: ObservationFieldsObject(),
+		},
+	}
+}
+
+func dynamicThresholdAttr() map[string]attr.Type {
+	return map[string]attr.Type{
+		"from":  types.Float64Type,
+		"color": types.StringType,
+		"label": types.StringType,
+	}
+}
+
+func ExpandDynamic(ctx context.Context, dynamic *DynamicModel) (*dashboardservice.WidgetDefinition, diag.Diagnostics) {
+	if dynamic == nil {
+		return nil, nil
+	}
+
+	queryDefinitions, diags := expandDynamicQueryDefinitions(ctx, dynamic.QueryDefinitions)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	timeFrame, diags := ExpandTimeFrameSelect(ctx, dynamic.TimeFrame)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	visualization, diags := expandDynamicVisualization(ctx, dynamic.Visualization)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &dashboardservice.WidgetDefinition{
+		Dynamic: &dashboardservice.WidgetsDynamic{
+			QueryDefinitions: queryDefinitions,
+			Interpretation:   OptionalEnumPointer(dynamic.Interpretation, dashboardSchemaToProtoInterpretation),
+			TimeFrame:        timeFrame,
+			Visualization:    visualization,
+		},
+	}, nil
+}
+
+func expandDynamicQueryDefinitions(ctx context.Context, queryDefinitions types.List) ([]dashboardservice.DynamicQueryDefinition, diag.Diagnostics) {
+	var queryDefinitionsObjects []types.Object
+	var expandedQueryDefinitions []dashboardservice.DynamicQueryDefinition
+	diags := queryDefinitions.ElementsAs(ctx, &queryDefinitionsObjects, true)
+	if diags.HasError() {
+		return nil, diags
+	}
+	for _, qdo := range queryDefinitionsObjects {
+		var queryDefinition DynamicQueryDefinitionModel
+		if dg := qdo.As(ctx, &queryDefinition, basetypes.ObjectAsOptions{}); dg.HasError() {
+			diags.Append(dg...)
+			continue
+		}
+		expandedQueryDefinition, expandDiags := expandDynamicQueryDefinition(ctx, &queryDefinition)
+		if expandDiags.HasError() {
+			diags.Append(expandDiags...)
+			continue
+		}
+		expandedQueryDefinitions = append(expandedQueryDefinitions, *expandedQueryDefinition)
+	}
+
+	return expandedQueryDefinitions, diags
+}
+
+func expandDynamicQueryDefinition(ctx context.Context, queryDefinition *DynamicQueryDefinitionModel) (*dashboardservice.DynamicQueryDefinition, diag.Diagnostics) {
+	if queryDefinition == nil {
+		return nil, nil
+	}
+
+	query, diags := expandDynamicQuery(ctx, queryDefinition.Query)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &dashboardservice.DynamicQueryDefinition{
+		Id:    *ExpandDashboardIDs(queryDefinition.ID),
+		Name:  utils.TypeStringToStringPointer(queryDefinition.Name),
+		Query: query,
+	}, nil
+}
+
+func expandDynamicQuery(ctx context.Context, query *DynamicQueryModel) (dashboardservice.DynamicQuery, diag.Diagnostics) {
+	if query == nil {
+		return dashboardservice.DynamicQuery{}, nil
+	}
+
+	switch {
+	case query.Logs != nil:
+		logs, diags := expandDynamicLogsQuery(ctx, query.Logs)
+		if diags.HasError() {
+			return dashboardservice.DynamicQuery{}, diags
+		}
+		return dashboardservice.DynamicQuery{Logs: logs}, nil
+	case query.Spans != nil:
+		spans, diags := expandDynamicSpansQuery(ctx, query.Spans)
+		if diags.HasError() {
+			return dashboardservice.DynamicQuery{}, diags
+		}
+		return dashboardservice.DynamicQuery{Spans: spans}, nil
+	case query.Metrics != nil:
+		metrics := expandDynamicMetricsQuery(query.Metrics)
+		return dashboardservice.DynamicQuery{Metrics: metrics}, nil
+	case query.DataPrime != nil:
+		dataPrime := expandDynamicDataPrimeQuery(query.DataPrime)
+		return dashboardservice.DynamicQuery{Dataprime: dataPrime}, nil
+	default:
+		return dashboardservice.DynamicQuery{}, diag.Diagnostics{diag.NewErrorDiagnostic("Error Expand Dynamic Query", "unknown dynamic query type")}
+	}
+}
+
+func expandDynamicLogsQuery(ctx context.Context, logs *DynamicQueryLogsModel) (*dashboardservice.Logs, diag.Diagnostics) {
+	if logs == nil {
+		return nil, nil
+	}
+
+	groupBy, diags := ExpandObservationFields(ctx, logs.GroupBy)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	aggregations, diags := ExpandLogsAggregations(ctx, logs.Aggregations)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	filters, diags := ExpandLogsFilters(ctx, logs.Filters)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &dashboardservice.Logs{
+		LuceneQuery:  ExpandLuceneQuery(logs.LuceneQuery),
+		GroupBy:      groupBy,
+		Aggregation:  aggregations,
+		Filters:      filters,
+		DataModeType: OptionalEnumPointer(logs.DataModeType, DashboardSchemaToProtoDataModeType),
+	}, nil
+}
+
+func expandDynamicSpansQuery(ctx context.Context, spans *DynamicQuerySpansModel) (*dashboardservice.Spans, diag.Diagnostics) {
+	if spans == nil {
+		return nil, nil
+	}
+
+	groupBy, diags := expandSpanObservationFields(ctx, spans.GroupBy)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	aggregations, diags := ExpandLogsAggregations(ctx, spans.Aggregations)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	filters, diags := ExpandSpansFilters(ctx, spans.Filters)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &dashboardservice.Spans{
+		LuceneQuery:  ExpandLuceneQuery(spans.LuceneQuery),
+		GroupBy:      groupBy,
+		Aggregation:  aggregations,
+		Filters:      filters,
+		DataModeType: OptionalEnumPointer(spans.DataModeType, DashboardSchemaToProtoDataModeType),
+	}, nil
+}
+
+func expandDynamicMetricsQuery(metrics *DynamicQueryMetricsModel) *dashboardservice.Metrics {
+	if metrics == nil {
+		return nil
+	}
+
+	return &dashboardservice.Metrics{
+		PromqlQuery:     ExpandPromqlQuery(metrics.PromqlQuery),
+		PromqlQueryType: OptionalEnumPointer(metrics.PromqlQueryType, DashboardSchemaToProtoPromQLQueryType),
+		EditorMode:      OptionalEnumPointer(metrics.EditorMode, dashboardSchemaToProtoMetricsEditorMode),
+		SeriesLimitType: OptionalEnumPointer(metrics.SeriesLimitType, dashboardSchemaToProtoMetricsSeriesLimitType),
+	}
+}
+
+func expandDynamicDataPrimeQuery(dataPrime *DynamicQueryDataPrimeModel) *dashboardservice.Dataprime {
+	if dataPrime == nil {
+		return nil
+	}
+
+	return &dashboardservice.Dataprime{
+		DataprimeQuery: &dashboardservice.CommonDataprimeQuery{
+			Text: dataPrime.Query.ValueStringPointer(),
+		},
+		DataModeType: OptionalEnumPointer(dataPrime.DataModeType, DashboardSchemaToProtoDataModeType),
+	}
+}
+
+func expandSpanObservationFields(ctx context.Context, groupBy types.List) ([]dashboardservice.SpanObservationField, diag.Diagnostics) {
+	var objects []types.Object
+	diags := groupBy.ElementsAs(ctx, &objects, true)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	var fields []dashboardservice.SpanObservationField
+	for _, obj := range objects {
+		var model SpanObservationFieldModel
+		if dg := obj.As(ctx, &model, basetypes.ObjectAsOptions{}); dg.HasError() {
+			diags.Append(dg...)
+			continue
+		}
+		keypath, dg := typeStringListToStringSlice(ctx, model.Keypath)
+		if dg.HasError() {
+			diags.Append(dg...)
+			continue
+		}
+		fields = append(fields, dashboardservice.SpanObservationField{
+			Keypath:      keypath,
+			Scope:        OptionalEnumPointer(model.Scope, DashboardSchemaToProtoObservationFieldScope),
+			RelationType: OptionalEnumPointer(model.RelationType, dashboardSchemaToProtoSpanRelationType),
+		})
+	}
+
+	return fields, diags
+}
+
+func expandDynamicVisualization(ctx context.Context, visualization *DynamicVisualizationModel) (*dashboardservice.Visualization, diag.Diagnostics) {
+	if visualization == nil {
+		return nil, nil
+	}
+
+	switch {
+	case visualization.Stat != nil:
+		stat, diags := expandDynamicStat(ctx, visualization.Stat)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &dashboardservice.Visualization{Stat: stat}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func expandDynamicStat(ctx context.Context, stat *DynamicStatModel) (*dashboardservice.Stat, diag.Diagnostics) {
+	if stat == nil {
+		return nil, nil
+	}
+
+	valueField, diags := ExpandObservationFieldObject(ctx, stat.ValueField)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	categoryFields, diags := ExpandObservationFields(ctx, stat.CategoryFields)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	valueFields, diags := ExpandObservationFields(ctx, stat.ValueFields)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	thresholds, diags := expandDynamicThresholds(ctx, stat.Thresholds)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	legend, diags := ExpandLegend(ctx, stat.Legend)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &dashboardservice.Stat{
+		AllowAbbreviation: stat.AllowAbbreviation.ValueBoolPointer(),
+		CategoryFields:    categoryFields,
+		CustomUnit:        stat.CustomUnit.ValueStringPointer(),
+		DecimalPrecision:  expandInt32Pointer(stat.DecimalPrecision),
+		DisplaySeriesName: stat.DisplaySeriesName.ValueBoolPointer(),
+		Legend:            legend,
+		LegendBy:          OptionalEnumPointer(stat.LegendBy, DashboardSchemaToProtoLegendBy),
+		Max:               stat.Max.ValueFloat64Pointer(),
+		Min:               stat.Min.ValueFloat64Pointer(),
+		ThresholdBy:       OptionalEnumPointer(stat.ThresholdBy, dashboardSchemaToProtoThresholdBy),
+		ThresholdType:     OptionalEnumPointer(stat.ThresholdType, DashboardSchemaToProtoThresholdType),
+		Thresholds:        thresholds,
+		Unit:              OptionalEnumPointer(stat.Unit, DashboardSchemaToProtoUnit),
+		ValueField:        valueField,
+		ValueFields:       valueFields,
+	}, nil
+}
+
+func expandInt32Pointer(value types.Int64) *int32 {
+	if value.IsNull() || value.IsUnknown() {
+		return nil
+	}
+	converted := int32(value.ValueInt64())
+	return &converted
+}
+
+func expandDynamicThresholds(ctx context.Context, thresholds types.List) ([]dashboardservice.CommonThreshold, diag.Diagnostics) {
+	var models []DynamicThresholdModel
+	diags := thresholds.ElementsAs(ctx, &models, true)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	expanded := make([]dashboardservice.CommonThreshold, 0, len(models))
+	for _, model := range models {
+		expanded = append(expanded, dashboardservice.CommonThreshold{
+			From:  model.From.ValueFloat64Pointer(),
+			Color: model.Color.ValueStringPointer(),
+			Label: model.Label.ValueStringPointer(),
+		})
+	}
+
+	return expanded, diags
+}
+
+func FlattenDynamic(ctx context.Context, dynamic *dashboardservice.WidgetsDynamic) (*WidgetDefinitionModel, diag.Diagnostics) {
+	if dynamic == nil {
+		return nil, nil
+	}
+
+	queryDefinitions, diags := flattenDynamicQueryDefinitions(ctx, dynamic.GetQueryDefinitions())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	timeFrame, diags := FlattenTimeFrameSelect(ctx, dynamic.TimeFrame)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	visualization, diags := flattenDynamicVisualization(ctx, dynamic.Visualization)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &WidgetDefinitionModel{
+		Dynamic: &DynamicModel{
+			QueryDefinitions: queryDefinitions,
+			Interpretation:   flattenOptionalEnum(dynamic.Interpretation, dashboardProtoToSchemaInterpretation),
+			TimeFrame:        timeFrame,
+			Visualization:    visualization,
+		},
+	}, nil
+}
+
+func flattenDynamicQueryDefinitions(ctx context.Context, definitions []dashboardservice.DynamicQueryDefinition) (types.List, diag.Diagnostics) {
+	if len(definitions) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: dynamicQueryDefinitionModelAttr()}), nil
+	}
+
+	var diagnostics diag.Diagnostics
+	definitionsElements := make([]attr.Value, 0, len(definitions))
+	for i := range definitions {
+		flattenedDefinition, diags := flattenDynamicQueryDefinition(ctx, &definitions[i])
+		if diags.HasError() {
+			diagnostics.Append(diags...)
+			continue
+		}
+		definitionElement, diags := types.ObjectValueFrom(ctx, dynamicQueryDefinitionModelAttr(), flattenedDefinition)
+		if diags.HasError() {
+			diagnostics.Append(diags...)
+			continue
+		}
+		definitionsElements = append(definitionsElements, definitionElement)
+	}
+
+	if diagnostics.HasError() {
+		return types.ListNull(types.ObjectType{AttrTypes: dynamicQueryDefinitionModelAttr()}), diagnostics
+	}
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: dynamicQueryDefinitionModelAttr()}, definitionsElements)
+}
+
+func flattenDynamicQueryDefinition(ctx context.Context, definition *dashboardservice.DynamicQueryDefinition) (*DynamicQueryDefinitionModel, diag.Diagnostics) {
+	if definition == nil {
+		return nil, nil
+	}
+
+	query, diags := flattenDynamicQuery(ctx, &definition.Query)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &DynamicQueryDefinitionModel{
+		ID:    types.StringValue(definition.GetId()),
+		Name:  utils.StringPointerToTypeString(definition.Name),
+		Query: query,
+	}, nil
+}
+
+func flattenDynamicQuery(ctx context.Context, query *dashboardservice.DynamicQuery) (*DynamicQueryModel, diag.Diagnostics) {
+	if query == nil {
+		return nil, nil
+	}
+
+	switch {
+	case query.Logs != nil:
+		return flattenDynamicLogsQuery(ctx, query.Logs)
+	case query.Spans != nil:
+		return flattenDynamicSpansQuery(ctx, query.Spans)
+	case query.Metrics != nil:
+		return flattenDynamicMetricsQuery(query.Metrics), nil
+	case query.Dataprime != nil:
+		return flattenDynamicDataPrimeQuery(query.Dataprime), nil
+	default:
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error Flatten Dynamic Query", "unknown dynamic query type")}
+	}
+}
+
+func flattenDynamicLogsQuery(ctx context.Context, logs *dashboardservice.Logs) (*DynamicQueryModel, diag.Diagnostics) {
+	if logs == nil {
+		return nil, nil
+	}
+
+	groupBy, diags := FlattenObservationFields(ctx, logs.GetGroupBy())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	aggregations, diags := flattenAggregations(ctx, logs.GetAggregation())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	filters, diags := FlattenLogsFilters(ctx, logs.GetFilters())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &DynamicQueryModel{
+		Logs: &DynamicQueryLogsModel{
+			LuceneQuery:  flattenLuceneQuery(logs.LuceneQuery),
+			GroupBy:      groupBy,
+			Aggregations: aggregations,
+			Filters:      filters,
+			DataModeType: flattenOptionalEnum(logs.DataModeType, DashboardProtoToSchemaDataModeType),
+		},
+	}, nil
+}
+
+func flattenDynamicSpansQuery(ctx context.Context, spans *dashboardservice.Spans) (*DynamicQueryModel, diag.Diagnostics) {
+	if spans == nil {
+		return nil, nil
+	}
+
+	groupBy, diags := flattenSpanObservationFields(ctx, spans.GetGroupBy())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	aggregations, diags := flattenAggregations(ctx, spans.GetAggregation())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	filters, diags := FlattenSpansFilters(ctx, spans.GetFilters())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &DynamicQueryModel{
+		Spans: &DynamicQuerySpansModel{
+			LuceneQuery:  flattenLuceneQuery(spans.LuceneQuery),
+			GroupBy:      groupBy,
+			Aggregations: aggregations,
+			Filters:      filters,
+			DataModeType: flattenOptionalEnum(spans.DataModeType, DashboardProtoToSchemaDataModeType),
+		},
+	}, nil
+}
+
+func flattenDynamicMetricsQuery(metrics *dashboardservice.Metrics) *DynamicQueryModel {
+	if metrics == nil {
+		return nil
+	}
+
+	return &DynamicQueryModel{
+		Metrics: &DynamicQueryMetricsModel{
+			PromqlQuery:     flattenPromqlQuery(metrics.PromqlQuery),
+			PromqlQueryType: flattenOptionalEnum(metrics.PromqlQueryType, DashboardProtoToSchemaPromQLQueryType),
+			EditorMode:      flattenOptionalEnum(metrics.EditorMode, dashboardProtoToSchemaMetricsEditorMode),
+			SeriesLimitType: flattenOptionalEnum(metrics.SeriesLimitType, dashboardProtoToSchemaMetricsSeriesLimitType),
+		},
+	}
+}
+
+func flattenDynamicDataPrimeQuery(dataPrime *dashboardservice.Dataprime) *DynamicQueryModel {
+	if dataPrime == nil {
+		return nil
+	}
+
+	query := types.StringNull()
+	if dataPrime.DataprimeQuery != nil && dataPrime.DataprimeQuery.Text != nil {
+		query = types.StringPointerValue(dataPrime.DataprimeQuery.Text)
+	}
+
+	return &DynamicQueryModel{
+		DataPrime: &DynamicQueryDataPrimeModel{
+			Query:        query,
+			DataModeType: flattenOptionalEnum(dataPrime.DataModeType, DashboardProtoToSchemaDataModeType),
+		},
+	}
+}
+
+func flattenSpanObservationFields(ctx context.Context, fields []dashboardservice.SpanObservationField) (types.List, diag.Diagnostics) {
+	if len(fields) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: spanObservationFieldAttr()}), nil
+	}
+
+	var diagnostics diag.Diagnostics
+	fieldElements := make([]attr.Value, 0, len(fields))
+	for i := range fields {
+		model := &SpanObservationFieldModel{
+			Keypath:      utils.StringSliceToTypeStringList(fields[i].GetKeypath()),
+			Scope:        flattenOptionalEnum(fields[i].Scope, DashboardProtoToSchemaObservationFieldScope),
+			RelationType: flattenOptionalEnum(fields[i].RelationType, dashboardProtoToSchemaSpanRelationType),
+		}
+		fieldElement, diags := types.ObjectValueFrom(ctx, spanObservationFieldAttr(), model)
+		if diags.HasError() {
+			diagnostics.Append(diags...)
+			continue
+		}
+		fieldElements = append(fieldElements, fieldElement)
+	}
+
+	if diagnostics.HasError() {
+		return types.ListNull(types.ObjectType{AttrTypes: spanObservationFieldAttr()}), diagnostics
+	}
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: spanObservationFieldAttr()}, fieldElements)
+}
+
+func flattenDynamicVisualization(ctx context.Context, visualization *dashboardservice.Visualization) (*DynamicVisualizationModel, diag.Diagnostics) {
+	if visualization == nil {
+		return nil, nil
+	}
+
+	switch {
+	case visualization.Stat != nil:
+		stat, diags := flattenDynamicStat(ctx, visualization.Stat)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &DynamicVisualizationModel{Stat: stat}, nil
+	default:
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic(
+			"Unsupported Dashboard Widget Definition",
+			"The dynamic widget uses a visualization variant this provider version cannot represent as typed HCL. Manage this dashboard with `content_json` until that visualization is supported.",
+		)}
+	}
+}
+
+func flattenDynamicStat(ctx context.Context, stat *dashboardservice.Stat) (*DynamicStatModel, diag.Diagnostics) {
+	if stat == nil {
+		return nil, nil
+	}
+
+	valueField, diags := FlattenObservationField(ctx, stat.ValueField)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	categoryFields, diags := FlattenObservationFields(ctx, stat.GetCategoryFields())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	valueFields, diags := FlattenObservationFields(ctx, stat.GetValueFields())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	thresholds, diags := flattenDynamicThresholds(ctx, stat.GetThresholds())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &DynamicStatModel{
+		AllowAbbreviation: types.BoolPointerValue(stat.AllowAbbreviation),
+		CategoryFields:    categoryFields,
+		CustomUnit:        types.StringPointerValue(stat.CustomUnit),
+		DecimalPrecision:  flattenInt32Pointer(stat.DecimalPrecision),
+		DisplaySeriesName: types.BoolPointerValue(stat.DisplaySeriesName),
+		Legend:            FlattenLegend(stat.Legend),
+		LegendBy:          flattenOptionalEnum(stat.LegendBy, DashboardProtoToSchemaLegendBy),
+		Max:               types.Float64PointerValue(stat.Max),
+		Min:               types.Float64PointerValue(stat.Min),
+		ThresholdBy:       flattenOptionalEnum(stat.ThresholdBy, dashboardProtoToSchemaThresholdBy),
+		ThresholdType:     flattenOptionalEnum(stat.ThresholdType, DashboardProtoToSchemaThresholdType),
+		Thresholds:        thresholds,
+		Unit:              flattenOptionalEnum(stat.Unit, DashboardProtoToSchemaUnit),
+		ValueField:        valueField,
+		ValueFields:       valueFields,
+	}, nil
+}
+
+func flattenInt32Pointer(value *int32) types.Int64 {
+	if value == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(int64(*value))
+}
+
+func flattenDynamicThresholds(ctx context.Context, thresholds []dashboardservice.CommonThreshold) (types.List, diag.Diagnostics) {
+	if len(thresholds) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: dynamicThresholdAttr()}), nil
+	}
+
+	var diagnostics diag.Diagnostics
+	thresholdElements := make([]attr.Value, 0, len(thresholds))
+	for i := range thresholds {
+		model := &DynamicThresholdModel{
+			From:  types.Float64PointerValue(thresholds[i].From),
+			Color: types.StringPointerValue(thresholds[i].Color),
+			Label: types.StringPointerValue(thresholds[i].Label),
+		}
+		thresholdElement, diags := types.ObjectValueFrom(ctx, dynamicThresholdAttr(), model)
+		if diags.HasError() {
+			diagnostics.Append(diags...)
+			continue
+		}
+		thresholdElements = append(thresholdElements, thresholdElement)
+	}
+
+	if diagnostics.HasError() {
+		return types.ListNull(types.ObjectType{AttrTypes: dynamicThresholdAttr()}), diagnostics
+	}
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: dynamicThresholdAttr()}, thresholdElements)
+}
+
+func flattenOptionalEnum[T ~string](value *T, mapping map[T]string) types.String {
+	if value == nil {
+		return types.StringNull()
+	}
+	if mapped, ok := mapping[*value]; ok {
+		return types.StringValue(mapped)
+	}
+	return types.StringNull()
+}

--- a/internal/provider/dashboards/dashboard_widgets/dynamic_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic_test.go
@@ -1,0 +1,347 @@
+// Copyright 2025 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_widgets
+
+import (
+	"context"
+	"testing"
+
+	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestDynamicWidgetLogsStatRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	assertDynamicRoundTrip(ctx, t, logsStatFixture(ctx, t))
+}
+
+func TestExpandDynamicPopulatesQueryAndVisualization(t *testing.T) {
+	ctx := context.Background()
+
+	definition, diags := ExpandDynamic(ctx, logsStatFixture(ctx, t))
+	if diags.HasError() {
+		t.Fatalf("expanding dynamic model: %v", diags)
+	}
+	if definition == nil || definition.Dynamic == nil {
+		t.Fatal("ExpandDynamic returned no dynamic widget")
+	}
+	if got := len(definition.Dynamic.QueryDefinitions); got != 1 {
+		t.Fatalf("expanded query definitions = %d, want 1", got)
+	}
+	if definition.Dynamic.QueryDefinitions[0].Query.Logs == nil {
+		t.Fatal("expanded query definition omitted its logs query")
+	}
+	if definition.Dynamic.Visualization == nil || definition.Dynamic.Visualization.Stat == nil {
+		t.Fatal("expanded dynamic widget omitted its stat visualization")
+	}
+	if definition.Dynamic.TimeFrame == nil || definition.Dynamic.TimeFrame.RelativeTimeFrame == nil {
+		t.Fatal("expanded dynamic widget omitted its relative time frame")
+	}
+}
+
+func logsStatFixture(ctx context.Context, t *testing.T) *DynamicModel {
+	t.Helper()
+
+	return &DynamicModel{
+		QueryDefinitions: logsQueryDefinitionsFixture(ctx, t),
+		TimeFrame: &TimeFrameModel{
+			Relative: &TimeFrameRelativeModel{Duration: types.StringValue("seconds:900")},
+		},
+		Visualization: &DynamicVisualizationModel{
+			Stat: statWithUnsetCollections(func(stat *DynamicStatModel) {
+				stat.ThresholdType = types.StringValue("absolute")
+				stat.Thresholds = dynamicThresholdList()
+				stat.Unit = types.StringValue("bytes")
+				stat.ValueField = observationFieldObject("duration", "metadata")
+			}),
+		},
+	}
+}
+
+// Every SDK field of Stat is set, so a dropped field in either direction fails
+// the object comparison instead of silently disappearing on the next read.
+func TestDynamicWidgetStatFullFidelityRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	original := &DynamicModel{
+		QueryDefinitions: logsQueryDefinitionsFixture(ctx, t),
+		Interpretation:   types.StringValue("single_value_kpi_stat"),
+		TimeFrame: &TimeFrameModel{
+			Relative: &TimeFrameRelativeModel{Duration: types.StringValue("seconds:900")},
+		},
+		Visualization: &DynamicVisualizationModel{
+			Stat: &DynamicStatModel{
+				AllowAbbreviation: types.BoolValue(true),
+				CategoryFields:    observationFieldList("category", "user_data"),
+				CustomUnit:        types.StringValue("widgets"),
+				DecimalPrecision:  types.Int64Value(3),
+				DisplaySeriesName: types.BoolValue(true),
+				Legend: &LegendModel{
+					IsVisible:    types.BoolValue(true),
+					Columns:      types.ListValueMust(types.StringType, []attr.Value{types.StringValue("min")}),
+					GroupByQuery: types.BoolValue(true),
+					Placement:    types.StringValue("bottom"),
+				},
+				LegendBy:      types.StringValue("thresholds"),
+				Max:           types.Float64Value(100),
+				Min:           types.Float64Value(0),
+				ThresholdBy:   types.StringValue("background"),
+				ThresholdType: types.StringValue("absolute"),
+				Thresholds:    dynamicThresholdList(),
+				Unit:          types.StringValue("bytes"),
+				ValueField:    observationFieldObject("duration", "metadata"),
+				ValueFields:   observationFieldList("duration2", "metadata"),
+			},
+		},
+	}
+
+	assertDynamicRoundTrip(ctx, t, original)
+}
+
+func TestDynamicWidgetMetricsQueryFullFidelityRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	metricsQuery := &DynamicQueryMetricsModel{
+		PromqlQuery:     types.StringValue("rate(x[5m])"),
+		PromqlQueryType: types.StringValue("instant"),
+		EditorMode:      types.StringValue("text"),
+		SeriesLimitType: types.StringValue("by_series_count"),
+	}
+
+	original := &DynamicModel{
+		QueryDefinitions: types.ListValueMust(
+			types.ObjectType{AttrTypes: dynamicQueryDefinitionModelAttr()},
+			[]attr.Value{
+				types.ObjectValueMust(dynamicQueryDefinitionModelAttr(), map[string]attr.Value{
+					"id":   types.StringValue("query-1"),
+					"name": types.StringValue("rate by service"),
+					"query": types.ObjectValueMust(dynamicQueryModelAttr(), map[string]attr.Value{
+						"logs":       types.ObjectNull(dynamicLogsQueryAttr()),
+						"spans":      types.ObjectNull(dynamicSpansQueryAttr()),
+						"metrics":    objectFrom(ctx, t, dynamicMetricsQueryAttr(), metricsQuery),
+						"data_prime": types.ObjectNull(dynamicDataPrimeQueryAttr()),
+					}),
+				}),
+			},
+		),
+		Visualization: &DynamicVisualizationModel{
+			Stat: statWithUnsetCollections(func(stat *DynamicStatModel) {
+				stat.Unit = types.StringValue("bytes")
+			}),
+		},
+	}
+
+	assertDynamicRoundTrip(ctx, t, original)
+}
+
+func TestDynamicWidgetSpansAndDataPrimeQueryFullFidelityRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	spansQuery := &DynamicQuerySpansModel{
+		LuceneQuery: types.StringValue("*"),
+		GroupBy: types.ListValueMust(types.ObjectType{AttrTypes: spanObservationFieldAttr()}, []attr.Value{
+			types.ObjectValueMust(spanObservationFieldAttr(), map[string]attr.Value{
+				"keypath":       types.ListValueMust(types.StringType, []attr.Value{types.StringValue("service"), types.StringValue("name")}),
+				"scope":         types.StringValue("user_data"),
+				"relation_type": types.StringValue("parent"),
+			}),
+		}),
+		Aggregations: types.ListValueMust(types.ObjectType{AttrTypes: AggregationModelAttr()}, []attr.Value{
+			types.ObjectValueMust(AggregationModelAttr(), map[string]attr.Value{
+				"type":              types.StringValue("count"),
+				"field":             types.StringNull(),
+				"percent":           types.Float64Null(),
+				"observation_field": types.ObjectNull(ObservationFieldAttr()),
+			}),
+		}),
+		Filters: types.ListValueMust(types.ObjectType{AttrTypes: SpansFilterModelAttr()}, []attr.Value{
+			types.ObjectValueMust(SpansFilterModelAttr(), map[string]attr.Value{
+				"field": types.ObjectValueMust(SpansFieldModelAttr(), map[string]attr.Value{
+					"type":  types.StringValue("metadata"),
+					"value": types.StringValue("application_name"),
+				}),
+				"operator": types.ObjectValueMust(FilterOperatorModelAttr(), map[string]attr.Value{
+					"type":            types.StringValue("equals"),
+					"selected_values": types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
+				}),
+			}),
+		}),
+		DataModeType: types.StringValue("archive"),
+	}
+
+	dataPrimeQuery := &DynamicQueryDataPrimeModel{
+		Query:        types.StringValue("source logs | limit 10"),
+		DataModeType: types.StringValue("archive"),
+	}
+
+	original := &DynamicModel{
+		QueryDefinitions: types.ListValueMust(
+			types.ObjectType{AttrTypes: dynamicQueryDefinitionModelAttr()},
+			[]attr.Value{
+				types.ObjectValueMust(dynamicQueryDefinitionModelAttr(), map[string]attr.Value{
+					"id":   types.StringValue("query-1"),
+					"name": types.StringValue("spans"),
+					"query": types.ObjectValueMust(dynamicQueryModelAttr(), map[string]attr.Value{
+						"logs":       types.ObjectNull(dynamicLogsQueryAttr()),
+						"spans":      objectFrom(ctx, t, dynamicSpansQueryAttr(), spansQuery),
+						"metrics":    types.ObjectNull(dynamicMetricsQueryAttr()),
+						"data_prime": types.ObjectNull(dynamicDataPrimeQueryAttr()),
+					}),
+				}),
+				types.ObjectValueMust(dynamicQueryDefinitionModelAttr(), map[string]attr.Value{
+					"id":   types.StringValue("query-2"),
+					"name": types.StringValue("data prime"),
+					"query": types.ObjectValueMust(dynamicQueryModelAttr(), map[string]attr.Value{
+						"logs":       types.ObjectNull(dynamicLogsQueryAttr()),
+						"spans":      types.ObjectNull(dynamicSpansQueryAttr()),
+						"metrics":    types.ObjectNull(dynamicMetricsQueryAttr()),
+						"data_prime": objectFrom(ctx, t, dynamicDataPrimeQueryAttr(), dataPrimeQuery),
+					}),
+				}),
+			},
+		),
+		Visualization: &DynamicVisualizationModel{
+			Stat: statWithUnsetCollections(func(stat *DynamicStatModel) {
+				stat.Unit = types.StringValue("bytes")
+			}),
+		},
+	}
+
+	assertDynamicRoundTrip(ctx, t, original)
+}
+
+// A visualization variant this provider version does not model must fail the
+// read rather than write partial state.
+func TestFlattenDynamicRejectsUnmodeledVisualization(t *testing.T) {
+	_, diags := flattenDynamicVisualization(context.Background(), &dashboardservice.Visualization{
+		Table: &dashboardservice.Table{},
+	})
+	if !diags.HasError() {
+		t.Fatal("flattening an unmodeled visualization returned no error diagnostic")
+	}
+}
+
+// A zero-value types.List/types.Object carries no element type, which fails
+// conversion against the schema's typed attributes, so unset stat collections
+// are built explicitly.
+func statWithUnsetCollections(set func(*DynamicStatModel)) *DynamicStatModel {
+	stat := &DynamicStatModel{
+		CategoryFields: types.ListNull(ObservationFieldsObject()),
+		Thresholds:     types.ListNull(types.ObjectType{AttrTypes: dynamicThresholdAttr()}),
+		ValueField:     types.ObjectNull(ObservationFieldAttr()),
+		ValueFields:    types.ListNull(ObservationFieldsObject()),
+	}
+	set(stat)
+	return stat
+}
+
+func observationFieldObject(keypath, scope string) types.Object {
+	return types.ObjectValueMust(ObservationFieldAttr(), map[string]attr.Value{
+		"keypath": types.ListValueMust(types.StringType, []attr.Value{types.StringValue(keypath)}),
+		"scope":   types.StringValue(scope),
+	})
+}
+
+func observationFieldList(keypath, scope string) types.List {
+	return types.ListValueMust(ObservationFieldsObject(), []attr.Value{observationFieldObject(keypath, scope)})
+}
+
+func dynamicThresholdList() types.List {
+	return types.ListValueMust(types.ObjectType{AttrTypes: dynamicThresholdAttr()}, []attr.Value{
+		types.ObjectValueMust(dynamicThresholdAttr(), map[string]attr.Value{
+			"from":  types.Float64Value(10),
+			"color": types.StringValue("#ff0000"),
+			"label": types.StringValue("high"),
+		}),
+	})
+}
+
+func logsQueryDefinitionsFixture(ctx context.Context, t *testing.T) types.List {
+	t.Helper()
+	logs := &DynamicQueryLogsModel{
+		LuceneQuery: types.StringValue("level:error"),
+		GroupBy:     observationFieldList("service", "user_data"),
+		Aggregations: types.ListValueMust(types.ObjectType{AttrTypes: AggregationModelAttr()}, []attr.Value{
+			types.ObjectValueMust(AggregationModelAttr(), map[string]attr.Value{
+				"type":              types.StringValue("count"),
+				"field":             types.StringNull(),
+				"percent":           types.Float64Null(),
+				"observation_field": types.ObjectNull(ObservationFieldAttr()),
+			}),
+		}),
+		Filters:      types.ListNull(types.ObjectType{AttrTypes: LogsFilterModelAttr()}),
+		DataModeType: types.StringValue("archive"),
+	}
+	return types.ListValueMust(
+		types.ObjectType{AttrTypes: dynamicQueryDefinitionModelAttr()},
+		[]attr.Value{
+			types.ObjectValueMust(dynamicQueryDefinitionModelAttr(), map[string]attr.Value{
+				"id":   types.StringValue("query-1"),
+				"name": types.StringValue("errors by service"),
+				"query": types.ObjectValueMust(dynamicQueryModelAttr(), map[string]attr.Value{
+					"logs":       objectFrom(ctx, t, dynamicLogsQueryAttr(), logs),
+					"spans":      types.ObjectNull(dynamicSpansQueryAttr()),
+					"metrics":    types.ObjectNull(dynamicMetricsQueryAttr()),
+					"data_prime": types.ObjectNull(dynamicDataPrimeQueryAttr()),
+				}),
+			}),
+		},
+	)
+}
+
+func assertDynamicRoundTrip(ctx context.Context, t *testing.T, original *DynamicModel) {
+	t.Helper()
+
+	originalObject, diags := types.ObjectValueFrom(ctx, dynamicModelAttr(), original)
+	if diags.HasError() {
+		t.Fatalf("normalizing original dynamic model: %v", diags)
+	}
+
+	definition, diags := ExpandDynamic(ctx, original)
+	if diags.HasError() {
+		t.Fatalf("expanding dynamic model: %v", diags)
+	}
+	if definition == nil || definition.Dynamic == nil {
+		t.Fatal("ExpandDynamic returned no dynamic widget")
+	}
+
+	flattened, diags := FlattenDynamic(ctx, definition.Dynamic)
+	if diags.HasError() {
+		t.Fatalf("flattening dynamic widget: %v", diags)
+	}
+	if flattened == nil || flattened.Dynamic == nil {
+		t.Fatal("FlattenDynamic returned no dynamic model")
+	}
+
+	flattenedObject, diags := types.ObjectValueFrom(ctx, dynamicModelAttr(), flattened.Dynamic)
+	if diags.HasError() {
+		t.Fatalf("normalizing flattened dynamic model: %v", diags)
+	}
+
+	if !originalObject.Equal(flattenedObject) {
+		t.Fatalf("dynamic model did not round-trip.\noriginal:  %s\nflattened: %s", originalObject, flattenedObject)
+	}
+}
+
+func objectFrom(ctx context.Context, t *testing.T, attrTypes map[string]attr.Type, value any) types.Object {
+	t.Helper()
+	object, diags := types.ObjectValueFrom(ctx, attrTypes, value)
+	if diags.HasError() {
+		t.Fatalf("building object value: %v", diags)
+	}
+	return object
+}

--- a/internal/provider/dashboards/dashboard_widgets/schema.go
+++ b/internal/provider/dashboards/dashboard_widgets/schema.go
@@ -63,6 +63,9 @@ func SpansFilterSchema() schema.Attribute {
 			},
 		},
 		Optional: true,
+		Validators: []validator.List{
+			listvalidator.SizeAtLeast(1),
+		},
 	}
 }
 

--- a/internal/provider/dashboards/dashboard_widgets/schema.go
+++ b/internal/provider/dashboards/dashboard_widgets/schema.go
@@ -34,8 +34,11 @@ import (
 func ObservationFieldSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"keypath": schema.ListAttribute{
-			ElementType:         types.StringType,
-			Required:            true,
+			ElementType: types.StringType,
+			Required:    true,
+			Validators: []validator.List{
+				listvalidator.SizeAtLeast(1),
+			},
 			MarkdownDescription: "Ordered path segments. Single element for literal-dot identifiers (`[\"log.level\"]`); multiple elements for nested paths (`[\"meta\",\"responseTime\"]`).",
 		},
 		"scope": schema.StringAttribute{

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -2111,6 +2111,8 @@ func expandWidgetDefinition(ctx context.Context, definition *dashboardwidgets.Wi
 		return dashboardwidgets.ExpandHexagon(ctx, definition.Hexagon)
 	case definition.LineChart != nil:
 		return dashboardwidgets.ExpandLineChart(ctx, definition.LineChart)
+	case definition.Dynamic != nil:
+		return dashboardwidgets.ExpandDynamic(ctx, definition.Dynamic)
 	case definition.DataTable != nil:
 		return dashboardwidgets.ExpandDataTable(ctx, definition.DataTable)
 	case definition.BarChart != nil:
@@ -4013,6 +4015,7 @@ func widgetModelAttr() map[string]attr.Type {
 				"hexagon":    dashboardwidgets.HexagonType(),
 				"line_chart": dashboardwidgets.LineChartType(),
 				"data_table": dashboardwidgets.DataTableType(),
+				"dynamic":    dashboardwidgets.DynamicType(),
 				"gauge": types.ObjectType{
 					AttrTypes: map[string]attr.Type{
 						"query": types.ObjectType{
@@ -4931,10 +4934,7 @@ func flattenDashboardWidgetDefinition(ctx context.Context, definition *dashboard
 	case definition.Markdown != nil:
 		return flattenMarkdown(definition.Markdown), nil
 	case definition.Dynamic != nil:
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic(
-			"Unsupported Dashboard Widget Definition",
-			"The backend returned a dynamic widget. Dynamic widgets are supported only when configuring content_json; import and data-source reads cannot reconstruct content_json as structured Terraform state.",
-		)}
+		return dashboardwidgets.FlattenDynamic(ctx, definition.Dynamic)
 	default:
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error Flatten Widget Definition", "unknown widget definition type")}
 	}

--- a/internal/provider/dashboards/resource_coralogix_dashboard_test.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard_test.go
@@ -636,6 +636,49 @@ func TestFlattenDashboardRejectsDynamicWidgetWithoutPartialState(t *testing.T) {
 	}
 }
 
+// A widget using the deprecated top-level query has no typed equivalent, and the
+// API returns it verbatim rather than migrating it to query_definitions
+// (verified against a real environment). Flattening it would drop the widget's
+// only data source, so the read must fail instead of writing state without it.
+func TestFlattenDashboardRejectsDynamicWidgetWithLegacyTopLevelQuery(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("..", "testdata", "dashboards", "content_json_dynamic_legacy_query.json"))
+	if err != nil {
+		t.Fatalf("read legacy dynamic query fixture: %s", err)
+	}
+
+	dashboard := new(dashboardservice.Dashboard)
+	if err := json.Unmarshal(content, dashboard); err != nil {
+		t.Fatalf("unmarshal legacy dynamic dashboard response: %s", err)
+	}
+
+	dynamic := dashboard.Layout.Sections[0].GetRows()[0].GetWidgets()[0].Definition.Dynamic
+	if dynamic.Query == nil {
+		t.Fatal("fixture does not populate the deprecated top-level query")
+	}
+	if len(dynamic.GetQueryDefinitions()) != 0 {
+		t.Fatalf("fixture also populates query_definitions (%d), which is not the case under test", len(dynamic.GetQueryDefinitions()))
+	}
+
+	flattened, diags := flattenDashboard(context.Background(), DashboardResourceModel{
+		ID:           types.StringValue("backend-dashboard-id"),
+		Folder:       types.ObjectNull(dashboardFolderModelAttr()),
+		ContentJson:  types.StringNull(),
+		AccessPolicy: types.StringNull(),
+	}, &dashboardOpenAPIReadResult{Dashboard: dashboard})
+	if flattened != nil {
+		t.Fatalf("flatten returned partial state for a legacy dynamic query: %#v", flattened)
+	}
+	if !diags.HasError() {
+		t.Fatal("flatten silently dropped the deprecated top-level query instead of failing")
+	}
+	detail := diags.Errors()[0].Summary() + ": " + diags.Errors()[0].Detail()
+	for _, expected := range []string{"Unsupported Dashboard Widget Definition", "query", "content_json"} {
+		if !strings.Contains(detail, expected) {
+			t.Errorf("legacy dynamic query diagnostic %q does not contain %q", detail, expected)
+		}
+	}
+}
+
 func TestDashboardAccessPolicyForConfiguredRequest(t *testing.T) {
 	policy := types.StringValue(`{"version":"2025-01-01"}`)
 

--- a/internal/provider/dashboards/resource_coralogix_dashboard_test.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard_test.go
@@ -629,7 +629,7 @@ func TestFlattenDashboardRejectsDynamicWidgetWithoutPartialState(t *testing.T) {
 		t.Fatal("flatten dynamic dashboard returned no error diagnostic")
 	}
 	detail := diags.Errors()[0].Summary() + ": " + diags.Errors()[0].Detail()
-	for _, expected := range []string{"Unsupported Dashboard Widget Definition", "dynamic", "content_json", "import", "data-source"} {
+	for _, expected := range []string{"Unsupported Dashboard Widget Definition", "dynamic", "visualization", "content_json"} {
 		if !strings.Contains(detail, expected) {
 			t.Errorf("dynamic dashboard diagnostic %q does not contain %q", detail, expected)
 		}

--- a/internal/provider/resource_coralogix_dashboard_dynamic_test.go
+++ b/internal/provider/resource_coralogix_dashboard_dynamic_test.go
@@ -15,16 +15,24 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
 )
 
+const dashboardOpenAPIDynamicStatTestName = "TestAccCoralogixResourceDashboardDynamicStatWidget"
+
 func TestAccCoralogixResourceDashboardDynamicStatWidget(t *testing.T) {
-	name := dashboardOpenAPIFixtureName(t.Name())
+	ctx := context.Background()
+	var client *dashboardservice.DashboardServiceAPIService
+	fixture := t.Name()
+	name := dashboardOpenAPIFixtureName(fixture)
 	widgetPrefix := "layout.sections.0.rows.0.widgets.0.definition.dynamic."
 	statPrefix := widgetPrefix + "visualization.stat."
 	spansPrefix := "layout.sections.0.rows.0.widgets.1.definition.dynamic.query_definitions.0.query.spans."
@@ -35,123 +43,180 @@ func TestAccCoralogixResourceDashboardDynamicStatWidget(t *testing.T) {
 	thresholds := `{ from = 0, color = "green", label = "ok" }`
 	thresholdsUpdated := `{ from = 0, color = "green", label = "ok" }, { from = 1000, color = "red", label = "high" }`
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckDashboardDestroy(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCoralogixResourceDashboardDynamicStatConfig(name, "dynamic stat logs", thresholds, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
-					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.title", "dynamic stat logs"),
-					resource.TestCheckResourceAttrSet(dashboardResourceName, widgetPrefix+"query_definitions.0.id"),
-					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.name", "errors"),
-					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.group_by.0.keypath.0", "subsystemname"),
-					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.group_by.0.scope", "label"),
-					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.aggregations.0.type", "count"),
-					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.filters.0.field", "applicationname"),
-					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.data_mode_type", "unspecified"),
-					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"interpretation", "single_value_kpi_stat"),
-					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"time_frame.relative.duration", "seconds:900"),
+	backendCheck := func(state *terraform.State) error {
+		dashboard, err := dashboardOpenAPIFetchDashboard(ctx, client, state, dashboardResourceName, fixture)
+		if err != nil {
+			return err
+		}
+		return dashboardOpenAPIAssertDynamicStatWidgets(dashboard, fixture)
+	}
 
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"allow_abbreviation", "true"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"category_fields.0.keypath.0", "applicationname"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"category_fields.0.scope", "label"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"custom_unit", "widgets"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"decimal_precision", "2"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"display_series_name", "true"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.is_visible", "true"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.columns.0", "min"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.group_by_query", "true"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.placement", "bottom"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend_by", "thresholds"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"max", "100"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"min", "0"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"threshold_by", "background"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"threshold_type", "absolute"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.from", "0"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.color", "green"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.label", "ok"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"unit", "custom"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_field.keypath.0", "meta.responseTime.numeric"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_field.scope", "user_data"),
-					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_fields.0.keypath.0", "meta.responseTime.numeric"),
+	steps := dashboardOpenAPIStructuredLifecycleSteps(
+		dashboardOpenAPILifecyclePhase{
+			Config: testAccCoralogixResourceDashboardDynamicStatConfig(name, "dynamic stat logs", thresholds, true),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+				resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.title", "dynamic stat logs"),
+				resource.TestCheckResourceAttrSet(dashboardResourceName, widgetPrefix+"query_definitions.0.id"),
+				resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.name", "errors"),
+				resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.group_by.0.keypath.0", "subsystemname"),
+				resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.group_by.0.scope", "label"),
+				resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.aggregations.0.type", "count"),
+				resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.filters.0.field", "applicationname"),
+				resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.data_mode_type", "unspecified"),
+				resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"interpretation", "single_value_kpi_stat"),
+				resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"time_frame.relative.duration", "seconds:900"),
 
-					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.1.title", "dynamic stat spans"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"lucene_query", "*"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.keypath.0", "service"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.keypath.1", "name"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.scope", "user_data"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.relation_type", "unspecified"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"aggregations.0.type", "count"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.field.type", "metadata"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.field.value", "application_name"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.operator.type", "equals"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.operator.selected_values.0", "api"),
-					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"data_mode_type", "unspecified"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"allow_abbreviation", "true"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"category_fields.0.keypath.0", "applicationname"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"category_fields.0.scope", "label"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"custom_unit", "widgets"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"decimal_precision", "2"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"display_series_name", "true"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.is_visible", "true"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.columns.0", "min"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.group_by_query", "true"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.placement", "bottom"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend_by", "thresholds"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"max", "100"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"min", "0"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"threshold_by", "background"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"threshold_type", "absolute"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.from", "0"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.color", "green"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.label", "ok"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"unit", "custom"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_field.keypath.0", "meta.responseTime.numeric"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_field.scope", "user_data"),
+				resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_fields.0.keypath.0", "meta.responseTime.numeric"),
 
-					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.1.widgets.0.title", "dynamic stat metrics explicit"),
-					resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"promql_query", "vector(1)"),
-					resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"promql_query_type", "instant"),
-					resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"editor_mode", "text"),
-					resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"series_limit_type", "by_series_count"),
+				resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.1.title", "dynamic stat spans"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"lucene_query", "*"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.keypath.0", "service"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.keypath.1", "name"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.scope", "user_data"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.relation_type", "unspecified"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"aggregations.0.type", "count"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.field.type", "metadata"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.field.value", "application_name"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.operator.type", "equals"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.operator.selected_values.0", "api"),
+				resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"data_mode_type", "unspecified"),
 
-					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.1.widgets.1.title", "dynamic stat metrics defaults"),
-					resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"promql_query", "vector(2)"),
-					resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"promql_query_type", "unspecified"),
-					resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"editor_mode", "unspecified"),
-					resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"series_limit_type", "unspecified"),
+				resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.1.widgets.0.title", "dynamic stat metrics explicit"),
+				resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"promql_query", "vector(1)"),
+				resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"promql_query_type", "instant"),
+				resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"editor_mode", "text"),
+				resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"series_limit_type", "by_series_count"),
 
-					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.2.widgets.0.title", "dynamic stat data prime"),
-					resource.TestCheckResourceAttr(dashboardResourceName, dataPrimePrefix+"query", "source logs | limit 10"),
-					resource.TestCheckResourceAttr(dashboardResourceName, dataPrimePrefix+"data_mode_type", "unspecified"),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+				resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.1.widgets.1.title", "dynamic stat metrics defaults"),
+				resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"promql_query", "vector(2)"),
+				resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"promql_query_type", "unspecified"),
+				resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"editor_mode", "unspecified"),
+				resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"series_limit_type", "unspecified"),
+
+				resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.2.widgets.0.title", "dynamic stat data prime"),
+				resource.TestCheckResourceAttr(dashboardResourceName, dataPrimePrefix+"query", "source logs | limit 10"),
+				resource.TestCheckResourceAttr(dashboardResourceName, dataPrimePrefix+"data_mode_type", "unspecified"),
+
+				backendCheck,
+			),
+		},
+		[]dashboardOpenAPILifecyclePhase{
 			{
 				Config: testAccCoralogixResourceDashboardDynamicStatConfig(name, "dynamic stat logs updated", thresholdsUpdated, true),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(dashboardResourceName, plancheck.ResourceActionUpdate),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.title", "dynamic stat logs updated"),
 					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.1.from", "1000"),
 					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.1.color", "red"),
 					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.1.label", "high"),
+					backendCheck,
 				),
 			},
 			{
 				Config: testAccCoralogixResourceDashboardDynamicStatConfig(name, "dynamic stat logs updated", thresholdsUpdated, false),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(dashboardResourceName, plancheck.ResourceActionUpdate),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"interpretation", "unspecified"),
 					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"threshold_type", "unspecified"),
+					backendCheck,
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
+		resource.TestStep{
+			ResourceName:      dashboardResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			ImportStateCheck: dashboardOpenAPIImportDashboardCheck(ctx, &client, fixture, func(dashboard *dashboardservice.Dashboard) error {
+				return dashboardOpenAPIAssertDynamicStatWidgets(dashboard, fixture)
+			}),
+		},
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			client = dashboardOpenAPIAcceptanceClient(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(t),
+		Steps:                    steps,
 	})
+}
+
+func dashboardOpenAPIAssertDynamicStatWidgets(dashboard *dashboardservice.Dashboard, fixture string) error {
+	expected := []struct {
+		row         int
+		widget      int
+		queryBranch string
+	}{
+		{row: 0, widget: 0, queryBranch: "logs"},
+		{row: 0, widget: 1, queryBranch: "spans"},
+		{row: 1, widget: 0, queryBranch: "metrics"},
+		{row: 1, widget: 1, queryBranch: "metrics"},
+		{row: 2, widget: 0, queryBranch: "dataprime"},
+	}
+
+	sections := dashboard.Layout.Sections
+	if len(sections) != 1 {
+		return fmt.Errorf("dashboard fixture %q (dashboard %q): sections = %d, want 1", fixture, dashboard.GetId(), len(sections))
+	}
+	rows := sections[0].GetRows()
+
+	for _, want := range expected {
+		if want.row >= len(rows) {
+			return fmt.Errorf("dashboard fixture %q (dashboard %q): rows = %d, want row %d", fixture, dashboard.GetId(), len(rows), want.row)
+		}
+		widgets := rows[want.row].GetWidgets()
+		if want.widget >= len(widgets) {
+			return fmt.Errorf("dashboard fixture %q (dashboard %q): row %d widgets = %d, want widget %d", fixture, dashboard.GetId(), want.row, len(widgets), want.widget)
+		}
+
+		definition := widgets[want.widget].Definition
+		if definition == nil {
+			return fmt.Errorf("dashboard fixture %q (dashboard %q): row %d widget %d has no definition", fixture, dashboard.GetId(), want.row, want.widget)
+		}
+		if err := dashboardOpenAPIAssertOneOfBranch(definition, "WidgetDefinition", "dynamic", dashboard.GetId(), fixture); err != nil {
+			return err
+		}
+
+		dynamic := definition.Dynamic
+		if len(dynamic.GetQueryDefinitions()) != 1 {
+			return fmt.Errorf("dashboard fixture %q (dashboard %q): row %d widget %d dynamic queryDefinitions = %d, want 1", fixture, dashboard.GetId(), want.row, want.widget, len(dynamic.GetQueryDefinitions()))
+		}
+		query := &dynamic.QueryDefinitions[0].Query
+		if err := dashboardOpenAPIAssertOneOfBranch(query, "DynamicQuery", want.queryBranch, dashboard.GetId(), fixture); err != nil {
+			return err
+		}
+
+		if dynamic.Visualization == nil {
+			return fmt.Errorf("dashboard fixture %q (dashboard %q): row %d widget %d dynamic visualization is nil", fixture, dashboard.GetId(), want.row, want.widget)
+		}
+		if err := dashboardOpenAPIAssertOneOfBranch(dynamic.Visualization, "Visualization", "stat", dashboard.GetId(), fixture); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func testAccCoralogixResourceDashboardDynamicStatConfig(name, statTitle, statThresholds string, setOptionalEnums bool) string {

--- a/internal/provider/resource_coralogix_dashboard_dynamic_test.go
+++ b/internal/provider/resource_coralogix_dashboard_dynamic_test.go
@@ -368,6 +368,30 @@ func testAccCoralogixResourceDashboardDynamicStatConfig(name, statTitle, statThr
 func TestAccCoralogixResourceDashboardDynamicRejectsEmptyLists(t *testing.T) {
 	name := dashboardOpenAPIFixtureName(t.Name())
 
+	t.Run("spans_filters", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{{
+				Config: fmt.Sprintf(`resource "coralogix_dashboard" "test" {
+  name = %q
+  layout = { sections = [{ rows = [{
+    height = 19
+    widgets = [{
+      title = "empty spans filters"
+      definition = { dynamic = {
+        query_definitions = [{ query = { spans = { lucene_query = "*", filters = [] } } }]
+        visualization     = { stat = {} }
+      }}
+    }]
+  }] }] }
+}
+`, name),
+				ExpectError: regexp.MustCompile(`(?s)list must contain at least 1 element`),
+			}},
+		})
+	})
+
 	for attribute, visualization := range map[string]string{
 		"thresholds":                `stat = { thresholds = [] }`,
 		"category_fields":           `stat = { category_fields = [] }`,

--- a/internal/provider/resource_coralogix_dashboard_dynamic_test.go
+++ b/internal/provider/resource_coralogix_dashboard_dynamic_test.go
@@ -1,0 +1,401 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestAccCoralogixResourceDashboardDynamicStatWidget(t *testing.T) {
+	name := dashboardOpenAPIFixtureName(t.Name())
+	widgetPrefix := "layout.sections.0.rows.0.widgets.0.definition.dynamic."
+	statPrefix := widgetPrefix + "visualization.stat."
+	spansPrefix := "layout.sections.0.rows.0.widgets.1.definition.dynamic.query_definitions.0.query.spans."
+	metricsExplicitPrefix := "layout.sections.0.rows.1.widgets.0.definition.dynamic.query_definitions.0.query.metrics."
+	metricsDefaultPrefix := "layout.sections.0.rows.1.widgets.1.definition.dynamic.query_definitions.0.query.metrics."
+	dataPrimePrefix := "layout.sections.0.rows.2.widgets.0.definition.dynamic.query_definitions.0.query.data_prime."
+
+	thresholds := `{ from = 0, color = "green", label = "ok" }`
+	thresholdsUpdated := `{ from = 0, color = "green", label = "ok" }, { from = 1000, color = "red", label = "high" }`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceDashboardDynamicStatConfig(name, "dynamic stat logs", thresholds, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.title", "dynamic stat logs"),
+					resource.TestCheckResourceAttrSet(dashboardResourceName, widgetPrefix+"query_definitions.0.id"),
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.name", "errors"),
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.group_by.0.keypath.0", "subsystemname"),
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.group_by.0.scope", "label"),
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.aggregations.0.type", "count"),
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.filters.0.field", "applicationname"),
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"query_definitions.0.query.logs.data_mode_type", "unspecified"),
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"interpretation", "single_value_kpi_stat"),
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"time_frame.relative.duration", "seconds:900"),
+
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"allow_abbreviation", "true"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"category_fields.0.keypath.0", "applicationname"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"category_fields.0.scope", "label"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"custom_unit", "widgets"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"decimal_precision", "2"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"display_series_name", "true"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.is_visible", "true"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.columns.0", "min"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.group_by_query", "true"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend.placement", "bottom"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"legend_by", "thresholds"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"max", "100"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"min", "0"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"threshold_by", "background"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"threshold_type", "absolute"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.from", "0"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.color", "green"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.0.label", "ok"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"unit", "custom"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_field.keypath.0", "meta.responseTime.numeric"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_field.scope", "user_data"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"value_fields.0.keypath.0", "meta.responseTime.numeric"),
+
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.1.title", "dynamic stat spans"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"lucene_query", "*"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.keypath.0", "service"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.keypath.1", "name"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.scope", "user_data"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"group_by.0.relation_type", "unspecified"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"aggregations.0.type", "count"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.field.type", "metadata"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.field.value", "application_name"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.operator.type", "equals"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"filters.0.operator.selected_values.0", "api"),
+					resource.TestCheckResourceAttr(dashboardResourceName, spansPrefix+"data_mode_type", "unspecified"),
+
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.1.widgets.0.title", "dynamic stat metrics explicit"),
+					resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"promql_query", "vector(1)"),
+					resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"promql_query_type", "instant"),
+					resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"editor_mode", "text"),
+					resource.TestCheckResourceAttr(dashboardResourceName, metricsExplicitPrefix+"series_limit_type", "by_series_count"),
+
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.1.widgets.1.title", "dynamic stat metrics defaults"),
+					resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"promql_query", "vector(2)"),
+					resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"promql_query_type", "unspecified"),
+					resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"editor_mode", "unspecified"),
+					resource.TestCheckResourceAttr(dashboardResourceName, metricsDefaultPrefix+"series_limit_type", "unspecified"),
+
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.2.widgets.0.title", "dynamic stat data prime"),
+					resource.TestCheckResourceAttr(dashboardResourceName, dataPrimePrefix+"query", "source logs | limit 10"),
+					resource.TestCheckResourceAttr(dashboardResourceName, dataPrimePrefix+"data_mode_type", "unspecified"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccCoralogixResourceDashboardDynamicStatConfig(name, "dynamic stat logs updated", thresholdsUpdated, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(dashboardResourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.title", "dynamic stat logs updated"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.1.from", "1000"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.1.color", "red"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"thresholds.1.label", "high"),
+				),
+			},
+			{
+				Config: testAccCoralogixResourceDashboardDynamicStatConfig(name, "dynamic stat logs updated", thresholdsUpdated, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(dashboardResourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dashboardResourceName, widgetPrefix+"interpretation", "unspecified"),
+					resource.TestCheckResourceAttr(dashboardResourceName, statPrefix+"threshold_type", "unspecified"),
+				),
+			},
+			{
+				ResourceName:      dashboardResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCoralogixResourceDashboardDynamicStatConfig(name, statTitle, statThresholds string, setOptionalEnums bool) string {
+	interpretation := ""
+	thresholdType := ""
+	if setOptionalEnums {
+		interpretation = `
+                  interpretation = "single_value_kpi_stat"`
+		thresholdType = `
+                      threshold_type      = "absolute"`
+	}
+
+	return fmt.Sprintf(`resource "coralogix_dashboard" "test" {
+  name        = %q
+  description = "dynamic stat widget acceptance coverage"
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+  layout = {
+    sections = [{
+      rows = [
+        {
+          height = 19
+          widgets = [
+            {
+              title = %q
+              definition = {
+                dynamic = {
+                  query_definitions = [{
+                    name = "errors"
+                    query = {
+                      logs = {
+                        lucene_query = "coralogix.metadata.severity=\"5\""
+                        group_by = [{
+                          keypath = ["subsystemname"]
+                          scope   = "label"
+                        }]
+                        aggregations = [{
+                          type = "count"
+                        }]
+                        filters = [{
+                          field = "applicationname"
+                          operator = {
+                            type            = "equals"
+                            selected_values = ["api"]
+                          }
+                        }]
+                      }
+                    }
+                  }]%s
+                  time_frame = {
+                    relative = {
+                      duration = "seconds:900"
+                    }
+                  }
+                  visualization = {
+                    stat = {
+                      allow_abbreviation  = true
+                      custom_unit         = "widgets"
+                      decimal_precision   = 2
+                      display_series_name = true
+                      legend_by           = "thresholds"
+                      max                 = 100
+                      min                 = 0
+                      threshold_by        = "background"
+                      unit                = "custom"%s
+                      thresholds          = [%s]
+                      legend = {
+                        is_visible     = true
+                        columns        = ["min"]
+                        group_by_query = true
+                        placement      = "bottom"
+                      }
+                      category_fields = [{
+                        keypath = ["applicationname"]
+                        scope   = "label"
+                      }]
+                      value_field = {
+                        keypath = ["meta.responseTime.numeric"]
+                        scope   = "user_data"
+                      }
+                      value_fields = [{
+                        keypath = ["meta.responseTime.numeric"]
+                        scope   = "user_data"
+                      }]
+                    }
+                  }
+                }
+              }
+            },
+            {
+              title = "dynamic stat spans"
+              definition = {
+                dynamic = {
+                  query_definitions = [{
+                    name = "spans errors"
+                    query = {
+                      spans = {
+                        lucene_query = "*"
+                        group_by = [{
+                          keypath = ["service", "name"]
+                          scope   = "user_data"
+                        }]
+                        aggregations = [{
+                          type = "count"
+                        }]
+                        filters = [{
+                          field = {
+                            type  = "metadata"
+                            value = "application_name"
+                          }
+                          operator = {
+                            type            = "equals"
+                            selected_values = ["api"]
+                          }
+                        }]
+                      }
+                    }
+                  }]
+                  visualization = {
+                    stat = {
+                      unit = "bytes"
+                    }
+                  }
+                }
+              }
+            },
+          ]
+        },
+        {
+          height = 19
+          widgets = [
+            {
+              title = "dynamic stat metrics explicit"
+              definition = {
+                dynamic = {
+                  query_definitions = [{
+                    name = "metrics explicit"
+                    query = {
+                      metrics = {
+                        promql_query      = "vector(1)"
+                        promql_query_type = "instant"
+                        editor_mode       = "text"
+                        series_limit_type = "by_series_count"
+                      }
+                    }
+                  }]
+                  visualization = {
+                    stat = {
+                      unit = "bytes"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              title = "dynamic stat metrics defaults"
+              definition = {
+                dynamic = {
+                  query_definitions = [{
+                    name = "metrics defaults"
+                    query = {
+                      metrics = {
+                        promql_query = "vector(2)"
+                      }
+                    }
+                  }]
+                  visualization = {
+                    stat = {
+                      unit = "bytes"
+                    }
+                  }
+                }
+              }
+            },
+          ]
+        },
+        {
+          height = 19
+          widgets = [{
+            title = "dynamic stat data prime"
+            definition = {
+              dynamic = {
+                query_definitions = [{
+                  name = "dataprime logs"
+                  query = {
+                    data_prime = {
+                      query = "source logs | limit 10"
+                    }
+                  }
+                }]
+                visualization = {
+                  stat = {
+                    unit = "bytes"
+                  }
+                }
+              }
+            }
+          }]
+        },
+      ]
+    }]
+  }
+}
+`, name, statTitle, interpretation, thresholdType, statThresholds)
+}
+
+// An explicitly empty list is not the same value as an absent one: expansion
+// sends an empty slice, the API omits it, and the refreshed value comes back
+// null, which fails the apply with an inconsistent-result error. The size
+// validators turn that into a plan-time error naming the attribute.
+func TestAccCoralogixResourceDashboardDynamicRejectsEmptyLists(t *testing.T) {
+	name := dashboardOpenAPIFixtureName(t.Name())
+
+	for attribute, visualization := range map[string]string{
+		"thresholds":                `stat = { thresholds = [] }`,
+		"category_fields":           `stat = { category_fields = [] }`,
+		"value_fields":              `stat = { value_fields = [] }`,
+		"observation_field_keypath": `stat = { category_fields = [{ keypath = [], scope = "label" }] }`,
+	} {
+		t.Run(attribute, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{{
+					Config: fmt.Sprintf(`resource "coralogix_dashboard" "test" {
+  name = %q
+  layout = { sections = [{ rows = [{
+    height = 19
+    widgets = [{
+      title = "empty list"
+      definition = { dynamic = {
+        query_definitions = [{ query = { logs = { lucene_query = "*" } } }]
+        visualization     = { %s }
+      }}
+    }]
+  }] }] }
+}
+`, name, visualization),
+					ExpectError: regexp.MustCompile(`(?s)list must contain at least 1 element`),
+				}},
+			})
+		})
+	}
+}

--- a/internal/provider/resource_coralogix_dashboard_dynamic_test.go
+++ b/internal/provider/resource_coralogix_dashboard_dynamic_test.go
@@ -488,3 +488,36 @@ func TestAccCoralogixResourceDashboardDynamicRejectsEmptyLists(t *testing.T) {
 		})
 	}
 }
+
+// The proto documents decimal_precision as 0-15 (minimum: 0, maximum: 15). The
+// API does not enforce it — 16 is accepted and applied — so this is a plan-time
+// guard against a documented limit rather than a reflection of backend rejection.
+func TestAccCoralogixResourceDashboardDynamicRejectsOutOfRangeDecimalPrecision(t *testing.T) {
+	name := dashboardOpenAPIFixtureName(t.Name())
+
+	for _, precision := range []string{"16", "-1"} {
+		t.Run(precision, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{{
+					Config: fmt.Sprintf(`resource "coralogix_dashboard" "test" {
+  name = %q
+  layout = { sections = [{ rows = [{
+    height = 19
+    widgets = [{
+      title = "out of range decimal precision"
+      definition = { dynamic = {
+        query_definitions = [{ query = { logs = { lucene_query = "*" } } }]
+        visualization     = { stat = { decimal_precision = %s } }
+      }}
+    }]
+  }] }] }
+}
+`, name, precision),
+					ExpectError: regexp.MustCompile(`(?s)must be between 0 and 15`),
+				}},
+			})
+		})
+	}
+}

--- a/internal/provider/resource_coralogix_dashboard_hydration_test.go
+++ b/internal/provider/resource_coralogix_dashboard_hydration_test.go
@@ -192,7 +192,7 @@ func TestAccCoralogixResourceDashboardRESTCreatedUnsupportedDynamicHydration(t *
 	dashboardName := dashboardOpenAPIFixtureName(fixture)
 	variables := config.Variables{}
 	var dashboardID string
-	diagnostic := regexp.MustCompile(`(?s)Unsupported Dashboard Widget Definition.*dynamic.*content_json.*import.*data-source`)
+	diagnostic := regexp.MustCompile(`(?s)Unsupported Dashboard Widget Definition.*dynamic widget.*content_json`)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/provider/testdata/dashboards/content_json_dynamic_legacy_query.json
+++ b/internal/provider/testdata/dashboards/content_json_dynamic_legacy_query.json
@@ -1,0 +1,58 @@
+{
+  "name": "legacy dynamic top-level query",
+  "layout": {
+    "sections": [
+      {
+        "id": {
+          "value": "10000000-0000-4000-8000-000000000000"
+        },
+        "rows": [
+          {
+            "id": {
+              "value": "20000000-0000-4000-8000-000000000001"
+            },
+            "appearance": {
+              "height": 19
+            },
+            "widgets": [
+              {
+                "id": {
+                  "value": "30000000-0000-4000-8000-000000000001"
+                },
+                "title": "Dynamic logs table",
+                "definition": {
+                  "dynamic": {
+                    "interpretation": "INTERPRETATION_UNSPECIFIED",
+                    "visualization": {
+                      "stat": {
+                        "decimalPrecision": 0
+                      }
+                    },
+                    "query": {
+                      "logs": {
+                        "luceneQuery": {
+                          "value": ""
+                        },
+                        "dataModeType": "DATA_MODE_TYPE_HIGH_UNSPECIFIED",
+                        "filters": [],
+                        "groupBy": [],
+                        "aggregation": []
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "variables": [],
+  "variablesV2": [],
+  "filters": [],
+  "relativeTimeFrame": "900s",
+  "annotations": [],
+  "off": {},
+  "actions": []
+}


### PR DESCRIPTION
## What this does

The dashboards API has a widget type, `dynamic`, that the provider never supported. Worse, **reading** a dashboard that already contained one failed outright — so `terraform import` and the data source broke on any dashboard built in the Coralogix UI or through `content_json`.

This adds `dynamic` to HCL: the whole query side, and one visualization, `stat`.

```hcl
definition = {
  dynamic = {
    query_definitions = [{
      query = { logs = { lucene_query = "*", aggregations = [{ type = "count" }] } }
    }]
    visualization = { stat = { unit = "bytes", threshold_type = "absolute" } }
  }
}
```

A visualization that isn't supported yet still fails the read with a clear message telling the user to use `content_json`; it never writes half a widget into state.

## Where to look

| What | Where |
|---|---|
| The read that used to fail | `resource_coralogix_dashboard.go`, the flatten dispatch's `dynamic` branch |
| What the user writes | `dynamic.go` → `DynamicSchema()` |
| The two directions that must mirror each other | `expandDynamicVisualization` / `flattenDynamicVisualization` |

**The thing worth checking:** the write direction (HCL → API) and the read direction (API → state) have to carry the same fields. If the read drops a field the write sends, `import` loses it and the next `apply` sends it back empty — **clearing the setting on the server**. That's why `stat` models all of its API fields instead of a useful subset.

Adding a variant means wiring it into five places: the schema map, the attribute-type map, both dispatch switches, and the exactly-one-of list. Miss one and you get either an error on read or a branch that silently never fires.

## How the HCL differs from the API

Two renames, both to match what this provider already does elsewhere. Nothing else deviates.

**1. `aggregations`, not `aggregation`**
- *What it is:* the calculations a query runs — count, average, and so on.
- *API (wire):* `"aggregation": [ { "type": "count" } ]` — singular name, holds a list.
- *Terraform:* `aggregations = [{ type = "count" }]`
- *Why:* `data_table` and `line_chart` already spell it plural, so it reads the same across widgets.
- *Does the API restrict this too?* No. Terraform-only rename, mapped back to `aggregation` on send.

**2. Enum values in lower case**
- *API (wire):* `"dataModeType": "DATA_MODE_TYPE_ARCHIVE"`
- *Terraform:* `data_mode_type = "archive"`
- *Why:* every other resource here does this, so users don't learn a different spelling per field.
- *Does the API restrict this too?* No. Terraform-only, mapped back on send.

**Empty lists are now rejected when you plan, not when you apply**
- *What the user saw:* `thresholds = []` passed the plan and then broke the **first** apply with `Provider produced inconsistent result after apply … was cty.ListValEmpty(…), but now null`. Reproduced against a real environment.
- *What changed:* it fails at plan, naming the attribute. Every list this widget exposes is guarded.
- *Why:* an empty list and an absent list are different values. We send empty, the API stores nothing, the refresh reads back null — and Terraform rejects the mismatch.
- *Does the API restrict this too?* Yes. The API has no way to hold an empty list, so there is nothing that could round-trip.

**Two deprecated fields kept on purpose: `interpretation` and `value_field`**
The API deprecates both — `interpretation` in favour of the visualization block, `value_field` in favour of `value_fields` — but dashboards out there still set them. Modelling them means those import cleanly and a later `apply` won't silently reset them. Both carry a deprecation notice, and deleting either from your config clears it rather than keeping the old value.

**`decimal_precision` accepts 0 to 15**
- *What it is:* how many digits to show after the decimal point.
- *API:* the proto documents `minimum: 0, maximum: 15`.
- *Terraform:* values outside that range are refused when you plan, naming the attribute.
- *Does the API restrict this too?* **No** — I applied `16` against a real environment and it was accepted and stored. This is a guard against the documented limit, not a mirror of backend behaviour, and the code says so where a future reader will see it.

## Scope

**Reused, not rewritten.** The query, filter and observation-field schemas are the same shared ones the existing widgets use.

**Two shared fixes, both the same bug as above.** `keypath` on observation fields and `filters` on spans queries accepted an empty list at plan and then failed the apply — reproduced against a real environment for both. This widget exposes both, so leaving them would ship a known bug in the new surface, and copying the schemas to fix them here only would be worse. **Not breaking, and no one-time diff on upgrade:** the only config they newly reject is one that already fails at apply today. No existing config, test or example sets either list to empty.

**The API-coverage manifest is reclassified.** The repo tracks every branch of the API and how the provider covers it. `dynamic`, its four query branches and `stat` move from "only usable through `content_json`, no import" to "covered by a test". The other visualizations stay as they are. Without this the coverage suite keeps passing while reporting the new surface as missing.

**Schema stays at version 4.** Adding an optional attribute needs no state upgrader — asserted, not assumed, below.

The remaining pre-existing bugs in shared enum maps and object validators are a separate PR, deliberately left out.

## Evidence

`TestAccCoralogixResourceDashboardDynamicStatWidget` runs against a real Coralogix environment on the repo's enforced create/update/import lifecycle: all four query sources, the metrics query with its optional fields both set and both left out, an update, a step that removes optional fields, and a verified import. Every step asserts the next plan is empty and reads the dashboard back from the API. **Every field of `stat` is set and checked**, so each one is proven to survive the trip out to the backend and back.

`TestAccCoralogixResourceDashboardDynamicRejectsEmptyLists` — `thresholds`, `category_fields`, `value_fields`, an observation field's `keypath` and a spans query's `filters` set to `[]` are each refused at plan.

`TestCurrentSchemaDecodesNarrowDynamicStatState` reads a stat widget stored before these fields existed, using the current schema — the evidence for keeping version 4. Honest limit: it can only fail for a type change or a removal, not for a purely additive one.

`TestFlattenDashboardRejectsDynamicWidgetWithLegacyTopLevelQuery` covers the deprecated-query case above. Worth stating how that one was found, because no test in this PR could have: a reviewer read the flatten and asked what happens to the old field. I then authored the legacy shape through `content_json` and read it back from a real environment, which returned the deprecated `query` populated and `query_definitions` empty — so the dashboard state is reachable, not theoretical. Without the guard the widget's only data source was dropped silently and a later apply would have erased it from the live dashboard. The test was checked by removing the guard and confirming it fails.

Unit tests in `dynamic_test.go` check `stat` and the query union survive expand → flatten. The example passes `terraform validate`; docs are regenerated.

**Checked in the product, not just the API.** The example was applied to a real account and the widget renders, with the threshold colours working — `14K` in red against the `1000` threshold. Two things that only a UI check could surface:

- On an account with no matching data the widget reports *"Data doesn't match this widget type"* rather than *"No data found"*. Nothing is wrong with the configuration; the message is just misleading when the account is empty.
- **Opening a `dynamic` `stat` in the UI editor rewrites it to a `stat_card`** and saves that. After that, this branch can no longer read the dashboard — the read fails with the diagnostic above, which is the fail-closed behaviour working as intended on a real payload. The follow-up PR adds `stat_card` and resolves it, so **the two should ship in the same release**; on its own this one leaves a dashboard that Terraform cannot read once anyone edits the widget in the product.

`TestDashboardProtoOneOfInventoryAgainstCheckout` cross-checks the manifest against the protobuf definitions. It needs a current sibling `cx-management-apis` checkout — with a stale one it stops at a count mismatch before reaching the manifest comparison, which is what happened to me at first. Against a current checkout it passes, so the reclassification above is verified against the protos and not only against the generated client.

## Not included, on purpose

- **The other visualizations** — `stat_card` next, then `table` and the time-series ones, the bar charts, and finally gauge, pie, hexagon, heatmap and geomap. Each brings its own tests, docs and example.
- **The deprecated single `query`** on the widget — use `query_definitions`, which holds the same queries and more (several, each named). Note it is *not* true that the API migrates the old field to the new one: I assumed that and it is wrong. A dashboard can hold a populated deprecated `query` with no `query_definitions` at all, so the read now refuses such a widget rather than dropping its data source — see the evidence section.
- **The shared-code bug fixes**, per the scope note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


