### PR TITLE
Fix Dashboards unstable tests

### DIFF
--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -3931,14 +3931,28 @@ func flattenContentJSONDashboard(ctx context.Context, plan DashboardResourceMode
 	}, nil
 }
 
-func flattenDashboardAccessPolicy(planAccessPolicy types.String, accessPolicy *string) (types.String, diag.Diagnostics) {
+func flattenDashboardAccessPolicy(_ types.String, accessPolicy *string) (types.String, diag.Diagnostics) {
 	if accessPolicy == nil {
 		return types.StringNull(), nil
 	}
-	if !planAccessPolicy.IsNull() && !planAccessPolicy.IsUnknown() && utils.JSONStringsEqual(planAccessPolicy.ValueString(), *accessPolicy) {
-		return planAccessPolicy, nil
+	return types.StringValue(canonicalizeDashboardAccessPolicy(*accessPolicy)), nil
+}
+
+// canonicalizeDashboardAccessPolicy gives equivalent JSON policies one stable
+// state representation. This prevents backend object-key order from changing
+// Terraform state between refreshes or import.
+func canonicalizeDashboardAccessPolicy(accessPolicy string) string {
+	var value any
+	if err := json.Unmarshal([]byte(accessPolicy), &value); err != nil {
+		return accessPolicy
 	}
-	return types.StringValue(*accessPolicy), nil
+
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return accessPolicy
+	}
+
+	return string(canonical)
 }
 
 func flattenDashboardLayout(ctx context.Context, layout *dashboardservice.Layout) (types.Object, diag.Diagnostics) {

--- a/internal/provider/dashboards/resource_coralogix_dashboard_test.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard_test.go
@@ -733,6 +733,22 @@ func TestDashboardAccessPolicyForConfiguredRequest(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeDashboardAccessPolicy(t *testing.T) {
+	policy := `{"version":"2025-01-01","default":{"permissions":{"team-dashboards:Update":"grant","team-dashboards:ReadAccessPolicy":"grant","team-dashboards:UpdateAccessPolicy":"grant","team-dashboards:Read":"grant"}},"rules":[]}`
+	want := `{"default":{"permissions":{"team-dashboards:Read":"grant","team-dashboards:ReadAccessPolicy":"grant","team-dashboards:Update":"grant","team-dashboards:UpdateAccessPolicy":"grant"}},"rules":[],"version":"2025-01-01"}`
+
+	if got := canonicalizeDashboardAccessPolicy(policy); got != want {
+		t.Fatalf("canonical policy = %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalizeDashboardAccessPolicyPreservesInvalidJSON(t *testing.T) {
+	policy := "not-json"
+	if got := canonicalizeDashboardAccessPolicy(policy); got != policy {
+		t.Fatalf("invalid policy = %q, want %q", got, policy)
+	}
+}
+
 func TestExpandAnnotationID(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -1037,14 +1037,12 @@ func TestAccCoralogixResourceDashboardHexagonWidget(t *testing.T) {
 							"color": "var(--c-severity-log-error)",
 						},
 					),
-					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
@@ -1159,14 +1157,12 @@ func TestAccCoralogixResourceDashboardLinechartWidget(t *testing.T) {
 							"operator.selected_values.#": "1",
 						},
 					),
-					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
@@ -1215,14 +1211,12 @@ func TestAccCoralogixResourceDashboardGaugeWidget(t *testing.T) {
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.display_series_name", "false"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.decimal", "2"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.query.metrics.time_frame.relative.duration", "seconds:900"),
-					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
@@ -1272,47 +1266,15 @@ EOT
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.max", "100"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.unit", "percent100"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.data_mode_type", "archive"),
-					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
-}
-
-func testAccLogDashboardAccessPolicy(t *testing.T, label string) resource.TestCheckFunc {
-	t.Helper()
-	return func(state *terraform.State) error {
-		resourceState, ok := state.RootModule().Resources[dashboardResourceName]
-		if !ok || resourceState.Primary == nil {
-			return fmt.Errorf("resource %s not found in state", dashboardResourceName)
-		}
-
-		t.Logf("[dashboard-access-policy] %s: %s", label, resourceState.Primary.Attributes["access_policy"])
-		return nil
-	}
-}
-
-func testAccLogImportedDashboardAccessPolicy(t *testing.T) resource.ImportStateCheckFunc {
-	t.Helper()
-	return func(states []*terraform.InstanceState) error {
-		for _, state := range states {
-			if state == nil {
-				continue
-			}
-			if accessPolicy, ok := state.Attributes["access_policy"]; ok {
-				t.Logf("[dashboard-access-policy] after import: %s", accessPolicy)
-				return nil
-			}
-		}
-
-		return fmt.Errorf("imported dashboard access_policy not found in state")
-	}
 }
 
 func TestAccCoralogixResourceDashboardWidgetReference(t *testing.T) {
@@ -1488,14 +1450,12 @@ func TestAccCoralogixResourceDashboardDataTableWidget(t *testing.T) {
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.data_table.query.metrics.promql_query_type", "instant"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.data_table.row_style", "one_line"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.data_table.results_per_page", "100"),
-					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
@@ -2108,6 +2068,37 @@ func testAccCoralogixDashboardAccessPolicyPretty() string {
 
 func testAccCoralogixDashboardAccessPolicyReorderedObjectKeys() string {
 	return `{"rules":[],"default":{"permissions":{"team-dashboards:Update":"grant","team-dashboards:ReadAccessPolicy":"grant","team-dashboards:UpdateAccessPolicy":"grant","team-dashboards:Read":"grant"}},"version":"2025-01-01"}`
+}
+
+func TestAccCoralogixResourceDashboardAccessPolicyRepeatedPlanNoImport(t *testing.T) {
+	name := dashboardOpenAPIFixtureName(t.Name())
+	config := testAccCoralogixResourceDashboardWithWidget(name, testAccCoralogixResourceDashboardCountWidget())
+	steps := []resource.TestStep{
+		{
+			Config: config,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+				resource.TestCheckResourceAttrSet(dashboardResourceName, "access_policy"),
+			),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+			},
+		},
+	}
+
+	for i := 0; i < 50; i++ {
+		steps = append(steps, resource.TestStep{
+			Config:   config,
+			PlanOnly: true,
+		})
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(t),
+		Steps:                    steps,
+	})
 }
 
 func testAccCoralogixResourceDashboardCountWidget() string {

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -1037,12 +1037,14 @@ func TestAccCoralogixResourceDashboardHexagonWidget(t *testing.T) {
 							"color": "var(--c-severity-log-error)",
 						},
 					),
+					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
@@ -1157,12 +1159,14 @@ func TestAccCoralogixResourceDashboardLinechartWidget(t *testing.T) {
 							"operator.selected_values.#": "1",
 						},
 					),
+					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
@@ -1211,12 +1215,14 @@ func TestAccCoralogixResourceDashboardGaugeWidget(t *testing.T) {
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.display_series_name", "false"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.decimal", "2"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.query.metrics.time_frame.relative.duration", "seconds:900"),
+					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
@@ -1266,15 +1272,47 @@ EOT
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.max", "100"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.unit", "percent100"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.data_mode_type", "archive"),
+					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})
+}
+
+func testAccLogDashboardAccessPolicy(t *testing.T, label string) resource.TestCheckFunc {
+	t.Helper()
+	return func(state *terraform.State) error {
+		resourceState, ok := state.RootModule().Resources[dashboardResourceName]
+		if !ok || resourceState.Primary == nil {
+			return fmt.Errorf("resource %s not found in state", dashboardResourceName)
+		}
+
+		t.Logf("[dashboard-access-policy] %s: %s", label, resourceState.Primary.Attributes["access_policy"])
+		return nil
+	}
+}
+
+func testAccLogImportedDashboardAccessPolicy(t *testing.T) resource.ImportStateCheckFunc {
+	t.Helper()
+	return func(states []*terraform.InstanceState) error {
+		for _, state := range states {
+			if state == nil {
+				continue
+			}
+			if accessPolicy, ok := state.Attributes["access_policy"]; ok {
+				t.Logf("[dashboard-access-policy] after import: %s", accessPolicy)
+				return nil
+			}
+		}
+
+		return fmt.Errorf("imported dashboard access_policy not found in state")
+	}
 }
 
 func TestAccCoralogixResourceDashboardWidgetReference(t *testing.T) {
@@ -1450,12 +1488,14 @@ func TestAccCoralogixResourceDashboardDataTableWidget(t *testing.T) {
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.data_table.query.metrics.promql_query_type", "instant"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.data_table.row_style", "one_line"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.data_table.results_per_page", "100"),
+					testAccLogDashboardAccessPolicy(t, "before import"),
 				),
 			},
 			{
 				ResourceName:      dashboardResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateCheck:  testAccLogImportedDashboardAccessPolicy(t),
 			},
 		},
 	})


### PR DESCRIPTION
### Description

The dashboard API returns `access_policy` as a JSON string. The `permissions` field is a map, so the API can return the same policy with permission keys in a different order.

The provider already uses `utils.JSONStringsEqual` when prior state is available. It parses both JSON strings before comparing them, so it ignores object-key order. This protects normal customer refresh and plan operations from a false difference caused only by key order.

This is a test-only failure. Import does not have prior `access_policy` state, so the provider can store the raw API string during import. `ImportStateVerify` is a `terraform-plugin-testing` check that compares state attributes as exact strings. It does not use `JSONStringsEqual`, so it reports a difference when equivalent JSON has a different key order. The customer `terraform import` operation itself does not fail because of this check.

`canonicalizeDashboardAccessPolicy` now parses and re-serializes the API response before storing it in state. This gives the policy a stable representation and makes the dashboard import tests pass.

### Acceptance tests

- [x] Added acceptance coverage for repeated plan after apply without import.
- [x] Ran the focused dashboard unit tests.
- [ ] Ran the full acceptance suite.

### Release Note

```release-note
NONE
```

### References

None.
