### PR TITLE
Bump SDK and adapt variables_v2 to required OpenAPI value types

### DIFF
--- a/.claude/skills/dashboard-variables-v2-wire-shape/SKILL.md
+++ b/.claude/skills/dashboard-variables-v2-wire-shape/SKILL.md
@@ -19,6 +19,7 @@ description: "Use when expanding/flattening coralogix_dashboard variables_v2, or
 - empty `value_display_options`: schema `AtLeastOneOfChildren` rejects `{}` (Framework cannot plan null when config keeps the block; omit the block or set a regex)
 - empty `multi_string.list.values` → flatten known empty list, not null (values is Required)
 - enums (`display_type`, order, refresh, data_mode) → `OptionalEnumPointer` (never pointer-to-empty)
+- OpenAPI-required fields (`VariableV2` id/name/display_name/display_type/source/value, static/query all_option + values_order_direction, ValueLabel value/label, AllOption.include_all, logs FieldValue.observation_field, metrics LabelValue.label_name) are non-pointer SDK values — expand with `requiredEnumValue` / `derefOrZero` / `ValueString()`, flatten by address (`&variable.Source`) and `types.StringValue` / `types.BoolValue`. TF schema stays Optional+Computed+Default where already defaulted; do not re-mark schema Required just because the Go type lost `*`.
 - static `values[].label`: Optional+Computed + `StaticValueLabelFromValue` (omit → plan=`value`). Flatten always stores API label (incl. label==value). Never `UseStateForUnknown` — needed for omit→set→omit and omit→value-change. Expand still copies `value` if label null/unknown.
 On flatten, fill missing oneof siblings as null from schema AttrTypes (API omits unset arms).
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
       - id: go-imports
       - id: go-cyclo
         args: [-over=15]
-        exclude: _test\.go$
       - id: validate-toml
       - id: no-go-testing
       - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       - id: go-imports
       - id: go-cyclo
         args: [-over=15]
+        exclude: _test\.go$
       - id: validate-toml
       - id: no-go-testing
       - id: golangci-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Unreleased
 
 #### provider
+- CHORE: Bump `coralogix-management-sdk` to include OpenAPI required fields for dashboard `variables_v2`.
+
+#### resource/coralogix_dashboard
+- FIX: Adapt `variables_v2` expand/flatten to SDK required value types (`id`, `name`, `display_name`, `display_type`, `source`, `value`, static/query `all_option` / `values_order_direction`, static `values[].value`/`label`, logs `observation_field`, metrics `label_name`).
+
+#### provider
 - FIX: API error diagnostics now classify failures by HTTP status and include the backend's response body, instead of showing only the bare error text.
 - FIX: gRPC error diagnostics now surface the attached `google.rpc` details (for example, per-field validation messages).
 - FIX: Error diagnostics no longer echo the request payload, so credentials carried in a request body cannot leak into CLI or CI logs.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260729141455-fd0f828d882b
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260729141455-fd0f828d882b h1:FooEe+Je4Mxqsy2AHMw0/BXzOKgcfmGOnGNvT8H9/7I=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260729141455-fd0f828d882b/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c h1:zWTINNZMXUGkdO5rB3Ld0y6uwz0usyFCMoCfx/860Eg=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5 h1:mqmL/WJA8Cdzim6r3jmXY8uiPn9KX4AvqxjEPDRXKj4=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/dashboards/variables_v2.go
+++ b/internal/provider/dashboards/variables_v2.go
@@ -256,12 +256,12 @@ func expandDashboardVariableV2(ctx context.Context, model DashboardVariableV2Mod
 	}
 
 	result := &dashboardservice.VariableV2{
-		Id:          dashboardwidgets.ExpandDashboardUUID(model.ID),
-		Name:        utils.TypeStringToStringPointer(model.Name),
-		DisplayName: utils.TypeStringToStringPointer(model.DisplayName),
-		DisplayType: dashboardwidgets.OptionalEnumPointer(model.DisplayType, dashboardwidgets.DashboardSchemaToProtoDisplayTypeV2),
-		Source:      source,
-		Value:       value,
+		Id:          *dashboardwidgets.ExpandDashboardUUID(model.ID),
+		Name:        model.Name.ValueString(),
+		DisplayName: model.DisplayName.ValueString(),
+		DisplayType: requiredEnumValue(model.DisplayType, dashboardwidgets.DashboardSchemaToProtoDisplayTypeV2),
+		Source:      derefOrZero(source),
+		Value:       derefOrZero(value),
 	}
 	if !model.Description.IsNull() && !model.Description.IsUnknown() {
 		result.Description = model.Description.ValueStringPointer()
@@ -317,7 +317,7 @@ func expandStaticSourceV2(ctx context.Context, model *staticSourceV2Model) (*das
 		return nil, diags
 	}
 	return &dashboardservice.StaticSource{
-		ValuesOrderDirection: dashboardwidgets.OptionalEnumPointer(model.ValuesOrderDirection, dashboardwidgets.DashboardOrderDirectionSchemaToProtoV2),
+		ValuesOrderDirection: requiredEnumValue(model.ValuesOrderDirection, dashboardwidgets.DashboardOrderDirectionSchemaToProtoV2),
 		AllOption:            expandAllOptionV2(model.AllOption),
 		Values:               values,
 	}, nil
@@ -339,8 +339,8 @@ func expandStaticValuesV2(ctx context.Context, values types.List) ([]dashboardse
 			label = model.Value
 		}
 		entry := dashboardservice.ValueLabel{
-			Value: utils.TypeStringToStringPointer(model.Value),
-			Label: utils.TypeStringToStringPointer(label),
+			Value: model.Value.ValueString(),
+			Label: label.ValueString(),
 		}
 		if !model.IsDefault.IsNull() && !model.IsDefault.IsUnknown() {
 			entry.IsDefault = model.IsDefault.ValueBoolPointer()
@@ -350,13 +350,13 @@ func expandStaticValuesV2(ctx context.Context, values types.List) ([]dashboardse
 	return result, nil
 }
 
-func expandAllOptionV2(model *allOptionV2Model) *dashboardservice.AllOption {
+func expandAllOptionV2(model *allOptionV2Model) dashboardservice.AllOption {
 	if model == nil {
-		return nil
+		return dashboardservice.AllOption{}
 	}
-	result := &dashboardservice.AllOption{}
+	result := dashboardservice.AllOption{}
 	if !model.IncludeAll.IsNull() && !model.IncludeAll.IsUnknown() {
-		result.IncludeAll = model.IncludeAll.ValueBoolPointer()
+		result.IncludeAll = model.IncludeAll.ValueBool()
 	}
 	if !model.Label.IsNull() && !model.Label.IsUnknown() {
 		result.Label = model.Label.ValueStringPointer()
@@ -411,7 +411,7 @@ func expandTextboxDefaultValueV2(model *textboxDefaultValueV2Model) (*dashboards
 
 func expandQuerySourceV2(ctx context.Context, model *querySourceV2Model) (*dashboardservice.VariableSourceV2QuerySource, diag.Diagnostics) {
 	result := &dashboardservice.VariableSourceV2QuerySource{
-		ValuesOrderDirection: dashboardwidgets.OptionalEnumPointer(model.ValuesOrderDirection, dashboardwidgets.DashboardOrderDirectionSchemaToProtoV2),
+		ValuesOrderDirection: requiredEnumValue(model.ValuesOrderDirection, dashboardwidgets.DashboardOrderDirectionSchemaToProtoV2),
 		AllOption:            expandAllOptionV2(model.AllOption),
 		ValueDisplayOptions:  expandValueDisplayOptionsV2(model.ValueDisplayOptions),
 		RefreshStrategy:      dashboardwidgets.OptionalEnumPointer(model.RefreshStrategy, dashboardwidgets.DashboardSchemaToProtoVariableV2RefreshStrategy),
@@ -474,7 +474,7 @@ func expandLogsQueryV2(ctx context.Context, model *logsQueryV2Model) (*dashboard
 	return &dashboardservice.QuerySourceLogsQuery{
 		Type: &dashboardservice.QuerySourceLogsQueryType{
 			FieldValue: &dashboardservice.QuerySourceLogsQueryTypeFieldValue{
-				ObservationField: observationField,
+				ObservationField: derefOrZero(observationField),
 			},
 		},
 	}, diags
@@ -562,7 +562,7 @@ func expandMetricsLabelValueV2(ctx context.Context, model *metricsLabelValueV2Mo
 	}
 	return &dashboardservice.QuerySourceMetricsQueryTypeLabelValue{
 		MetricName:   metricName,
-		LabelName:    labelName,
+		LabelName:    derefOrZero(labelName),
 		LabelFilters: labelFilters,
 	}, diags
 }
@@ -827,11 +827,11 @@ func flattenDashboardVariableV2(ctx context.Context, variable *dashboardservice.
 	sourceType := elementType.AttrTypes["source"].(types.ObjectType)
 	valueType := elementType.AttrTypes["value"].(types.ObjectType)
 
-	source, diags := flattenVariableSourceV2(ctx, variable.Source, sourceType)
+	source, diags := flattenVariableSourceV2(ctx, &variable.Source, sourceType)
 	if diags.HasError() {
 		return types.ObjectNull(elementType.AttrTypes), diags
 	}
-	value, valueDiags := flattenVariableValueV2(ctx, variable.Value, valueType)
+	value, valueDiags := flattenVariableValueV2(ctx, &variable.Value, valueType)
 	diags.Append(valueDiags...)
 	if diags.HasError() {
 		return types.ObjectNull(elementType.AttrTypes), diags
@@ -839,15 +839,15 @@ func flattenDashboardVariableV2(ctx context.Context, variable *dashboardservice.
 
 	attrs := map[string]attr.Value{
 		"id":               flattenVariableID(variable.Id),
-		"name":             types.StringPointerValue(variable.Name),
-		"display_name":     types.StringPointerValue(variable.DisplayName),
+		"name":             types.StringValue(variable.Name),
+		"display_name":     types.StringValue(variable.DisplayName),
 		"description":      types.StringPointerValue(variable.Description),
 		"display_full_row": types.BoolPointerValue(variable.DisplayFullRow),
 		"source":           source,
 		"value":            value,
 	}
-	if variable.DisplayType != nil && *variable.DisplayType != dashboardservice.VARIABLEDISPLAYTYPEV2_VARIABLE_DISPLAY_TYPE_V2_UNSPECIFIED {
-		if mapped, ok := dashboardwidgets.DashboardProtoToSchemaDisplayTypeV2[*variable.DisplayType]; ok {
+	if variable.DisplayType != "" && variable.DisplayType != dashboardservice.VARIABLEDISPLAYTYPEV2_VARIABLE_DISPLAY_TYPE_V2_UNSPECIFIED {
+		if mapped, ok := dashboardwidgets.DashboardProtoToSchemaDisplayTypeV2[variable.DisplayType]; ok {
 			attrs["display_type"] = types.StringValue(mapped)
 		} else {
 			attrs["display_type"] = types.StringNull()
@@ -858,8 +858,8 @@ func flattenDashboardVariableV2(ctx context.Context, variable *dashboardservice.
 	return types.ObjectValueMust(elementType.AttrTypes, attrs), diags
 }
 
-func flattenVariableID(id *dashboardservice.UUID) types.String {
-	if id == nil || id.Value == nil {
+func flattenVariableID(id dashboardservice.UUID) types.String {
+	if id.Value == nil {
 		return types.StringNull()
 	}
 	return types.StringValue(*id.Value)
@@ -907,13 +907,9 @@ func flattenStaticSourceV2(ctx context.Context, source *dashboardservice.StaticS
 		return types.ObjectNull(objectType.AttrTypes), diags
 	}
 	attrs := map[string]attr.Value{
-		"values":     values,
-		"all_option": allOption,
-	}
-	if source.ValuesOrderDirection != nil {
-		attrs["values_order_direction"] = types.StringValue(dashboardwidgets.DashboardOrderDirectionProtoToSchemaV2[*source.ValuesOrderDirection])
-	} else {
-		attrs["values_order_direction"] = types.StringNull()
+		"values":                 values,
+		"all_option":             allOption,
+		"values_order_direction": flattenOrderDirectionV2(source.ValuesOrderDirection),
 	}
 	return types.ObjectValueMust(objectType.AttrTypes, attrs), diags
 }
@@ -929,20 +925,17 @@ func flattenStaticValuesV2(ctx context.Context, values []dashboardservice.ValueL
 		// Optional+Computed label uses StaticValueLabelFromValue so omitted config
 		// plans as value. Always store the API label (including when label==value).
 		elements = append(elements, types.ObjectValueMust(entryType.AttrTypes, map[string]attr.Value{
-			"value":      types.StringPointerValue(value.Value),
-			"label":      types.StringPointerValue(value.Label),
+			"value":      types.StringValue(value.Value),
+			"label":      types.StringValue(value.Label),
 			"is_default": types.BoolPointerValue(value.IsDefault),
 		}))
 	}
 	return types.ListValueMust(entryType, elements), nil
 }
 
-func flattenAllOptionV2(option *dashboardservice.AllOption, objectType types.ObjectType) (types.Object, diag.Diagnostics) {
-	if option == nil {
-		return types.ObjectNull(objectType.AttrTypes), nil
-	}
+func flattenAllOptionV2(option dashboardservice.AllOption, objectType types.ObjectType) (types.Object, diag.Diagnostics) {
 	return types.ObjectValueMust(objectType.AttrTypes, map[string]attr.Value{
-		"include_all": types.BoolPointerValue(option.IncludeAll),
+		"include_all": types.BoolValue(option.IncludeAll),
 		"label":       types.StringPointerValue(option.Label),
 	}), nil
 }
@@ -1024,12 +1017,8 @@ func flattenQuerySourceV2(ctx context.Context, source *dashboardservice.Variable
 	allOption, allDiags := flattenAllOptionV2(source.AllOption, objectType.AttrTypes["all_option"].(types.ObjectType))
 	diags.Append(allDiags...)
 	attrs["all_option"] = allOption
+	attrs["values_order_direction"] = flattenOrderDirectionV2(source.ValuesOrderDirection)
 
-	if source.ValuesOrderDirection != nil {
-		attrs["values_order_direction"] = types.StringValue(dashboardwidgets.DashboardOrderDirectionProtoToSchemaV2[*source.ValuesOrderDirection])
-	} else {
-		attrs["values_order_direction"] = types.StringNull()
-	}
 	if source.RefreshStrategy != nil && *source.RefreshStrategy != dashboardservice.VARIABLESOURCEV2REFRESHSTRATEGY_REFRESH_STRATEGY_UNSPECIFIED {
 		attrs["refresh_strategy"] = types.StringValue(dashboardwidgets.DashboardProtoToSchemaVariableV2RefreshStrategy[*source.RefreshStrategy])
 	} else {
@@ -1076,7 +1065,7 @@ func flattenLogsQueryV2(ctx context.Context, query *dashboardservice.QuerySource
 	}
 	var diags diag.Diagnostics
 	if query.Type != nil && query.Type.FieldValue != nil {
-		observationField, obsDiags := dashboardwidgets.FlattenObservationField(ctx, query.Type.FieldValue.ObservationField)
+		observationField, obsDiags := dashboardwidgets.FlattenObservationField(ctx, &query.Type.FieldValue.ObservationField)
 		diags.Append(obsDiags...)
 		typeAttrs["field_value"] = types.ObjectValueMust(
 			typeType.AttrTypes["field_value"].(types.ObjectType).AttrTypes,
@@ -1186,7 +1175,7 @@ func flattenMetricsLabelValueV2(ctx context.Context, value *dashboardservice.Que
 	if diags.HasError() {
 		return types.ObjectNull(objectType.AttrTypes), diags
 	}
-	labelName, labelDiags := flattenStringOrVariableV2(ctx, value.LabelName, objectType.AttrTypes["label_name"].(types.ObjectType))
+	labelName, labelDiags := flattenStringOrVariableV2(ctx, &value.LabelName, objectType.AttrTypes["label_name"].(types.ObjectType))
 	diags.Append(labelDiags...)
 	if diags.HasError() {
 		return types.ObjectNull(objectType.AttrTypes), diags
@@ -1479,4 +1468,30 @@ func boolPointerIfSet(value types.Bool) *bool {
 		return nil
 	}
 	return value.ValueBoolPointer()
+}
+
+// requiredEnumValue converts a Terraform string to a required OpenAPI enum value.
+// Null/unknown/unmapped values become the zero value (empty string). Schema defaults
+// keep real plans off this path; zero is only for incomplete expand fixtures.
+func requiredEnumValue[T ~string](value types.String, values map[string]T) T {
+	if p := dashboardwidgets.OptionalEnumPointer(value, values); p != nil {
+		return *p
+	}
+	var zero T
+	return zero
+}
+
+func derefOrZero[T any](value *T) T {
+	if value == nil {
+		var zero T
+		return zero
+	}
+	return *value
+}
+
+func flattenOrderDirectionV2(direction dashboardservice.OrderDirection) types.String {
+	if mapped, ok := dashboardwidgets.DashboardOrderDirectionProtoToSchemaV2[direction]; ok {
+		return types.StringValue(mapped)
+	}
+	return types.StringNull()
 }

--- a/internal/provider/dashboards/variables_v2_expand_flatten_test.go
+++ b/internal/provider/dashboards/variables_v2_expand_flatten_test.go
@@ -13,98 +13,40 @@ import (
 func TestExpandFlattenVariablesV2StaticRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	elementType := dashboardVariablesV2ElementType()
-
 	sourceType := elementType.AttrTypes["source"].(types.ObjectType)
 	valueType := elementType.AttrTypes["value"].(types.ObjectType)
 	staticType := sourceType.AttrTypes["static"].(types.ObjectType)
-	allOptionType := staticType.AttrTypes["all_option"].(types.ObjectType)
 	valuesType := staticType.AttrTypes["values"].(types.ListType)
 	valueEntryType := valuesType.ElemType.(types.ObjectType)
-	singleStringType := valueType.AttrTypes["single_string"].(types.ObjectType)
 
-	valueEntry, diags := types.ObjectValue(valueEntryType.AttrTypes, map[string]attr.Value{
+	valueEntry := mustObjectValue(t, valueEntryType.AttrTypes, map[string]attr.Value{
 		"value":      types.StringValue("production"),
 		"label":      types.StringValue("production"),
 		"is_default": types.BoolValue(true),
 	})
-	if diags.HasError() {
-		t.Fatalf("value entry: %v", diags)
-	}
-
-	values, diags := types.ListValue(valueEntryType, []attr.Value{valueEntry})
-	if diags.HasError() {
-		t.Fatalf("values: %v", diags)
-	}
-
-	allOption, diags := types.ObjectValue(allOptionType.AttrTypes, map[string]attr.Value{
-		"include_all": types.BoolValue(false),
-		"label":       types.StringNull(),
+	static := mustStaticSourceV2(t, staticType, mustListValue(t, valueEntryType, []attr.Value{valueEntry}))
+	source := mustSourceWithStaticV2(t, sourceType, static)
+	value := mustSingleStringValueV2(t, valueType, "production", "production")
+	list := mustListValue(t, elementType, []attr.Value{
+		mustVariableV2(t, elementType, "environment", "Environment", source, value),
 	})
-	if diags.HasError() {
-		t.Fatalf("all option: %v", diags)
-	}
 
-	static, diags := types.ObjectValue(staticType.AttrTypes, map[string]attr.Value{
-		"values_order_direction": types.StringValue("none"),
-		"all_option":             allOption,
-		"values":                 values,
-	})
-	if diags.HasError() {
-		t.Fatalf("static: %v", diags)
-	}
+	expanded := mustExpandVariablesV2(t, ctx, list)
+	assertStaticRoundTripExpanded(t, expanded)
 
-	source, diags := types.ObjectValue(sourceType.AttrTypes, map[string]attr.Value{
-		"static":  static,
-		"textbox": types.ObjectNull(sourceType.AttrTypes["textbox"].(types.ObjectType).AttrTypes),
-		"query":   types.ObjectNull(sourceType.AttrTypes["query"].(types.ObjectType).AttrTypes),
-	})
-	if diags.HasError() {
-		t.Fatalf("source: %v", diags)
+	flattened := mustFlattenVariablesV2(t, ctx, expanded, list)
+	var models []DashboardVariableV2Model
+	mustElementsAs(t, flattened, &models)
+	if len(models) != 1 || models[0].Name.ValueString() != "environment" {
+		t.Fatalf("flattened models = %#v", models)
 	}
+	if models[0].ID.IsNull() || models[0].ID.ValueString() == "" {
+		t.Fatal("expected generated id after expand/flatten")
+	}
+}
 
-	singleString, diags := types.ObjectValue(singleStringType.AttrTypes, map[string]attr.Value{
-		"value": types.StringValue("production"),
-		"label": types.StringValue("production"),
-	})
-	if diags.HasError() {
-		t.Fatalf("single string: %v", diags)
-	}
-
-	value, diags := types.ObjectValue(valueType.AttrTypes, map[string]attr.Value{
-		"single_string":  singleString,
-		"single_numeric": types.ObjectNull(valueType.AttrTypes["single_numeric"].(types.ObjectType).AttrTypes),
-		"regex":          types.ObjectNull(valueType.AttrTypes["regex"].(types.ObjectType).AttrTypes),
-		"lucene":         types.ObjectNull(valueType.AttrTypes["lucene"].(types.ObjectType).AttrTypes),
-		"interval":       types.ObjectNull(valueType.AttrTypes["interval"].(types.ObjectType).AttrTypes),
-		"multi_string":   types.ObjectNull(valueType.AttrTypes["multi_string"].(types.ObjectType).AttrTypes),
-	})
-	if diags.HasError() {
-		t.Fatalf("value: %v", diags)
-	}
-
-	variable, diags := types.ObjectValue(elementType.AttrTypes, map[string]attr.Value{
-		"id":               types.StringNull(),
-		"name":             types.StringValue("environment"),
-		"display_name":     types.StringValue("Environment"),
-		"description":      types.StringNull(),
-		"display_type":     types.StringValue("label_value"),
-		"display_full_row": types.BoolNull(),
-		"source":           source,
-		"value":            value,
-	})
-	if diags.HasError() {
-		t.Fatalf("variable: %v", diags)
-	}
-
-	list, diags := types.ListValue(elementType, []attr.Value{variable})
-	if diags.HasError() {
-		t.Fatalf("list: %v", diags)
-	}
-
-	expanded, expandDiags := expandDashboardVariablesV2(ctx, list)
-	if expandDiags.HasError() {
-		t.Fatalf("expand: %v", expandDiags)
-	}
+func assertStaticRoundTripExpanded(t *testing.T, expanded []dashboardservice.VariableV2) {
+	t.Helper()
 	if len(expanded) != 1 {
 		t.Fatalf("expected 1 variable, got %d", len(expanded))
 	}
@@ -120,121 +62,39 @@ func TestExpandFlattenVariablesV2StaticRoundTrip(t *testing.T) {
 	if expanded[0].Value.SingleString == nil || expanded[0].Value.SingleString.Value == nil {
 		t.Fatal("expected single string value")
 	}
-	if expanded[0].Value.SingleString.Value.GetValue() != "production" || expanded[0].Value.SingleString.Value.GetLabel() != "production" {
-		t.Fatalf("single string = %#v", expanded[0].Value.SingleString.Value)
-	}
-
-	flattened, flattenDiags := flattenDashboardVariablesV2(ctx, expanded, list)
-	if flattenDiags.HasError() {
-		t.Fatalf("flatten: %v", flattenDiags)
-	}
-	var models []DashboardVariableV2Model
-	if diags := flattened.ElementsAs(ctx, &models, false); diags.HasError() {
-		t.Fatalf("elements: %v", diags)
-	}
-	if len(models) != 1 || models[0].Name.ValueString() != "environment" {
-		t.Fatalf("flattened models = %#v", models)
-	}
-	if models[0].ID.IsNull() || models[0].ID.ValueString() == "" {
-		t.Fatal("expected generated id after expand/flatten")
+	got := expanded[0].Value.SingleString.Value
+	if got.GetValue() != "production" || got.GetLabel() != "production" {
+		t.Fatalf("single string = %#v", got)
 	}
 }
 
 func TestExpandFlattenVariablesV2StaticOmittedLabel(t *testing.T) {
 	ctx := context.Background()
 	elementType := dashboardVariablesV2ElementType()
-
 	sourceType := elementType.AttrTypes["source"].(types.ObjectType)
 	valueType := elementType.AttrTypes["value"].(types.ObjectType)
 	staticType := sourceType.AttrTypes["static"].(types.ObjectType)
-	allOptionType := staticType.AttrTypes["all_option"].(types.ObjectType)
 	valuesType := staticType.AttrTypes["values"].(types.ListType)
 	valueEntryType := valuesType.ElemType.(types.ObjectType)
-	singleStringType := valueType.AttrTypes["single_string"].(types.ObjectType)
 
-	valueEntry, diags := types.ObjectValue(valueEntryType.AttrTypes, map[string]attr.Value{
+	valueEntry := mustObjectValue(t, valueEntryType.AttrTypes, map[string]attr.Value{
 		"value":      types.StringValue("production"),
 		"label":      types.StringNull(),
 		"is_default": types.BoolValue(true),
 	})
-	if diags.HasError() {
-		t.Fatalf("value entry: %v", diags)
-	}
-	customEntry, diags := types.ObjectValue(valueEntryType.AttrTypes, map[string]attr.Value{
+	customEntry := mustObjectValue(t, valueEntryType.AttrTypes, map[string]attr.Value{
 		"value":      types.StringValue("staging"),
 		"label":      types.StringValue("Staging"),
 		"is_default": types.BoolNull(),
 	})
-	if diags.HasError() {
-		t.Fatalf("custom entry: %v", diags)
-	}
-	values, diags := types.ListValue(valueEntryType, []attr.Value{valueEntry, customEntry})
-	if diags.HasError() {
-		t.Fatalf("values: %v", diags)
-	}
-	allOption, diags := types.ObjectValue(allOptionType.AttrTypes, map[string]attr.Value{
-		"include_all": types.BoolValue(false),
-		"label":       types.StringNull(),
+	static := mustStaticSourceV2(t, staticType, mustListValue(t, valueEntryType, []attr.Value{valueEntry, customEntry}))
+	source := mustSourceWithStaticV2(t, sourceType, static)
+	value := mustSingleStringValueV2(t, valueType, "production", "production")
+	list := mustListValue(t, elementType, []attr.Value{
+		mustVariableV2(t, elementType, "environment", "Environment", source, value),
 	})
-	if diags.HasError() {
-		t.Fatalf("all option: %v", diags)
-	}
-	static, diags := types.ObjectValue(staticType.AttrTypes, map[string]attr.Value{
-		"values_order_direction": types.StringValue("none"),
-		"all_option":             allOption,
-		"values":                 values,
-	})
-	if diags.HasError() {
-		t.Fatalf("static: %v", diags)
-	}
-	source, diags := types.ObjectValue(sourceType.AttrTypes, map[string]attr.Value{
-		"static":  static,
-		"textbox": types.ObjectNull(sourceType.AttrTypes["textbox"].(types.ObjectType).AttrTypes),
-		"query":   types.ObjectNull(sourceType.AttrTypes["query"].(types.ObjectType).AttrTypes),
-	})
-	if diags.HasError() {
-		t.Fatalf("source: %v", diags)
-	}
-	singleString, diags := types.ObjectValue(singleStringType.AttrTypes, map[string]attr.Value{
-		"value": types.StringValue("production"),
-		"label": types.StringValue("production"),
-	})
-	if diags.HasError() {
-		t.Fatalf("single string: %v", diags)
-	}
-	value, diags := types.ObjectValue(valueType.AttrTypes, map[string]attr.Value{
-		"single_string":  singleString,
-		"single_numeric": types.ObjectNull(valueType.AttrTypes["single_numeric"].(types.ObjectType).AttrTypes),
-		"regex":          types.ObjectNull(valueType.AttrTypes["regex"].(types.ObjectType).AttrTypes),
-		"lucene":         types.ObjectNull(valueType.AttrTypes["lucene"].(types.ObjectType).AttrTypes),
-		"interval":       types.ObjectNull(valueType.AttrTypes["interval"].(types.ObjectType).AttrTypes),
-		"multi_string":   types.ObjectNull(valueType.AttrTypes["multi_string"].(types.ObjectType).AttrTypes),
-	})
-	if diags.HasError() {
-		t.Fatalf("value: %v", diags)
-	}
-	variable, diags := types.ObjectValue(elementType.AttrTypes, map[string]attr.Value{
-		"id":               types.StringNull(),
-		"name":             types.StringValue("environment"),
-		"display_name":     types.StringValue("Environment"),
-		"description":      types.StringNull(),
-		"display_type":     types.StringValue("label_value"),
-		"display_full_row": types.BoolNull(),
-		"source":           source,
-		"value":            value,
-	})
-	if diags.HasError() {
-		t.Fatalf("variable: %v", diags)
-	}
-	list, diags := types.ListValue(elementType, []attr.Value{variable})
-	if diags.HasError() {
-		t.Fatalf("list: %v", diags)
-	}
 
-	expanded, expandDiags := expandDashboardVariablesV2(ctx, list)
-	if expandDiags.HasError() {
-		t.Fatalf("expand: %v", expandDiags)
-	}
+	expanded := mustExpandVariablesV2(t, ctx, list)
 	gotValues := expanded[0].Source.Static.Values
 	if len(gotValues) != 2 {
 		t.Fatalf("values len = %d", len(gotValues))
@@ -246,25 +106,21 @@ func TestExpandFlattenVariablesV2StaticOmittedLabel(t *testing.T) {
 		t.Fatalf("custom label expand = %q, want Staging", gotValues[1].GetLabel())
 	}
 
-	flattened, flattenDiags := flattenDashboardVariablesV2(ctx, expanded, list)
-	if flattenDiags.HasError() {
-		t.Fatalf("flatten: %v", flattenDiags)
-	}
+	flattened := mustFlattenVariablesV2(t, ctx, expanded, list)
+	assertStaticOmittedLabelFlattened(t, ctx, flattened)
+}
+
+func assertStaticOmittedLabelFlattened(t *testing.T, ctx context.Context, flattened types.List) {
+	t.Helper()
 	var models []DashboardVariableV2Model
-	if diags := flattened.ElementsAs(ctx, &models, false); diags.HasError() {
-		t.Fatalf("elements: %v", diags)
-	}
+	mustElementsAs(t, flattened, &models)
 	var sourceModel variableSourceV2Model
-	if diags := models[0].Source.As(ctx, &sourceModel, basetypes.ObjectAsOptions{}); diags.HasError() {
-		t.Fatalf("source: %v", diags)
-	}
+	mustObjectAs(t, models[0].Source, &sourceModel)
 	if sourceModel.Static == nil {
 		t.Fatal("expected static source on flattened model")
 	}
 	var flatValues []staticValueV2Model
-	if diags := sourceModel.Static.Values.ElementsAs(ctx, &flatValues, false); diags.HasError() {
-		t.Fatalf("flat values: %v", diags)
-	}
+	mustElementsAs(t, sourceModel.Static.Values, &flatValues)
 	if len(flatValues) != 2 {
 		t.Fatalf("flat values len = %d", len(flatValues))
 	}
@@ -299,40 +155,16 @@ func TestExpandVariableV2OptionalEnumsOmitUnset(t *testing.T) {
 	sourceType := elementType.AttrTypes["source"].(types.ObjectType)
 	valueType := elementType.AttrTypes["value"].(types.ObjectType)
 	textboxType := sourceType.AttrTypes["textbox"].(types.ObjectType)
-	singleStringType := valueType.AttrTypes["single_string"].(types.ObjectType)
 
-	textbox, diags := types.ObjectValue(textboxType.AttrTypes, map[string]attr.Value{
+	textbox := mustObjectValue(t, textboxType.AttrTypes, map[string]attr.Value{
 		"default_value": types.ObjectNull(textboxType.AttrTypes["default_value"].(types.ObjectType).AttrTypes),
 	})
-	if diags.HasError() {
-		t.Fatalf("textbox: %v", diags)
-	}
-	source, diags := types.ObjectValue(sourceType.AttrTypes, map[string]attr.Value{
-		"static":  types.ObjectNull(sourceType.AttrTypes["static"].(types.ObjectType).AttrTypes),
+	source := mustObjectValue(t, sourceType.AttrTypes, map[string]attr.Value{
+		"static":  nullObjectAttr(sourceType.AttrTypes["static"]),
 		"textbox": textbox,
-		"query":   types.ObjectNull(sourceType.AttrTypes["query"].(types.ObjectType).AttrTypes),
+		"query":   nullObjectAttr(sourceType.AttrTypes["query"]),
 	})
-	if diags.HasError() {
-		t.Fatalf("source: %v", diags)
-	}
-	singleString, diags := types.ObjectValue(singleStringType.AttrTypes, map[string]attr.Value{
-		"value": types.StringValue("hello"),
-		"label": types.StringValue("hello"),
-	})
-	if diags.HasError() {
-		t.Fatalf("single string: %v", diags)
-	}
-	value, diags := types.ObjectValue(valueType.AttrTypes, map[string]attr.Value{
-		"single_string":  singleString,
-		"single_numeric": types.ObjectNull(valueType.AttrTypes["single_numeric"].(types.ObjectType).AttrTypes),
-		"regex":          types.ObjectNull(valueType.AttrTypes["regex"].(types.ObjectType).AttrTypes),
-		"lucene":         types.ObjectNull(valueType.AttrTypes["lucene"].(types.ObjectType).AttrTypes),
-		"interval":       types.ObjectNull(valueType.AttrTypes["interval"].(types.ObjectType).AttrTypes),
-		"multi_string":   types.ObjectNull(valueType.AttrTypes["multi_string"].(types.ObjectType).AttrTypes),
-	})
-	if diags.HasError() {
-		t.Fatalf("value: %v", diags)
-	}
+	value := mustSingleStringValueV2(t, valueType, "hello", "hello")
 
 	expanded, expandDiags := expandDashboardVariableV2(ctx, DashboardVariableV2Model{
 		ID:          types.StringNull(),
@@ -382,457 +214,161 @@ func TestFlattenVariableV2DisplayTypeUnspecifiedIsNull(t *testing.T) {
 	}
 }
 
-func TestExpandFlattenVariablesV2QueryWireShapes(t *testing.T) {
+func TestExpandFlattenVariablesV2PromqlAndEmptyMultiList(t *testing.T) {
 	ctx := context.Background()
-	elementType := dashboardVariablesV2ElementType()
-	sourceType := elementType.AttrTypes["source"].(types.ObjectType)
-	valueType := elementType.AttrTypes["value"].(types.ObjectType)
-	queryType := sourceType.AttrTypes["query"].(types.ObjectType)
-	allOptionType := queryType.AttrTypes["all_option"].(types.ObjectType)
-	displayOptionsType := queryType.AttrTypes["value_display_options"].(types.ObjectType)
-	metricsType := queryType.AttrTypes["metrics_query"].(types.ObjectType)
-	metricsInnerType := metricsType.AttrTypes["type"].(types.ObjectType)
-	promqlType := metricsInnerType.AttrTypes["promql_query"].(types.ObjectType)
-	dataprimeType := queryType.AttrTypes["dataprime_query"].(types.ObjectType)
-	dataprimeInnerType := dataprimeType.AttrTypes["type"].(types.ObjectType)
-	queryTextType := dataprimeInnerType.AttrTypes["query_text"].(types.ObjectType)
-	multiType := valueType.AttrTypes["multi_string"].(types.ObjectType)
-	listType := multiType.AttrTypes["list"].(types.ObjectType)
-	listValuesType := listType.AttrTypes["values"].(types.ListType)
-	listEntryType := listValuesType.ElemType.(types.ObjectType)
-	spansType := queryType.AttrTypes["spans_query"].(types.ObjectType)
-	spansInnerType := spansType.AttrTypes["type"].(types.ObjectType)
-	spansFieldValueType := spansInnerType.AttrTypes["field_value"].(types.ObjectType)
-	spanValueType := spansFieldValueType.AttrTypes["value"].(types.ObjectType)
-	stringOrVarType := metricsInnerType.AttrTypes["label_value"].(types.ObjectType).AttrTypes["metric_name"].(types.ObjectType)
-	filtersType := metricsInnerType.AttrTypes["label_value"].(types.ObjectType).AttrTypes["label_filters"].(types.ListType)
-	filterEntryType := filtersType.ElemType.(types.ObjectType)
-	operatorType := filterEntryType.AttrTypes["operator"].(types.ObjectType)
+	typeset := newVariablesV2QueryTypes(t)
+	allOption := mustAllOptionV2(t, typeset.queryType, true)
 
-	allOption, diags := types.ObjectValue(allOptionType.AttrTypes, map[string]attr.Value{
-		"include_all": types.BoolValue(true),
-		"label":       types.StringNull(),
+	promql := mustObjectValue(t, typeset.promqlType.AttrTypes, map[string]attr.Value{
+		"query":             types.StringValue("vector(1)"),
+		"promql_query_type": types.StringValue("instant"),
 	})
-	if diags.HasError() {
-		t.Fatalf("all option: %v", diags)
+	metricsInner := mustObjectValue(t, typeset.metricsInnerType.AttrTypes, map[string]attr.Value{
+		"metric_name":  nullObjectAttr(typeset.metricsInnerType.AttrTypes["metric_name"]),
+		"label_name":   nullObjectAttr(typeset.metricsInnerType.AttrTypes["label_name"]),
+		"label_value":  nullObjectAttr(typeset.metricsInnerType.AttrTypes["label_value"]),
+		"promql_query": promql,
+	})
+	metrics := mustObjectValue(t, typeset.metricsType.AttrTypes, map[string]attr.Value{"type": metricsInner})
+	query := mustQuerySourceV2(t, typeset, allOption, types.StringValue("on_dashboard_load"), map[string]attr.Value{
+		"metrics_query": metrics,
+	})
+	value := mustMultiStringListValueV2(t, typeset.valueType, typeset.multiType, typeset.listType, typeset.listEntryType, nil)
+	list := mustQueryVariableListV2(t, typeset, "prom", "Prom", query, value)
+
+	expanded := mustExpandVariablesV2(t, ctx, list)
+	got := expanded[0]
+	if got.Source.Query.ValueDisplayOptions != nil {
+		t.Fatalf("omitted display options should expand nil, got %#v", got.Source.Query.ValueDisplayOptions)
+	}
+	promqlQuery := got.Source.Query.MetricsQuery.Type.PromqlQuery
+	if promqlQuery == nil || promqlQuery.Query == nil || promqlQuery.Query.GetValue() != "vector(1)" {
+		t.Fatalf("promql wrapper = %#v", promqlQuery)
+	}
+	if got.Value.MultiString == nil || got.Value.MultiString.List == nil {
+		t.Fatal("expected multi_string.list")
+	}
+	if got.Value.MultiString.List.Values == nil {
+		t.Fatal("expected non-nil empty values slice")
+	}
+	if len(got.Value.MultiString.List.Values) != 0 {
+		t.Fatalf("values len = %d", len(got.Value.MultiString.List.Values))
 	}
 
-	t.Run("promql_and_empty_multi_list", func(t *testing.T) {
-		promql, diags := types.ObjectValue(promqlType.AttrTypes, map[string]attr.Value{
-			"query":             types.StringValue("vector(1)"),
-			"promql_query_type": types.StringValue("instant"),
-		})
-		if diags.HasError() {
-			t.Fatalf("promql: %v", diags)
-		}
-		metricsInner, diags := types.ObjectValue(metricsInnerType.AttrTypes, map[string]attr.Value{
-			"metric_name":  types.ObjectNull(metricsInnerType.AttrTypes["metric_name"].(types.ObjectType).AttrTypes),
-			"label_name":   types.ObjectNull(metricsInnerType.AttrTypes["label_name"].(types.ObjectType).AttrTypes),
-			"label_value":  types.ObjectNull(metricsInnerType.AttrTypes["label_value"].(types.ObjectType).AttrTypes),
-			"promql_query": promql,
-		})
-		if diags.HasError() {
-			t.Fatalf("metrics type: %v", diags)
-		}
-		metrics, diags := types.ObjectValue(metricsType.AttrTypes, map[string]attr.Value{"type": metricsInner})
-		if diags.HasError() {
-			t.Fatalf("metrics: %v", diags)
-		}
-		query, diags := types.ObjectValue(queryType.AttrTypes, map[string]attr.Value{
-			"values_order_direction": types.StringValue("asc"),
-			"all_option":             allOption,
-			"refresh_strategy":       types.StringValue("on_dashboard_load"),
-			"value_display_options":  types.ObjectNull(displayOptionsType.AttrTypes),
-			"logs_query":             types.ObjectNull(queryType.AttrTypes["logs_query"].(types.ObjectType).AttrTypes),
-			"spans_query":            types.ObjectNull(queryType.AttrTypes["spans_query"].(types.ObjectType).AttrTypes),
-			"metrics_query":          metrics,
-			"dataprime_query":        types.ObjectNull(queryType.AttrTypes["dataprime_query"].(types.ObjectType).AttrTypes),
-		})
-		if diags.HasError() {
-			t.Fatalf("query: %v", diags)
-		}
-		emptyListValues, diags := types.ListValue(listEntryType, []attr.Value{})
-		if diags.HasError() {
-			t.Fatalf("empty list values: %v", diags)
-		}
-		listObj, diags := types.ObjectValue(listType.AttrTypes, map[string]attr.Value{"values": emptyListValues})
-		if diags.HasError() {
-			t.Fatalf("list: %v", diags)
-		}
-		multi, diags := types.ObjectValue(multiType.AttrTypes, map[string]attr.Value{
-			"selected_all": types.ObjectNull(multiType.AttrTypes["selected_all"].(types.ObjectType).AttrTypes),
-			"all":          types.ObjectNull(multiType.AttrTypes["all"].(types.ObjectType).AttrTypes),
-			"list":         listObj,
-		})
-		if diags.HasError() {
-			t.Fatalf("multi: %v", diags)
-		}
-		value, diags := types.ObjectValue(valueType.AttrTypes, map[string]attr.Value{
-			"single_string":  types.ObjectNull(valueType.AttrTypes["single_string"].(types.ObjectType).AttrTypes),
-			"single_numeric": types.ObjectNull(valueType.AttrTypes["single_numeric"].(types.ObjectType).AttrTypes),
-			"regex":          types.ObjectNull(valueType.AttrTypes["regex"].(types.ObjectType).AttrTypes),
-			"lucene":         types.ObjectNull(valueType.AttrTypes["lucene"].(types.ObjectType).AttrTypes),
-			"interval":       types.ObjectNull(valueType.AttrTypes["interval"].(types.ObjectType).AttrTypes),
-			"multi_string":   multi,
-		})
-		if diags.HasError() {
-			t.Fatalf("value: %v", diags)
-		}
-		source, diags := types.ObjectValue(sourceType.AttrTypes, map[string]attr.Value{
-			"static":  types.ObjectNull(sourceType.AttrTypes["static"].(types.ObjectType).AttrTypes),
-			"textbox": types.ObjectNull(sourceType.AttrTypes["textbox"].(types.ObjectType).AttrTypes),
-			"query":   query,
-		})
-		if diags.HasError() {
-			t.Fatalf("source: %v", diags)
-		}
-		variable, diags := types.ObjectValue(elementType.AttrTypes, map[string]attr.Value{
-			"id":               types.StringNull(),
-			"name":             types.StringValue("prom"),
-			"display_name":     types.StringValue("Prom"),
-			"description":      types.StringNull(),
-			"display_type":     types.StringValue("label_value"),
-			"display_full_row": types.BoolNull(),
-			"source":           source,
-			"value":            value,
-		})
-		if diags.HasError() {
-			t.Fatalf("variable: %v", diags)
-		}
-		list, diags := types.ListValue(elementType, []attr.Value{variable})
-		if diags.HasError() {
-			t.Fatalf("list: %v", diags)
-		}
+	assertPromqlFlattened(t, ctx, mustFlattenVariablesV2(t, ctx, expanded, list))
+}
 
-		expanded, expandDiags := expandDashboardVariablesV2(ctx, list)
-		if expandDiags.HasError() {
-			t.Fatalf("expand: %v", expandDiags)
-		}
-		got := expanded[0]
-		if got.Source.Query.ValueDisplayOptions != nil {
-			t.Fatalf("omitted display options should expand nil, got %#v", got.Source.Query.ValueDisplayOptions)
-		}
-		promqlQuery := got.Source.Query.MetricsQuery.Type.PromqlQuery
-		if promqlQuery == nil || promqlQuery.Query == nil || promqlQuery.Query.GetValue() != "vector(1)" {
-			t.Fatalf("promql wrapper = %#v", promqlQuery)
-		}
-		if got.Value.MultiString == nil || got.Value.MultiString.List == nil {
-			t.Fatal("expected multi_string.list")
-		}
-		if got.Value.MultiString.List.Values == nil {
-			t.Fatal("expected non-nil empty values slice")
-		}
-		if len(got.Value.MultiString.List.Values) != 0 {
-			t.Fatalf("values len = %d", len(got.Value.MultiString.List.Values))
-		}
+func assertPromqlFlattened(t *testing.T, ctx context.Context, flattened types.List) {
+	t.Helper()
+	var models []DashboardVariableV2Model
+	mustElementsAs(t, flattened, &models)
+	var sourceModel variableSourceV2Model
+	mustObjectAs(t, models[0].Source, &sourceModel)
+	if sourceModel.Query == nil || sourceModel.Query.ValueDisplayOptions != nil {
+		t.Fatalf("flattened display options should stay unset, got %#v", sourceModel.Query)
+	}
+	var valueModel variableValueV2Model
+	mustObjectAs(t, models[0].Value, &valueModel)
+	if valueModel.MultiString == nil || valueModel.MultiString.List == nil {
+		t.Fatal("expected flattened multi_string.list")
+	}
+	if valueModel.MultiString.List.Values.IsNull() || len(valueModel.MultiString.List.Values.Elements()) != 0 {
+		t.Fatalf("flattened empty list should stay known empty, got %#v", valueModel.MultiString.List.Values)
+	}
+}
 
-		flattened, flattenDiags := flattenDashboardVariablesV2(ctx, expanded, list)
-		if flattenDiags.HasError() {
-			t.Fatalf("flatten: %v", flattenDiags)
-		}
-		var models []DashboardVariableV2Model
-		if diags := flattened.ElementsAs(ctx, &models, false); diags.HasError() {
-			t.Fatalf("elements: %v", diags)
-		}
-		var sourceModel variableSourceV2Model
-		if diags := models[0].Source.As(ctx, &sourceModel, basetypes.ObjectAsOptions{}); diags.HasError() {
-			t.Fatalf("source: %v", diags)
-		}
-		if sourceModel.Query == nil || sourceModel.Query.ValueDisplayOptions != nil {
-			t.Fatalf("flattened display options should stay unset, got %#v", sourceModel.Query)
-		}
-		var valueModel variableValueV2Model
-		if diags := models[0].Value.As(ctx, &valueModel, basetypes.ObjectAsOptions{}); diags.HasError() {
-			t.Fatalf("value: %v", diags)
-		}
-		if valueModel.MultiString == nil || valueModel.MultiString.List == nil {
-			t.Fatal("expected flattened multi_string.list")
-		}
-		if valueModel.MultiString.List.Values.IsNull() || len(valueModel.MultiString.List.Values.Elements()) != 0 {
-			t.Fatalf("flattened empty list should stay known empty, got %#v", valueModel.MultiString.List.Values)
-		}
+func TestExpandFlattenVariablesV2DataprimeQuery(t *testing.T) {
+	ctx := context.Background()
+	typeset := newVariablesV2QueryTypes(t)
+	allOption := mustAllOptionV2(t, typeset.queryType, true)
+
+	queryText := mustObjectValue(t, typeset.queryTextType.AttrTypes, map[string]attr.Value{
+		"query":          types.StringValue("source logs | limit 10"),
+		"data_mode_type": types.StringValue("high"),
 	})
-
-	t.Run("dataprime_query", func(t *testing.T) {
-		queryText, diags := types.ObjectValue(queryTextType.AttrTypes, map[string]attr.Value{
-			"query":          types.StringValue("source logs | limit 10"),
-			"data_mode_type": types.StringValue("high"),
-		})
-		if diags.HasError() {
-			t.Fatalf("query text: %v", diags)
-		}
-		dataprimeInner, diags := types.ObjectValue(dataprimeInnerType.AttrTypes, map[string]attr.Value{"query_text": queryText})
-		if diags.HasError() {
-			t.Fatalf("dataprime type: %v", diags)
-		}
-		dataprime, diags := types.ObjectValue(dataprimeType.AttrTypes, map[string]attr.Value{"type": dataprimeInner})
-		if diags.HasError() {
-			t.Fatalf("dataprime: %v", diags)
-		}
-		query, diags := types.ObjectValue(queryType.AttrTypes, map[string]attr.Value{
-			"values_order_direction": types.StringValue("asc"),
-			"all_option":             allOption,
-			"refresh_strategy":       types.StringNull(),
-			"value_display_options":  types.ObjectNull(displayOptionsType.AttrTypes),
-			"logs_query":             types.ObjectNull(queryType.AttrTypes["logs_query"].(types.ObjectType).AttrTypes),
-			"spans_query":            types.ObjectNull(queryType.AttrTypes["spans_query"].(types.ObjectType).AttrTypes),
-			"metrics_query":          types.ObjectNull(metricsType.AttrTypes),
-			"dataprime_query":        dataprime,
-		})
-		if diags.HasError() {
-			t.Fatalf("query: %v", diags)
-		}
-		selectedAll, diags := types.ObjectValue(multiType.AttrTypes["selected_all"].(types.ObjectType).AttrTypes, map[string]attr.Value{})
-		if diags.HasError() {
-			t.Fatalf("selected all: %v", diags)
-		}
-		multi, diags := types.ObjectValue(multiType.AttrTypes, map[string]attr.Value{
-			"selected_all": selectedAll,
-			"all":          types.ObjectNull(multiType.AttrTypes["all"].(types.ObjectType).AttrTypes),
-			"list":         types.ObjectNull(listType.AttrTypes),
-		})
-		if diags.HasError() {
-			t.Fatalf("multi: %v", diags)
-		}
-		value, diags := types.ObjectValue(valueType.AttrTypes, map[string]attr.Value{
-			"single_string":  types.ObjectNull(valueType.AttrTypes["single_string"].(types.ObjectType).AttrTypes),
-			"single_numeric": types.ObjectNull(valueType.AttrTypes["single_numeric"].(types.ObjectType).AttrTypes),
-			"regex":          types.ObjectNull(valueType.AttrTypes["regex"].(types.ObjectType).AttrTypes),
-			"lucene":         types.ObjectNull(valueType.AttrTypes["lucene"].(types.ObjectType).AttrTypes),
-			"interval":       types.ObjectNull(valueType.AttrTypes["interval"].(types.ObjectType).AttrTypes),
-			"multi_string":   multi,
-		})
-		if diags.HasError() {
-			t.Fatalf("value: %v", diags)
-		}
-		source, diags := types.ObjectValue(sourceType.AttrTypes, map[string]attr.Value{
-			"static":  types.ObjectNull(sourceType.AttrTypes["static"].(types.ObjectType).AttrTypes),
-			"textbox": types.ObjectNull(sourceType.AttrTypes["textbox"].(types.ObjectType).AttrTypes),
-			"query":   query,
-		})
-		if diags.HasError() {
-			t.Fatalf("source: %v", diags)
-		}
-		variable, diags := types.ObjectValue(elementType.AttrTypes, map[string]attr.Value{
-			"id":               types.StringNull(),
-			"name":             types.StringValue("dp"),
-			"display_name":     types.StringValue("DP"),
-			"description":      types.StringNull(),
-			"display_type":     types.StringValue("label_value"),
-			"display_full_row": types.BoolNull(),
-			"source":           source,
-			"value":            value,
-		})
-		if diags.HasError() {
-			t.Fatalf("variable: %v", diags)
-		}
-		list, diags := types.ListValue(elementType, []attr.Value{variable})
-		if diags.HasError() {
-			t.Fatalf("list: %v", diags)
-		}
-
-		expanded, expandDiags := expandDashboardVariablesV2(ctx, list)
-		if expandDiags.HasError() {
-			t.Fatalf("expand: %v", expandDiags)
-		}
-		queryTextExpanded := expanded[0].Source.Query.DataprimeQuery.Type.QueryText
-		if queryTextExpanded == nil || queryTextExpanded.Query == nil || queryTextExpanded.Query.GetText() != "source logs | limit 10" {
-			t.Fatalf("dataprime wrapper = %#v", queryTextExpanded)
-		}
-		if expanded[0].Value.MultiString == nil || expanded[0].Value.MultiString.SelectedAll == nil {
-			t.Fatalf("selected_all wire = %#v", expanded[0].Value.MultiString)
-		}
+	dataprimeInner := mustObjectValue(t, typeset.dataprimeInnerType.AttrTypes, map[string]attr.Value{"query_text": queryText})
+	dataprime := mustObjectValue(t, typeset.dataprimeType.AttrTypes, map[string]attr.Value{"type": dataprimeInner})
+	query := mustQuerySourceV2(t, typeset, allOption, types.StringNull(), map[string]attr.Value{
+		"dataprime_query": dataprime,
 	})
+	value := mustMultiStringSelectedAllValueV2(t, typeset.valueType, typeset.multiType, typeset.listType)
+	list := mustQueryVariableListV2(t, typeset, "dp", "DP", query, value)
 
-	t.Run("spans_and_metrics_operator", func(t *testing.T) {
-		spanValue, diags := types.ObjectValue(spanValueType.AttrTypes, map[string]attr.Value{
-			"type":  types.StringValue("metadata"),
-			"value": types.StringValue("service_name"),
-		})
-		if diags.HasError() {
-			t.Fatalf("span value: %v", diags)
-		}
-		spansFieldValue, diags := types.ObjectValue(spansFieldValueType.AttrTypes, map[string]attr.Value{
-			"value":             spanValue,
-			"observation_field": types.ObjectNull(spansFieldValueType.AttrTypes["observation_field"].(types.ObjectType).AttrTypes),
-		})
-		if diags.HasError() {
-			t.Fatalf("spans field value: %v", diags)
-		}
-		spansInner, diags := types.ObjectValue(spansInnerType.AttrTypes, map[string]attr.Value{
-			"field_value": spansFieldValue,
-		})
-		if diags.HasError() {
-			t.Fatalf("spans type: %v", diags)
-		}
-		spans, diags := types.ObjectValue(spansType.AttrTypes, map[string]attr.Value{"type": spansInner})
-		if diags.HasError() {
-			t.Fatalf("spans: %v", diags)
-		}
+	expanded := mustExpandVariablesV2(t, ctx, list)
+	queryTextExpanded := expanded[0].Source.Query.DataprimeQuery.Type.QueryText
+	if queryTextExpanded == nil || queryTextExpanded.Query == nil || queryTextExpanded.Query.GetText() != "source logs | limit 10" {
+		t.Fatalf("dataprime wrapper = %#v", queryTextExpanded)
+	}
+	if expanded[0].Value.MultiString == nil || expanded[0].Value.MultiString.SelectedAll == nil {
+		t.Fatalf("selected_all wire = %#v", expanded[0].Value.MultiString)
+	}
+}
 
-		metricName, diags := types.ObjectValue(stringOrVarType.AttrTypes, map[string]attr.Value{
-			"string_value":  types.StringValue("http_requests_total"),
-			"variable_name": types.StringNull(),
-		})
-		if diags.HasError() {
-			t.Fatalf("metric name: %v", diags)
-		}
-		labelName, diags := types.ObjectValue(stringOrVarType.AttrTypes, map[string]attr.Value{
-			"string_value":  types.StringValue("env"),
-			"variable_name": types.StringNull(),
-		})
-		if diags.HasError() {
-			t.Fatalf("label name: %v", diags)
-		}
-		selectedValue, diags := types.ObjectValue(stringOrVarType.AttrTypes, map[string]attr.Value{
-			"string_value":  types.StringValue("prod"),
-			"variable_name": types.StringNull(),
-		})
-		if diags.HasError() {
-			t.Fatalf("selected value: %v", diags)
-		}
-		selectedValues, diags := types.ListValue(stringOrVarType, []attr.Value{selectedValue})
-		if diags.HasError() {
-			t.Fatalf("selected values: %v", diags)
-		}
-		operator, diags := types.ObjectValue(operatorType.AttrTypes, map[string]attr.Value{
-			"type":            types.StringValue("equals"),
-			"selected_values": selectedValues,
-		})
-		if diags.HasError() {
-			t.Fatalf("operator: %v", diags)
-		}
-		filterMetric, diags := types.ObjectValue(stringOrVarType.AttrTypes, map[string]attr.Value{
-			"string_value":  types.StringValue("http_requests_total"),
-			"variable_name": types.StringNull(),
-		})
-		if diags.HasError() {
-			t.Fatalf("filter metric: %v", diags)
-		}
-		filterLabel, diags := types.ObjectValue(stringOrVarType.AttrTypes, map[string]attr.Value{
-			"string_value":  types.StringValue("region"),
-			"variable_name": types.StringNull(),
-		})
-		if diags.HasError() {
-			t.Fatalf("filter label: %v", diags)
-		}
-		filter, diags := types.ObjectValue(filterEntryType.AttrTypes, map[string]attr.Value{
-			"metric":   filterMetric,
-			"label":    filterLabel,
-			"operator": operator,
-		})
-		if diags.HasError() {
-			t.Fatalf("filter: %v", diags)
-		}
-		emptyFilters, diags := types.ListValue(filterEntryType, []attr.Value{})
-		if diags.HasError() {
-			t.Fatalf("empty filters: %v", diags)
-		}
+func TestExpandFlattenVariablesV2SpansAndMetricsOperator(t *testing.T) {
+	ctx := context.Background()
+	typeset := newVariablesV2QueryTypes(t)
+	allOption := mustAllOptionV2(t, typeset.queryType, true)
 
-		// Spans variable
-		querySpans, diags := types.ObjectValue(queryType.AttrTypes, map[string]attr.Value{
-			"values_order_direction": types.StringValue("asc"),
-			"all_option":             allOption,
-			"refresh_strategy":       types.StringNull(),
-			"value_display_options":  types.ObjectNull(displayOptionsType.AttrTypes),
-			"logs_query":             types.ObjectNull(queryType.AttrTypes["logs_query"].(types.ObjectType).AttrTypes),
-			"spans_query":            spans,
-			"metrics_query":          types.ObjectNull(metricsType.AttrTypes),
-			"dataprime_query":        types.ObjectNull(dataprimeType.AttrTypes),
-		})
-		if diags.HasError() {
-			t.Fatalf("spans query: %v", diags)
-		}
-		selectedAll, diags := types.ObjectValue(multiType.AttrTypes["selected_all"].(types.ObjectType).AttrTypes, map[string]attr.Value{})
-		if diags.HasError() {
-			t.Fatalf("selected all: %v", diags)
-		}
-		multi, diags := types.ObjectValue(multiType.AttrTypes, map[string]attr.Value{
-			"selected_all": selectedAll,
-			"all":          types.ObjectNull(multiType.AttrTypes["all"].(types.ObjectType).AttrTypes),
-			"list":         types.ObjectNull(listType.AttrTypes),
-		})
-		if diags.HasError() {
-			t.Fatalf("multi: %v", diags)
-		}
-		value, diags := types.ObjectValue(valueType.AttrTypes, map[string]attr.Value{
-			"single_string":  types.ObjectNull(valueType.AttrTypes["single_string"].(types.ObjectType).AttrTypes),
-			"single_numeric": types.ObjectNull(valueType.AttrTypes["single_numeric"].(types.ObjectType).AttrTypes),
-			"regex":          types.ObjectNull(valueType.AttrTypes["regex"].(types.ObjectType).AttrTypes),
-			"lucene":         types.ObjectNull(valueType.AttrTypes["lucene"].(types.ObjectType).AttrTypes),
-			"interval":       types.ObjectNull(valueType.AttrTypes["interval"].(types.ObjectType).AttrTypes),
-			"multi_string":   multi,
-		})
-		if diags.HasError() {
-			t.Fatalf("value: %v", diags)
-		}
-		sourceSpans, diags := types.ObjectValue(sourceType.AttrTypes, map[string]attr.Value{
-			"static":  types.ObjectNull(sourceType.AttrTypes["static"].(types.ObjectType).AttrTypes),
-			"textbox": types.ObjectNull(sourceType.AttrTypes["textbox"].(types.ObjectType).AttrTypes),
-			"query":   querySpans,
-		})
-		if diags.HasError() {
-			t.Fatalf("source spans: %v", diags)
-		}
-		variableSpans, diags := types.ObjectValue(elementType.AttrTypes, map[string]attr.Value{
-			"id":               types.StringNull(),
-			"name":             types.StringValue("span"),
-			"display_name":     types.StringValue("Span"),
-			"description":      types.StringNull(),
-			"display_type":     types.StringValue("label_value"),
-			"display_full_row": types.BoolNull(),
-			"source":           sourceSpans,
-			"value":            value,
-		})
-		if diags.HasError() {
-			t.Fatalf("variable spans: %v", diags)
-		}
-		listSpans, diags := types.ListValue(elementType, []attr.Value{variableSpans})
-		if diags.HasError() {
-			t.Fatalf("list spans: %v", diags)
-		}
-		expandedSpans, expandDiags := expandDashboardVariablesV2(ctx, listSpans)
-		if expandDiags.HasError() {
-			t.Fatalf("expand spans: %v", expandDiags)
-		}
-		spanField := expandedSpans[0].Source.Query.SpansQuery.Type.FieldValue.Value
-		if spanField == nil || spanField.MetadataField == nil {
-			t.Fatalf("expected spans metadata field, got %#v", spanField)
-		}
-
-		// Metrics label_value + empty filters + operator expand helper
-		labelValueExpanded, labelDiags := expandMetricsLabelValueV2(ctx, &metricsLabelValueV2Model{
-			MetricName:   metricName,
-			LabelName:    labelName,
-			LabelFilters: emptyFilters,
-		})
-		if labelDiags.HasError() {
-			t.Fatalf("expand label value: %v", labelDiags)
-		}
-		if labelValueExpanded.LabelFilters != nil {
-			t.Fatalf("empty label_filters should expand nil, got %#v", labelValueExpanded.LabelFilters)
-		}
-
-		filtersWithOp, diags := types.ListValue(filterEntryType, []attr.Value{filter})
-		if diags.HasError() {
-			t.Fatalf("filters with op: %v", diags)
-		}
-		labelValueWithOp, labelDiags := expandMetricsLabelValueV2(ctx, &metricsLabelValueV2Model{
-			MetricName:   metricName,
-			LabelName:    labelName,
-			LabelFilters: filtersWithOp,
-		})
-		if labelDiags.HasError() {
-			t.Fatalf("expand label value with op: %v", labelDiags)
-		}
-		if len(labelValueWithOp.LabelFilters) != 1 || labelValueWithOp.LabelFilters[0].Operator == nil || labelValueWithOp.LabelFilters[0].Operator.Equals == nil {
-			t.Fatalf("metrics operator wire = %#v", labelValueWithOp.LabelFilters)
-		}
-		selection := labelValueWithOp.LabelFilters[0].Operator.Equals.Selection
-		if selection == nil || selection.List == nil || len(selection.List.Values) != 1 || selection.List.Values[0].GetStringValue() != "prod" {
-			t.Fatalf("metrics selection list = %#v", selection)
-		}
+	spanValue := mustObjectValue(t, typeset.spanValueType.AttrTypes, map[string]attr.Value{
+		"type":  types.StringValue("metadata"),
+		"value": types.StringValue("service_name"),
 	})
+	spansFieldValue := mustObjectValue(t, typeset.spansFieldValueType.AttrTypes, map[string]attr.Value{
+		"value":             spanValue,
+		"observation_field": nullObjectAttr(typeset.spansFieldValueType.AttrTypes["observation_field"]),
+	})
+	spansInner := mustObjectValue(t, typeset.spansInnerType.AttrTypes, map[string]attr.Value{"field_value": spansFieldValue})
+	spans := mustObjectValue(t, typeset.spansType.AttrTypes, map[string]attr.Value{"type": spansInner})
+	querySpans := mustQuerySourceV2(t, typeset, allOption, types.StringNull(), map[string]attr.Value{
+		"spans_query": spans,
+	})
+	value := mustMultiStringSelectedAllValueV2(t, typeset.valueType, typeset.multiType, typeset.listType)
+	listSpans := mustQueryVariableListV2(t, typeset, "span", "Span", querySpans, value)
+
+	expandedSpans := mustExpandVariablesV2(t, ctx, listSpans)
+	spanField := expandedSpans[0].Source.Query.SpansQuery.Type.FieldValue.Value
+	if spanField == nil || spanField.MetadataField == nil {
+		t.Fatalf("expected spans metadata field, got %#v", spanField)
+	}
+
+	assertMetricsLabelFiltersWire(t, ctx, typeset)
+}
+
+func assertMetricsLabelFiltersWire(t *testing.T, ctx context.Context, typeset variablesV2QueryTypes) {
+	t.Helper()
+	metricName := mustStringOrVariableV2(t, typeset.stringOrVarType, "http_requests_total")
+	labelName := mustStringOrVariableV2(t, typeset.stringOrVarType, "env")
+	emptyFilters := mustListValue(t, typeset.filterEntryType, []attr.Value{})
+
+	labelValueExpanded, labelDiags := expandMetricsLabelValueV2(ctx, &metricsLabelValueV2Model{
+		MetricName:   metricName,
+		LabelName:    labelName,
+		LabelFilters: emptyFilters,
+	})
+	if labelDiags.HasError() {
+		t.Fatalf("expand label value: %v", labelDiags)
+	}
+	if labelValueExpanded.LabelFilters != nil {
+		t.Fatalf("empty label_filters should expand nil, got %#v", labelValueExpanded.LabelFilters)
+	}
+
+	filter := mustMetricsLabelFilterV2(t, typeset, "http_requests_total", "region", "prod")
+	filtersWithOp := mustListValue(t, typeset.filterEntryType, []attr.Value{filter})
+	labelValueWithOp, labelDiags := expandMetricsLabelValueV2(ctx, &metricsLabelValueV2Model{
+		MetricName:   metricName,
+		LabelName:    labelName,
+		LabelFilters: filtersWithOp,
+	})
+	if labelDiags.HasError() {
+		t.Fatalf("expand label value with op: %v", labelDiags)
+	}
+	if len(labelValueWithOp.LabelFilters) != 1 || labelValueWithOp.LabelFilters[0].Operator == nil || labelValueWithOp.LabelFilters[0].Operator.Equals == nil {
+		t.Fatalf("metrics operator wire = %#v", labelValueWithOp.LabelFilters)
+	}
+	selection := labelValueWithOp.LabelFilters[0].Operator.Equals.Selection
+	if selection == nil || selection.List == nil || len(selection.List.Values) != 1 || selection.List.Values[0].GetStringValue() != "prod" {
+		t.Fatalf("metrics selection list = %#v", selection)
+	}
 }
 
 func TestFloat32PointerToTypeFloat64PreservesConfiguredFractions(t *testing.T) {
@@ -896,6 +432,11 @@ func TestExpandFlattenSingleNumericFractionalRoundTrip(t *testing.T) {
 		t.Fatalf("single_numeric.value = %v, want 0.1", gotValue.ValueFloat64())
 	}
 
+	assertTextboxNumericFractions(t)
+}
+
+func assertTextboxNumericFractions(t *testing.T) {
+	t.Helper()
 	textboxExpanded, diags := expandTextboxDefaultValueV2(&textboxDefaultValueV2Model{
 		DefaultNumericValue: &textboxNumericValueV2Model{
 			Value:     types.Float64Value(0.1),
@@ -917,4 +458,276 @@ func TestExpandFlattenSingleNumericFractionalRoundTrip(t *testing.T) {
 	if float32PointerToTypeFloat64(num.Max).ValueFloat64() != 1.1 {
 		t.Fatalf("textbox max = %v, want 1.1", float32PointerToTypeFloat64(num.Max).ValueFloat64())
 	}
+}
+
+type variablesV2QueryTypes struct {
+	elementType         types.ObjectType
+	sourceType          types.ObjectType
+	valueType           types.ObjectType
+	queryType           types.ObjectType
+	metricsType         types.ObjectType
+	metricsInnerType    types.ObjectType
+	promqlType          types.ObjectType
+	dataprimeType       types.ObjectType
+	dataprimeInnerType  types.ObjectType
+	queryTextType       types.ObjectType
+	multiType           types.ObjectType
+	listType            types.ObjectType
+	listEntryType       types.ObjectType
+	spansType           types.ObjectType
+	spansInnerType      types.ObjectType
+	spansFieldValueType types.ObjectType
+	spanValueType       types.ObjectType
+	stringOrVarType     types.ObjectType
+	filterEntryType     types.ObjectType
+	operatorType        types.ObjectType
+}
+
+func newVariablesV2QueryTypes(t *testing.T) variablesV2QueryTypes {
+	t.Helper()
+	elementType := dashboardVariablesV2ElementType()
+	sourceType := elementType.AttrTypes["source"].(types.ObjectType)
+	valueType := elementType.AttrTypes["value"].(types.ObjectType)
+	queryType := sourceType.AttrTypes["query"].(types.ObjectType)
+	metricsType := queryType.AttrTypes["metrics_query"].(types.ObjectType)
+	metricsInnerType := metricsType.AttrTypes["type"].(types.ObjectType)
+	multiType := valueType.AttrTypes["multi_string"].(types.ObjectType)
+	listType := multiType.AttrTypes["list"].(types.ObjectType)
+	listValuesType := listType.AttrTypes["values"].(types.ListType)
+	spansType := queryType.AttrTypes["spans_query"].(types.ObjectType)
+	spansInnerType := spansType.AttrTypes["type"].(types.ObjectType)
+	spansFieldValueType := spansInnerType.AttrTypes["field_value"].(types.ObjectType)
+	dataprimeType := queryType.AttrTypes["dataprime_query"].(types.ObjectType)
+	dataprimeInnerType := dataprimeType.AttrTypes["type"].(types.ObjectType)
+	filterEntryType := metricsInnerType.AttrTypes["label_value"].(types.ObjectType).AttrTypes["label_filters"].(types.ListType).ElemType.(types.ObjectType)
+	return variablesV2QueryTypes{
+		elementType:         elementType,
+		sourceType:          sourceType,
+		valueType:           valueType,
+		queryType:           queryType,
+		metricsType:         metricsType,
+		metricsInnerType:    metricsInnerType,
+		promqlType:          metricsInnerType.AttrTypes["promql_query"].(types.ObjectType),
+		dataprimeType:       dataprimeType,
+		dataprimeInnerType:  dataprimeInnerType,
+		queryTextType:       dataprimeInnerType.AttrTypes["query_text"].(types.ObjectType),
+		multiType:           multiType,
+		listType:            listType,
+		listEntryType:       listValuesType.ElemType.(types.ObjectType),
+		spansType:           spansType,
+		spansInnerType:      spansInnerType,
+		spansFieldValueType: spansFieldValueType,
+		spanValueType:       spansFieldValueType.AttrTypes["value"].(types.ObjectType),
+		stringOrVarType:     metricsInnerType.AttrTypes["label_value"].(types.ObjectType).AttrTypes["metric_name"].(types.ObjectType),
+		filterEntryType:     filterEntryType,
+		operatorType:        filterEntryType.AttrTypes["operator"].(types.ObjectType),
+	}
+}
+
+func mustObjectValue(t *testing.T, attrTypes map[string]attr.Type, attrs map[string]attr.Value) types.Object {
+	t.Helper()
+	v, diags := types.ObjectValue(attrTypes, attrs)
+	if diags.HasError() {
+		t.Fatalf("%v", diags)
+	}
+	return v
+}
+
+func mustListValue(t *testing.T, elemType attr.Type, elems []attr.Value) types.List {
+	t.Helper()
+	v, diags := types.ListValue(elemType, elems)
+	if diags.HasError() {
+		t.Fatalf("%v", diags)
+	}
+	return v
+}
+
+func nullObjectAttr(objectType attr.Type) types.Object {
+	return types.ObjectNull(objectType.(types.ObjectType).AttrTypes)
+}
+
+func mustExpandVariablesV2(t *testing.T, ctx context.Context, list types.List) []dashboardservice.VariableV2 {
+	t.Helper()
+	expanded, diags := expandDashboardVariablesV2(ctx, list)
+	if diags.HasError() {
+		t.Fatalf("expand: %v", diags)
+	}
+	return expanded
+}
+
+func mustFlattenVariablesV2(t *testing.T, ctx context.Context, expanded []dashboardservice.VariableV2, configured types.List) types.List {
+	t.Helper()
+	flattened, diags := flattenDashboardVariablesV2(ctx, expanded, configured)
+	if diags.HasError() {
+		t.Fatalf("flatten: %v", diags)
+	}
+	return flattened
+}
+
+func mustElementsAs(t *testing.T, list types.List, target any) {
+	t.Helper()
+	if diags := list.ElementsAs(context.Background(), target, false); diags.HasError() {
+		t.Fatalf("elements: %v", diags)
+	}
+}
+
+func mustObjectAs(t *testing.T, object types.Object, target any) {
+	t.Helper()
+	if diags := object.As(context.Background(), target, basetypes.ObjectAsOptions{}); diags.HasError() {
+		t.Fatalf("object as: %v", diags)
+	}
+}
+
+func mustAllOptionV2(t *testing.T, queryType types.ObjectType, includeAll bool) types.Object {
+	t.Helper()
+	allOptionType := queryType.AttrTypes["all_option"].(types.ObjectType)
+	return mustObjectValue(t, allOptionType.AttrTypes, map[string]attr.Value{
+		"include_all": types.BoolValue(includeAll),
+		"label":       types.StringNull(),
+	})
+}
+
+func mustStaticSourceV2(t *testing.T, staticType types.ObjectType, values types.List) types.Object {
+	t.Helper()
+	allOptionType := staticType.AttrTypes["all_option"].(types.ObjectType)
+	allOption := mustObjectValue(t, allOptionType.AttrTypes, map[string]attr.Value{
+		"include_all": types.BoolValue(false),
+		"label":       types.StringNull(),
+	})
+	return mustObjectValue(t, staticType.AttrTypes, map[string]attr.Value{
+		"values_order_direction": types.StringValue("none"),
+		"all_option":             allOption,
+		"values":                 values,
+	})
+}
+
+func mustSourceWithStaticV2(t *testing.T, sourceType types.ObjectType, static types.Object) types.Object {
+	t.Helper()
+	return mustObjectValue(t, sourceType.AttrTypes, map[string]attr.Value{
+		"static":  static,
+		"textbox": nullObjectAttr(sourceType.AttrTypes["textbox"]),
+		"query":   nullObjectAttr(sourceType.AttrTypes["query"]),
+	})
+}
+
+func mustSingleStringValueV2(t *testing.T, valueType types.ObjectType, value, label string) types.Object {
+	t.Helper()
+	singleString := mustObjectValue(t, valueType.AttrTypes["single_string"].(types.ObjectType).AttrTypes, map[string]attr.Value{
+		"value": types.StringValue(value),
+		"label": types.StringValue(label),
+	})
+	return mustObjectValue(t, valueType.AttrTypes, map[string]attr.Value{
+		"single_string":  singleString,
+		"single_numeric": nullObjectAttr(valueType.AttrTypes["single_numeric"]),
+		"regex":          nullObjectAttr(valueType.AttrTypes["regex"]),
+		"lucene":         nullObjectAttr(valueType.AttrTypes["lucene"]),
+		"interval":       nullObjectAttr(valueType.AttrTypes["interval"]),
+		"multi_string":   nullObjectAttr(valueType.AttrTypes["multi_string"]),
+	})
+}
+
+func mustVariableV2(t *testing.T, elementType types.ObjectType, name, displayName string, source, value types.Object) types.Object {
+	t.Helper()
+	return mustObjectValue(t, elementType.AttrTypes, map[string]attr.Value{
+		"id":               types.StringNull(),
+		"name":             types.StringValue(name),
+		"display_name":     types.StringValue(displayName),
+		"description":      types.StringNull(),
+		"display_type":     types.StringValue("label_value"),
+		"display_full_row": types.BoolNull(),
+		"source":           source,
+		"value":            value,
+	})
+}
+
+func mustQuerySourceV2(t *testing.T, typeset variablesV2QueryTypes, allOption types.Object, refresh types.String, arms map[string]attr.Value) types.Object {
+	t.Helper()
+	attrs := map[string]attr.Value{
+		"values_order_direction": types.StringValue("asc"),
+		"all_option":             allOption,
+		"refresh_strategy":       refresh,
+		"value_display_options":  nullObjectAttr(typeset.queryType.AttrTypes["value_display_options"]),
+		"logs_query":             nullObjectAttr(typeset.queryType.AttrTypes["logs_query"]),
+		"spans_query":            nullObjectAttr(typeset.queryType.AttrTypes["spans_query"]),
+		"metrics_query":          nullObjectAttr(typeset.metricsType),
+		"dataprime_query":        nullObjectAttr(typeset.dataprimeType),
+	}
+	for key, value := range arms {
+		attrs[key] = value
+	}
+	return mustObjectValue(t, typeset.queryType.AttrTypes, attrs)
+}
+
+func mustQueryVariableListV2(t *testing.T, typeset variablesV2QueryTypes, name, displayName string, query, value types.Object) types.List {
+	t.Helper()
+	source := mustObjectValue(t, typeset.sourceType.AttrTypes, map[string]attr.Value{
+		"static":  nullObjectAttr(typeset.sourceType.AttrTypes["static"]),
+		"textbox": nullObjectAttr(typeset.sourceType.AttrTypes["textbox"]),
+		"query":   query,
+	})
+	return mustListValue(t, typeset.elementType, []attr.Value{
+		mustVariableV2(t, typeset.elementType, name, displayName, source, value),
+	})
+}
+
+func mustMultiStringListValueV2(t *testing.T, valueType, multiType, listType, listEntryType types.ObjectType, values []attr.Value) types.Object {
+	t.Helper()
+	listObj := mustObjectValue(t, listType.AttrTypes, map[string]attr.Value{
+		"values": mustListValue(t, listEntryType, values),
+	})
+	multi := mustObjectValue(t, multiType.AttrTypes, map[string]attr.Value{
+		"selected_all": nullObjectAttr(multiType.AttrTypes["selected_all"]),
+		"all":          nullObjectAttr(multiType.AttrTypes["all"]),
+		"list":         listObj,
+	})
+	return mustObjectValue(t, valueType.AttrTypes, map[string]attr.Value{
+		"single_string":  nullObjectAttr(valueType.AttrTypes["single_string"]),
+		"single_numeric": nullObjectAttr(valueType.AttrTypes["single_numeric"]),
+		"regex":          nullObjectAttr(valueType.AttrTypes["regex"]),
+		"lucene":         nullObjectAttr(valueType.AttrTypes["lucene"]),
+		"interval":       nullObjectAttr(valueType.AttrTypes["interval"]),
+		"multi_string":   multi,
+	})
+}
+
+func mustMultiStringSelectedAllValueV2(t *testing.T, valueType, multiType, listType types.ObjectType) types.Object {
+	t.Helper()
+	selectedAll := mustObjectValue(t, multiType.AttrTypes["selected_all"].(types.ObjectType).AttrTypes, map[string]attr.Value{})
+	multi := mustObjectValue(t, multiType.AttrTypes, map[string]attr.Value{
+		"selected_all": selectedAll,
+		"all":          nullObjectAttr(multiType.AttrTypes["all"]),
+		"list":         nullObjectAttr(listType),
+	})
+	return mustObjectValue(t, valueType.AttrTypes, map[string]attr.Value{
+		"single_string":  nullObjectAttr(valueType.AttrTypes["single_string"]),
+		"single_numeric": nullObjectAttr(valueType.AttrTypes["single_numeric"]),
+		"regex":          nullObjectAttr(valueType.AttrTypes["regex"]),
+		"lucene":         nullObjectAttr(valueType.AttrTypes["lucene"]),
+		"interval":       nullObjectAttr(valueType.AttrTypes["interval"]),
+		"multi_string":   multi,
+	})
+}
+
+func mustStringOrVariableV2(t *testing.T, stringOrVarType types.ObjectType, stringValue string) types.Object {
+	t.Helper()
+	return mustObjectValue(t, stringOrVarType.AttrTypes, map[string]attr.Value{
+		"string_value":  types.StringValue(stringValue),
+		"variable_name": types.StringNull(),
+	})
+}
+
+func mustMetricsLabelFilterV2(t *testing.T, typeset variablesV2QueryTypes, metric, label, selected string) types.Object {
+	t.Helper()
+	selectedValues := mustListValue(t, typeset.stringOrVarType, []attr.Value{
+		mustStringOrVariableV2(t, typeset.stringOrVarType, selected),
+	})
+	operator := mustObjectValue(t, typeset.operatorType.AttrTypes, map[string]attr.Value{
+		"type":            types.StringValue("equals"),
+		"selected_values": selectedValues,
+	})
+	return mustObjectValue(t, typeset.filterEntryType.AttrTypes, map[string]attr.Value{
+		"metric":   mustStringOrVariableV2(t, typeset.stringOrVarType, metric),
+		"label":    mustStringOrVariableV2(t, typeset.stringOrVarType, label),
+		"operator": operator,
+	})
 }

--- a/internal/provider/dashboards/variables_v2_expand_flatten_test.go
+++ b/internal/provider/dashboards/variables_v2_expand_flatten_test.go
@@ -111,13 +111,13 @@ func TestExpandFlattenVariablesV2StaticRoundTrip(t *testing.T) {
 	if expanded[0].GetName() != "environment" {
 		t.Fatalf("name = %q", expanded[0].GetName())
 	}
-	if expanded[0].Source == nil || expanded[0].Source.Static == nil {
+	if expanded[0].Source.Static == nil {
 		t.Fatal("expected static source")
 	}
 	if len(expanded[0].Source.Static.Values) != 1 || expanded[0].Source.Static.Values[0].GetLabel() != "production" {
 		t.Fatalf("static values = %#v", expanded[0].Source.Static.Values)
 	}
-	if expanded[0].Value == nil || expanded[0].Value.SingleString == nil || expanded[0].Value.SingleString.Value == nil {
+	if expanded[0].Value.SingleString == nil || expanded[0].Value.SingleString.Value == nil {
 		t.Fatal("expected single string value")
 	}
 	if expanded[0].Value.SingleString.Value.GetValue() != "production" || expanded[0].Value.SingleString.Value.GetLabel() != "production" {
@@ -345,27 +345,24 @@ func TestExpandVariableV2OptionalEnumsOmitUnset(t *testing.T) {
 	if expandDiags.HasError() {
 		t.Fatalf("expand: %v", expandDiags)
 	}
-	if expanded.DisplayType != nil {
-		t.Fatalf("null display_type should omit API enum, got %q", *expanded.DisplayType)
+	if expanded.DisplayType != "" {
+		t.Fatalf("null display_type should expand to empty required enum, got %q", expanded.DisplayType)
 	}
 }
 
 func TestFlattenVariableV2DisplayTypeUnspecifiedIsNull(t *testing.T) {
 	ctx := context.Background()
 	elementType := dashboardVariablesV2ElementType()
-	unspecified := dashboardservice.VARIABLEDISPLAYTYPEV2_VARIABLE_DISPLAY_TYPE_V2_UNSPECIFIED
-	name := "search"
-	displayName := "Search"
 	hello := "hello"
 
 	flattened, diags := flattenDashboardVariableV2(ctx, &dashboardservice.VariableV2{
-		Name:        &name,
-		DisplayName: &displayName,
-		DisplayType: &unspecified,
-		Source: &dashboardservice.VariableSourceV2{
+		Name:        "search",
+		DisplayName: "Search",
+		DisplayType: dashboardservice.VARIABLEDISPLAYTYPEV2_VARIABLE_DISPLAY_TYPE_V2_UNSPECIFIED,
+		Source: dashboardservice.VariableSourceV2{
 			Textbox: &dashboardservice.TextboxSource{},
 		},
-		Value: &dashboardservice.VariableValueV2{
+		Value: dashboardservice.VariableValueV2{
 			SingleString: &dashboardservice.SingleStringValue{
 				Value: &dashboardservice.StringValueLabel{Value: &hello},
 			},

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -196,7 +196,7 @@ func testAccCheckDashboardVariablesV2StaticLabelOnAPI(resourceName, wantLabel st
 		}
 		dashboard := resp.GetDashboard()
 		vars := dashboard.GetVariablesV2()
-		if len(vars) == 0 || vars[0].Source == nil || vars[0].Source.Static == nil || len(vars[0].Source.Static.Values) == 0 {
+		if len(vars) == 0 || vars[0].Source.Static == nil || len(vars[0].Source.Static.Values) == 0 {
 			return fmt.Errorf("dashboard %s has no static variables_v2 values", rs.Primary.ID)
 		}
 		got := vars[0].Source.Static.Values[0].GetLabel()


### PR DESCRIPTION
### Description

## Summary
Bump `coralogix-management-sdk` to the sync that declares dashboard `variables_v2` OpenAPI-required fields, and adapt expand/flatten wiring to the new non-pointer Go types. Terraform schema is unchanged.

## Root Cause
[cx-management-apis#335](https://github.com/coralogix/cx-management-apis/pull/335) marked fields the dashboards backend already requires as OpenAPI `required`. [coralogix-management-sdk#670](https://github.com/coralogix/coralogix-management-sdk/pull/670) regenerated clients so those fields became value types instead of pointers. The provider still assigned `*T` / `OptionalEnumPointer` results into those fields and no longer compiled.

## Why was it introduced
Follow-on to the SDK sync that landed after `variables_v2` support ([#638](https://github.com/coralogix/terraform-provider-coralogix/pull/638)). The provider was written against the previous optional OpenAPI shape.

## Breaking change?
No. Schema Required / Optional+Computed+Default already matched backend requiredness. Valid HCL is unchanged.

Also adapted two nested required fields from the same sync beyond the VariableV2 top-level list: logs `FieldValue.observation_field` and metrics `LabelValue.label_name`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/provider/dashboards/...`
- [x] `TF_ACC=1 go test ./internal/provider/ -run 'TestAccCoralogixResourceDashboardVariablesV2' -count=1` (EU2)

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ TF_ACC=1 go test ./internal/provider/ -run 'TestAccCoralogixResourceDashboardVariablesV2' -v -count=1 -timeout 60m

--- PASS: TestAccCoralogixResourceDashboardVariablesV2Textbox
--- PASS: TestAccCoralogixResourceDashboardVariablesV2Dataprime
--- PASS: TestAccCoralogixResourceDashboardVariablesV2SpansFieldValue
--- PASS: TestAccCoralogixResourceDashboardVariablesV2LogsFieldValue
--- PASS: TestAccCoralogixResourceDashboardVariablesV2Metrics
--- PASS: TestAccCoralogixResourceDashboardVariablesV2ValueDisplayOptions
--- PASS: TestAccCoralogixResourceDashboardVariablesV2MetricsLabelName
--- PASS: TestAccCoralogixResourceDashboardVariablesV2MultiStringAll
--- PASS: TestAccCoralogixResourceDashboardVariablesV2MetricsLabelValue
--- PASS: TestAccCoralogixResourceDashboardVariablesV2Promql
--- PASS: TestAccCoralogixResourceDashboardVariablesV2TextboxValueTypes
--- PASS: TestAccCoralogixResourceDashboardVariablesV2Static
PASS
ok  	github.com/coralogix/terraform-provider-coralogix/internal/provider
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
resource/coralogix_dashboard: Adapt `variables_v2` expand/flatten to SDK required value types after OpenAPI required-field sync. Terraform schema unchanged.
provider: Bump `coralogix-management-sdk` for dashboard `variables_v2` OpenAPI required fields.
```

### References
- https://github.com/coralogix/cx-management-apis/pull/335
- https://github.com/coralogix/coralogix-management-sdk/pull/670
- Blocks follow-up for CX-44849 / CX-49459

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment