### PR TITLE
Migrate coralogix_team to the OpenAPI Teams REST client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - FIX: Schema v2/v3→v4 state upgrade no longer fails with `Missing Upgraded Resource State` when the dashboard was deleted outside Terraform. The upgrader no longer removes the resource from state (illegal inside a state upgrader); it returns a valid v4 state carrying the prior `id`, `name`, `description` and `content_json`, so the following refresh detects the missing dashboard and plans a recreate.
 
 #### resource/coralogix_team
+- CHORE: Migrate from the deprecated gRPC Teams client to the OpenAPI Teams REST client. No functional change. Also affects `data.coralogix_team`.
 - FIX: The "no longer exists in Coralogix backend" warning rendered the team ID with `%q`, which formats an integer as a character literal (team `12345` printed as `'〹'`). It now prints the numeric ID. Also affects `data.coralogix_team`.
 
 #### resource/coralogix_enrichment

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -49,6 +49,7 @@ import (
 	scopess "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/scopes_service"
 	archiveLogs "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/target_service"
 	teamGroupss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/team_groups_management_service"
+	teamss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
 
 	slos "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/slos_service"
 )
@@ -60,7 +61,6 @@ type ClientSet struct {
 	ruleGroups     *cxsdk.RuleGroupsClient
 	users          *UsersClient
 	events2Metrics *e2ms.Events2MetricsServiceAPIService
-	teams          *cxsdk.TeamsClient
 
 	dahboardsFolders      *dbfs.DashboardFoldersServiceAPIService
 	customDataEnrichments *cess.CustomEnrichmentsServiceAPIService
@@ -91,6 +91,7 @@ type ClientSet struct {
 	grafana               *GrafanaClient
 	groups                *GroupsClient
 	teamGroups            *teamGroupss.TeamGroupsManagementServiceAPIService
+	teams                 *teamss.TeamsServiceAPIService
 }
 
 func (c *ClientSet) ParsingRuleGroups() *prgs.RuleGroupsServiceAPIService {
@@ -218,7 +219,7 @@ func (c *ClientSet) LegacySLOs() *cxsdk.LegacySLOsClient {
 	return c.legacySlos
 }
 
-func (c *ClientSet) Teams() *cxsdk.TeamsClient {
+func (c *ClientSet) Teams() *teamss.TeamsServiceAPIService {
 	return c.teams
 }
 
@@ -256,7 +257,6 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 		enrichments: cxsdk.NewEnrichmentClient(grpcCreator),
 		legacySlos:  cxsdk.NewLegacySLOsClient(grpcCreator),
 		ruleGroups:  cxsdk.NewRuleGroupsClient(grpcCreator),
-		teams:       cxsdk.NewTeamsClient(grpcCreator),
 
 		users: NewUsersClient(region, apiKey),
 
@@ -291,5 +291,6 @@ func NewClientSet(region string, apiKey string, grpcTarget string) *ClientSet {
 		grafana:               NewGrafanaClient(apikeyCPC),
 		groups:                NewGroupsClient(region, apiKey),
 		teamGroups:            cs.Groups(),
+		teams:                 cs.Teams(),
 	}
 }

--- a/internal/clientset/clientset.go
+++ b/internal/clientset/clientset.go
@@ -49,7 +49,7 @@ import (
 	scopess "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/scopes_service"
 	archiveLogs "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/target_service"
 	teamGroupss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/team_groups_management_service"
-	teamss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
+	teamsservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
 
 	slos "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/slos_service"
 )
@@ -91,7 +91,7 @@ type ClientSet struct {
 	grafana               *GrafanaClient
 	groups                *GroupsClient
 	teamGroups            *teamGroupss.TeamGroupsManagementServiceAPIService
-	teams                 *teamss.TeamsServiceAPIService
+	teams                 *teamsservice.TeamsServiceAPIService
 }
 
 func (c *ClientSet) ParsingRuleGroups() *prgs.RuleGroupsServiceAPIService {
@@ -219,7 +219,7 @@ func (c *ClientSet) LegacySLOs() *cxsdk.LegacySLOsClient {
 	return c.legacySlos
 }
 
-func (c *ClientSet) Teams() *teamss.TeamsServiceAPIService {
+func (c *ClientSet) Teams() *teamsservice.TeamsServiceAPIService {
 	return c.teams
 }
 

--- a/internal/clientset/clientset_test.go
+++ b/internal/clientset/clientset_test.go
@@ -29,6 +29,9 @@ func TestNewClientSet_UsersClientNotNil(t *testing.T) {
 	if cs.TeamGroups() == nil {
 		t.Fatal("TeamGroups() must not be nil")
 	}
+	if cs.Teams() == nil {
+		t.Fatal("Teams() must not be nil")
+	}
 	if cs.Users().BaseURL() != "https://api.eu2.coralogix.com/scim/Users" {
 		t.Fatalf("Users().BaseURL() = %q", cs.Users().BaseURL())
 	}

--- a/internal/provider/aaa/data_source_coralogix_team.go
+++ b/internal/provider/aaa/data_source_coralogix_team.go
@@ -19,17 +19,17 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"net/http"
 	"strconv"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	teamss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var (
@@ -41,7 +41,7 @@ func NewTeamDataSource() datasource.DataSource {
 }
 
 type TeamDataSource struct {
-	client *cxsdk.TeamsClient
+	client *teamss.TeamsServiceAPIService
 }
 
 func (d *TeamDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -81,7 +81,7 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 	//Get refreshed Team value from Coralogix
-	intId, err := strconv.Atoi(data.ID.ValueString())
+	teamId, err := strconv.ParseInt(data.ID.ValueString(), 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error parsing Team ID",
@@ -89,32 +89,27 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		)
 		return
 	}
-	getTeamReq := &cxsdk.GetTeamRequest{
-		TeamId: &cxsdk.TeamID{
-			Id: uint32(intId),
-		},
-	}
-	log.Printf("[INFO] Reading Team: %s", protojson.Format(getTeamReq))
-	getTeamResp, err := d.client.Get(ctx, getTeamReq)
+	log.Printf("[INFO] Reading Team: %d", teamId)
+	getTeamResp, httpResponse, err := d.client.TeamServiceGetTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if httpResponse.StatusCode == http.StatusNotFound {
 			resp.Diagnostics.AddWarning(
 				err.Error(),
-				fmt.Sprintf("Team %d is in state, but no longer exists in Coralogix backend", intId),
+				fmt.Sprintf("Team %d is in state, but no longer exists in Coralogix backend", teamId),
 			)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Team",
-				utils.FormatRpcErrors(err, cxsdk.GetTeamRPC, protojson.Format(getTeamReq)),
+				utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Read", nil),
 			)
 		}
 		return
 	}
-	log.Printf("[INFO] Received Team: %s", protojson.Format(getTeamResp))
+	log.Printf("[INFO] Received Team: %s", utils.FormatJSON(getTeamResp))
 
 	data = &TeamResourceModel{
-		ID:         types.StringValue(strconv.Itoa(int(getTeamResp.GetTeamId().GetId()))),
+		ID:         types.StringValue(strconv.FormatInt(teamIDValue(getTeamResp.GetTeamId()), 10)),
 		Name:       types.StringValue(getTeamResp.GetTeamName()),
 		Retention:  types.Int64Value(int64(getTeamResp.GetRetention())),
 		DailyQuota: types.Float64Value(math.Round(getTeamResp.GetDailyQuota()*1000) / 1000),

--- a/internal/provider/aaa/data_source_coralogix_team.go
+++ b/internal/provider/aaa/data_source_coralogix_team.go
@@ -92,7 +92,7 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	getTeamResp, httpResponse, err := d.client.TeamServiceGetTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if isTeamNotFound(httpResponse, err) {
+		if cxsdkOpenapi.IsNotFound(cxsdkOpenapi.NewAPIError(httpResponse, err)) {
 			resp.Diagnostics.AddWarning(
 				err.Error(),
 				fmt.Sprintf("Team %d is in state, but no longer exists in Coralogix backend", teamId),
@@ -108,7 +108,7 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	log.Printf("[INFO] Received Team: %s", utils.FormatJSON(getTeamResp))
 
 	data = &TeamResourceModel{
-		ID:         types.StringValue(strconv.FormatInt(teamIDValue(getTeamResp.GetTeamId()), 10)),
+		ID:         types.StringValue(strconv.FormatInt(getTeamResp.TeamId.GetId(), 10)),
 		Name:       types.StringValue(getTeamResp.GetTeamName()),
 		Retention:  types.Int64Value(int64(getTeamResp.GetRetention())),
 		DailyQuota: types.Float64Value(math.Round(getTeamResp.GetDailyQuota()*1000) / 1000),

--- a/internal/provider/aaa/data_source_coralogix_team.go
+++ b/internal/provider/aaa/data_source_coralogix_team.go
@@ -26,7 +26,7 @@ import (
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
-	teamss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
+	teamsservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -41,7 +41,7 @@ func NewTeamDataSource() datasource.DataSource {
 }
 
 type TeamDataSource struct {
-	client *teamss.TeamsServiceAPIService
+	client *teamsservice.TeamsServiceAPIService
 }
 
 func (d *TeamDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/aaa/data_source_coralogix_team.go
+++ b/internal/provider/aaa/data_source_coralogix_team.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"net/http"
 	"strconv"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
@@ -93,7 +92,7 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	getTeamResp, httpResponse, err := d.client.TeamServiceGetTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if httpResponse.StatusCode == http.StatusNotFound {
+		if isTeamNotFound(httpResponse, err) {
 			resp.Diagnostics.AddWarning(
 				err.Error(),
 				fmt.Sprintf("Team %d is in state, but no longer exists in Coralogix backend", teamId),

--- a/internal/provider/aaa/data_source_coralogix_team.go
+++ b/internal/provider/aaa/data_source_coralogix_team.go
@@ -21,11 +21,11 @@ import (
 	"math"
 	"strconv"
 
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	teamsservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
-	teamsservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/aaa/resource_coralogix_team.go
+++ b/internal/provider/aaa/resource_coralogix_team.go
@@ -19,18 +19,17 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"net/http"
 	"strconv"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	teamss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
-	"google.golang.org/grpc/codes"
-
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -46,7 +45,7 @@ func NewTeamResource() resource.Resource {
 }
 
 type TeamResource struct {
-	client *cxsdk.TeamsClient
+	client *teamss.TeamsServiceAPIService
 }
 
 func (r *TeamResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -117,6 +116,12 @@ type TeamResourceModel struct {
 	DailyQuota types.Float64 `tfsdk:"daily_quota"`
 }
 
+// teamIDValue extracts the numeric ID from a V2TeamId value. GetId() has a pointer
+// receiver, so a temporary variable is required to make the value addressable.
+func teamIDValue(id teamss.V2TeamId) int64 {
+	return id.GetId()
+}
+
 func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan *TeamResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -130,34 +135,35 @@ func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		resp.Diagnostics = diags
 		return
 	}
-	log.Printf("[INFO] Creating new Team: %s", protojson.Format(createTeamReq))
-	createTeamResp, err := r.client.Create(ctx, createTeamReq)
+	log.Printf("[INFO] Creating new Team: %s", utils.FormatJSON(createTeamReq))
+	createTeamResp, httpResponse, err := r.client.
+		TeamServiceCreateTeamInOrg(ctx).
+		TeamServiceCreateTeamInOrgRequest(*createTeamReq).
+		Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error creating Team",
-			utils.FormatRpcErrors(err, cxsdk.CreateTeamInOrgRPC, protojson.Format(createTeamReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Create", createTeamReq),
 		)
 
 		return
 	}
-	log.Printf("[INFO] Submitted new team: %s", protojson.Format(createTeamResp.GetTeamId()))
+	teamId := teamIDValue(createTeamResp.GetTeamId())
+	log.Printf("[INFO] Submitted new team: %d", teamId)
 
-	getTeamReq := &cxsdk.GetTeamRequest{
-		TeamId: createTeamResp.GetTeamId(),
-	}
-	getTeamResp, err := r.client.Get(ctx, getTeamReq)
+	getTeamResp, httpResponse, err := r.client.TeamServiceGetTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error reading Team",
-			utils.FormatRpcErrors(err, cxsdk.GetTeamRPC, protojson.Format(getTeamReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Read", nil),
 		)
 		return
 	}
-	log.Printf("[INFO] Received Team: %s", protojson.Format(getTeamResp))
+	log.Printf("[INFO] Received Team: %s", utils.FormatJSON(getTeamResp))
 	state := TeamResourceModel{
-		ID:         types.StringValue(strconv.Itoa(int(getTeamResp.GetTeamId().GetId()))),
+		ID:         types.StringValue(strconv.FormatInt(teamIDValue(getTeamResp.GetTeamId()), 10)),
 		Name:       types.StringValue(getTeamResp.GetTeamName()),
 		Retention:  types.Int64Value(int64(getTeamResp.GetRetention())),
 		DailyQuota: types.Float64Value(math.Round(getTeamResp.GetDailyQuota()*1000) / 1000),
@@ -167,14 +173,14 @@ func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, r
 	resp.Diagnostics.Append(diags...)
 }
 
-func extractCreateTeam(plan *TeamResourceModel) (*cxsdk.CreateTeamInOrgRequest, diag.Diagnostics) {
+func extractCreateTeam(plan *TeamResourceModel) (*teamss.TeamServiceCreateTeamInOrgRequest, diag.Diagnostics) {
 	var dailyQuota *float64
 	if !(plan.DailyQuota.IsUnknown() || plan.DailyQuota.IsNull()) {
 		dailyQuota = new(float64)
 		*dailyQuota = plan.DailyQuota.ValueFloat64()
 	}
 
-	return &cxsdk.CreateTeamInOrgRequest{
+	return &teamss.TeamServiceCreateTeamInOrgRequest{
 		TeamName:   plan.Name.ValueString(),
 		DailyQuota: dailyQuota,
 	}, nil
@@ -188,7 +194,7 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	intId, err := strconv.Atoi(plan.ID.ValueString())
+	teamId, err := strconv.ParseInt(plan.ID.ValueString(), 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error parsing Team ID",
@@ -196,33 +202,28 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		)
 		return
 	}
-	getTeamReq := &cxsdk.GetTeamRequest{
-		TeamId: &cxsdk.TeamID{
-			Id: uint32(intId),
-		},
-	}
-	log.Printf("[INFO] Reading Team: %s", protojson.Format(getTeamReq))
-	getTeamResp, err := r.client.Get(ctx, getTeamReq)
+	log.Printf("[INFO] Reading Team: %d", teamId)
+	getTeamResp, httpResponse, err := r.client.TeamServiceGetTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if cxsdk.Code(err) == codes.NotFound {
+		if httpResponse.StatusCode == http.StatusNotFound {
 			resp.Diagnostics.AddWarning(
-				fmt.Sprintf("Team %d is in state, but no longer exists in Coralogix backend", intId),
-				fmt.Sprintf("%d will be recreated when you apply", intId),
+				fmt.Sprintf("Team %d is in state, but no longer exists in Coralogix backend", teamId),
+				fmt.Sprintf("%d will be recreated when you apply", teamId),
 			)
 			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error reading Team",
-				utils.FormatRpcErrors(err, cxsdk.GetTeamRPC, protojson.Format(getTeamReq)),
+				utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Read", nil),
 			)
 		}
 		return
 	}
-	log.Printf("[INFO] Received Team: %s", protojson.Format(getTeamResp))
+	log.Printf("[INFO] Received Team: %s", utils.FormatJSON(getTeamResp))
 
 	state := TeamResourceModel{
-		ID:         types.StringValue(strconv.Itoa(int(getTeamResp.GetTeamId().GetId()))),
+		ID:         types.StringValue(strconv.FormatInt(teamIDValue(getTeamResp.GetTeamId()), 10)),
 		Name:       types.StringValue(getTeamResp.GetTeamName()),
 		Retention:  types.Int64Value(int64(getTeamResp.GetRetention())),
 		DailyQuota: types.Float64Value(math.Round(getTeamResp.GetDailyQuota()*1000) / 1000),
@@ -240,19 +241,22 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	updateReq, diags := extractUpdateTeam(plan)
+	teamId, updateReq, diags := extractUpdateTeam(plan)
 	if diags.HasError() {
 		resp.Diagnostics = diags
 		return
 	}
-	log.Printf("[INFO] Updating Team: %s", protojson.Format(updateReq))
+	log.Printf("[INFO] Updating Team: %s", utils.FormatJSON(updateReq))
 
-	_, err := r.client.Update(ctx, updateReq)
+	_, httpResponse, err := r.client.
+		TeamServiceUpdateTeam(ctx, teamId).
+		TeamServiceUpdateTeamRequest(*updateReq).
+		Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error updating Team",
-			utils.FormatRpcErrors(err, cxsdk.UpdateTeamRPC, protojson.Format(updateReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Update", updateReq),
 		)
 
 		return
@@ -260,21 +264,18 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	log.Printf("[INFO] Updated team: %s", plan.ID.ValueString())
 
-	getTeamReq := &cxsdk.GetTeamRequest{
-		TeamId: updateReq.GetTeamId(),
-	}
-	getTeamResp, err := r.client.Get(ctx, getTeamReq)
+	getTeamResp, httpResponse, err := r.client.TeamServiceGetTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error reading Team",
-			utils.FormatRpcErrors(err, cxsdk.GetTeamRPC, protojson.Format(getTeamReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Read", nil),
 		)
 		return
 	}
-	log.Printf("[INFO] Received Team: %s", protojson.Format(getTeamResp))
+	log.Printf("[INFO] Received Team: %s", utils.FormatJSON(getTeamResp))
 	state := TeamResourceModel{
-		ID:         types.StringValue(strconv.Itoa(int(getTeamResp.GetTeamId().GetId()))),
+		ID:         types.StringValue(strconv.FormatInt(teamIDValue(getTeamResp.GetTeamId()), 10)),
 		Name:       types.StringValue(getTeamResp.GetTeamName()),
 		Retention:  types.Int64Value(int64(getTeamResp.GetRetention())),
 		DailyQuota: types.Float64Value(math.Round(getTeamResp.GetDailyQuota()*1000) / 1000),
@@ -284,21 +285,19 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(diags...)
 }
 
-func extractUpdateTeam(plan *TeamResourceModel) (*cxsdk.UpdateTeamRequest, diag.Diagnostics) {
+func extractUpdateTeam(plan *TeamResourceModel) (int64, *teamss.TeamServiceUpdateTeamRequest, diag.Diagnostics) {
 	dailyQuota := new(float64)
 	*dailyQuota = plan.DailyQuota.ValueFloat64()
 
-	id, err := strconv.Atoi(plan.ID.ValueString())
+	teamId, err := strconv.ParseInt(plan.ID.ValueString(), 10, 64)
 	if err != nil {
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting team id to int", err.Error())}
+		return 0, nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting team id to int", err.Error())}
 	}
-	teamId := &cxsdk.TeamID{Id: uint32(id)}
 
 	teamName := new(string)
 	*teamName = plan.Name.ValueString()
 
-	return &cxsdk.UpdateTeamRequest{
-		TeamId:     teamId,
+	return teamId, &teamss.TeamServiceUpdateTeamRequest{
 		TeamName:   teamName,
 		DailyQuota: dailyQuota,
 	}, nil
@@ -313,7 +312,7 @@ func (r *TeamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	log.Printf("[INFO] Deleting Team: %s", state.ID.ValueString())
-	id, err := strconv.Atoi(state.ID.ValueString())
+	teamId, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting Team",
@@ -322,14 +321,13 @@ func (r *TeamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	deleteReq := &cxsdk.DeleteTeamRequest{TeamId: &cxsdk.TeamID{Id: uint32(id)}}
-	log.Printf("[INFO] Deleting Team: %s", protojson.Format(deleteReq))
-	_, err = r.client.Delete(ctx, deleteReq)
+	log.Printf("[INFO] Deleting Team: %d", teamId)
+	_, httpResponse, err := r.client.TeamServiceDeleteTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
 		resp.Diagnostics.AddError(
 			"Error deleting Team",
-			utils.FormatRpcErrors(err, cxsdk.DeleteTeamRPC, protojson.Format(deleteReq)),
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Delete", nil),
 		)
 		return
 	}

--- a/internal/provider/aaa/resource_coralogix_team.go
+++ b/internal/provider/aaa/resource_coralogix_team.go
@@ -122,6 +122,14 @@ func teamIDValue(id teamsservice.V2TeamId) int64 {
 	return id.GetId()
 }
 
+// isTeamNotFound reports whether err represents a real resource-not-found response.
+// httpResponse can be nil (e.g. on a network/DNS/timeout failure before any HTTP
+// response was received), so callers must not dereference httpResponse.StatusCode
+// directly; cxsdkOpenapi.NewAPIError guards that internally.
+func isTeamNotFound(httpResponse *http.Response, err error) bool {
+	return cxsdkOpenapi.IsNotFound(cxsdkOpenapi.NewAPIError(httpResponse, err))
+}
+
 func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan *TeamResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -206,7 +214,7 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	getTeamResp, httpResponse, err := r.client.TeamServiceGetTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if httpResponse.StatusCode == http.StatusNotFound {
+		if isTeamNotFound(httpResponse, err) {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Team %d is in state, but no longer exists in Coralogix backend", teamId),
 				fmt.Sprintf("%d will be recreated when you apply", teamId),

--- a/internal/provider/aaa/resource_coralogix_team.go
+++ b/internal/provider/aaa/resource_coralogix_team.go
@@ -22,19 +22,17 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
-	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
-
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 	teamsservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
+	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/aaa/resource_coralogix_team.go
+++ b/internal/provider/aaa/resource_coralogix_team.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"net/http"
 	"strconv"
 
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
@@ -114,20 +113,6 @@ type TeamResourceModel struct {
 	DailyQuota types.Float64 `tfsdk:"daily_quota"`
 }
 
-// teamIDValue extracts the numeric ID from a V2TeamId value. GetId() has a pointer
-// receiver, so a temporary variable is required to make the value addressable.
-func teamIDValue(id teamsservice.V2TeamId) int64 {
-	return id.GetId()
-}
-
-// isTeamNotFound reports whether err represents a real resource-not-found response.
-// httpResponse can be nil (e.g. on a network/DNS/timeout failure before any HTTP
-// response was received), so callers must not dereference httpResponse.StatusCode
-// directly; cxsdkOpenapi.NewAPIError guards that internally.
-func isTeamNotFound(httpResponse *http.Response, err error) bool {
-	return cxsdkOpenapi.IsNotFound(cxsdkOpenapi.NewAPIError(httpResponse, err))
-}
-
 func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan *TeamResourceModel
 	diags := req.Plan.Get(ctx, &plan)
@@ -155,7 +140,7 @@ func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 		return
 	}
-	teamId := teamIDValue(createTeamResp.GetTeamId())
+	teamId := createTeamResp.TeamId.GetId()
 	log.Printf("[INFO] Submitted new team: %d", teamId)
 
 	getTeamResp, httpResponse, err := r.client.TeamServiceGetTeam(ctx, teamId).Execute()
@@ -169,7 +154,7 @@ func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 	log.Printf("[INFO] Received Team: %s", utils.FormatJSON(getTeamResp))
 	state := TeamResourceModel{
-		ID:         types.StringValue(strconv.FormatInt(teamIDValue(getTeamResp.GetTeamId()), 10)),
+		ID:         types.StringValue(strconv.FormatInt(getTeamResp.TeamId.GetId(), 10)),
 		Name:       types.StringValue(getTeamResp.GetTeamName()),
 		Retention:  types.Int64Value(int64(getTeamResp.GetRetention())),
 		DailyQuota: types.Float64Value(math.Round(getTeamResp.GetDailyQuota()*1000) / 1000),
@@ -212,7 +197,7 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	getTeamResp, httpResponse, err := r.client.TeamServiceGetTeam(ctx, teamId).Execute()
 	if err != nil {
 		log.Printf("[ERROR] Received error: %s", err.Error())
-		if isTeamNotFound(httpResponse, err) {
+		if cxsdkOpenapi.IsNotFound(cxsdkOpenapi.NewAPIError(httpResponse, err)) {
 			resp.Diagnostics.AddWarning(
 				fmt.Sprintf("Team %d is in state, but no longer exists in Coralogix backend", teamId),
 				fmt.Sprintf("%d will be recreated when you apply", teamId),
@@ -229,7 +214,7 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	log.Printf("[INFO] Received Team: %s", utils.FormatJSON(getTeamResp))
 
 	state := TeamResourceModel{
-		ID:         types.StringValue(strconv.FormatInt(teamIDValue(getTeamResp.GetTeamId()), 10)),
+		ID:         types.StringValue(strconv.FormatInt(getTeamResp.TeamId.GetId(), 10)),
 		Name:       types.StringValue(getTeamResp.GetTeamName()),
 		Retention:  types.Int64Value(int64(getTeamResp.GetRetention())),
 		DailyQuota: types.Float64Value(math.Round(getTeamResp.GetDailyQuota()*1000) / 1000),
@@ -281,7 +266,7 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 	log.Printf("[INFO] Received Team: %s", utils.FormatJSON(getTeamResp))
 	state := TeamResourceModel{
-		ID:         types.StringValue(strconv.FormatInt(teamIDValue(getTeamResp.GetTeamId()), 10)),
+		ID:         types.StringValue(strconv.FormatInt(getTeamResp.TeamId.GetId(), 10)),
 		Name:       types.StringValue(getTeamResp.GetTeamName()),
 		Retention:  types.Int64Value(int64(getTeamResp.GetRetention())),
 		DailyQuota: types.Float64Value(math.Round(getTeamResp.GetDailyQuota()*1000) / 1000),

--- a/internal/provider/aaa/resource_coralogix_team.go
+++ b/internal/provider/aaa/resource_coralogix_team.go
@@ -26,7 +26,7 @@ import (
 	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
-	teamss "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
+	teamsservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
@@ -45,7 +45,7 @@ func NewTeamResource() resource.Resource {
 }
 
 type TeamResource struct {
-	client *teamss.TeamsServiceAPIService
+	client *teamsservice.TeamsServiceAPIService
 }
 
 func (r *TeamResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -118,7 +118,7 @@ type TeamResourceModel struct {
 
 // teamIDValue extracts the numeric ID from a V2TeamId value. GetId() has a pointer
 // receiver, so a temporary variable is required to make the value addressable.
-func teamIDValue(id teamss.V2TeamId) int64 {
+func teamIDValue(id teamsservice.V2TeamId) int64 {
 	return id.GetId()
 }
 
@@ -173,14 +173,14 @@ func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, r
 	resp.Diagnostics.Append(diags...)
 }
 
-func extractCreateTeam(plan *TeamResourceModel) (*teamss.TeamServiceCreateTeamInOrgRequest, diag.Diagnostics) {
+func extractCreateTeam(plan *TeamResourceModel) (*teamsservice.TeamServiceCreateTeamInOrgRequest, diag.Diagnostics) {
 	var dailyQuota *float64
 	if !(plan.DailyQuota.IsUnknown() || plan.DailyQuota.IsNull()) {
 		dailyQuota = new(float64)
 		*dailyQuota = plan.DailyQuota.ValueFloat64()
 	}
 
-	return &teamss.TeamServiceCreateTeamInOrgRequest{
+	return &teamsservice.TeamServiceCreateTeamInOrgRequest{
 		TeamName:   plan.Name.ValueString(),
 		DailyQuota: dailyQuota,
 	}, nil
@@ -285,7 +285,7 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(diags...)
 }
 
-func extractUpdateTeam(plan *TeamResourceModel) (int64, *teamss.TeamServiceUpdateTeamRequest, diag.Diagnostics) {
+func extractUpdateTeam(plan *TeamResourceModel) (int64, *teamsservice.TeamServiceUpdateTeamRequest, diag.Diagnostics) {
 	dailyQuota := new(float64)
 	*dailyQuota = plan.DailyQuota.ValueFloat64()
 
@@ -297,7 +297,7 @@ func extractUpdateTeam(plan *TeamResourceModel) (int64, *teamss.TeamServiceUpdat
 	teamName := new(string)
 	*teamName = plan.Name.ValueString()
 
-	return teamId, &teamss.TeamServiceUpdateTeamRequest{
+	return teamId, &teamsservice.TeamServiceUpdateTeamRequest{
 		TeamName:   teamName,
 		DailyQuota: dailyQuota,
 	}, nil


### PR DESCRIPTION
## Description

Migrates `coralogix_team` (resource + data source) from the deprecated gRPC `cxsdk.TeamsClient` onto the new OpenAPI-generated `teams_service` REST client, now available in `coralogix-management-sdk` since the SDK bump in #643.

This is the terraform-provider half of CX-53336 ("[tf] move to Teams rest API"); the SDK-side facade/client wiring landed in `coralogix-management-sdk` PR #670 (merged), and the corresponding backend API work is `cx-management-apis` PR #384/#395.

## Changes

- `internal/clientset/clientset.go`: `ClientSet.teams` is now backed by `teams_service.TeamsServiceAPIService` (via `cs.Teams()`), moved out of the `// deprecated` gRPC-client block.
- `internal/provider/aaa/resource_coralogix_team.go` / `data_source_coralogix_team.go`: CRUD calls and error handling (`utils.FormatOpenAPIErrors` + `httpResponse.StatusCode == http.StatusNotFound`) now follow the same pattern already used by `resource_coralogix_scope.go`.

**Scope:** pure client-layer swap — no schema, model, or user-facing behavior changes. Two pre-existing, unrelated things are intentionally left untouched:
- `data.coralogix_team`'s missing `DataSources()` registration (it exists in code but was never wired into `provider.go`).
- No new acceptance test coverage for `coralogix_team` (none existed before this change either).

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l` all pass.
- No `make testacc` run as part of this PR (no test coverage added/changed). Recommend a manual apply/read/update/import pass against a real Coralogix environment before merging out of draft — the new `Update` endpoint returns a generic map instead of the full team (mitigated by the existing update-then-Get pattern), and IDs are now wrapped in `V2TeamId{Id *int64}` instead of the old `TeamID{Id uint32}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
