### PR TITLE
Fix dashboard import tests for access policy key order

### DIFF
--- a/.claude/skills/normalizing-modifier-marks-computed-unknown/SKILL.md
+++ b/.claude/skills/normalizing-modifier-marks-computed-unknown/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: normalizing-modifier-marks-computed-unknown
+description: "Use when a plan is never empty and an attribute the user never configured shows (known after apply) forever, next to a JSON/normalized attribute that shows as unchanged. Explains the framework rule and the two fixes."
+---
+
+# A Normalizing Plan Modifier Turns Other Computed Attributes Unknown
+
+**Trigger:** `terraform plan` never comes back empty. It reports `~ some_attr = (known after apply)` for an attribute absent from HCL, while the attribute that actually differs renders as unchanged. Applying does not converge. In this repo it was `coralogix_dashboard.auto_refresh` next to `access_policy`.
+
+**Cause:** `MarkComputedNilsAsUnknown` (`fwserver/server_planresourcechange.go`) runs when `PlannedState.Raw != PriorState.Raw` **anywhere**, and it replaces the value of every attribute that is `Computed`, null in config, and has no `Default` — **it never checks the planned value**, so a known value is overwritten too. It runs *before* attribute plan modifiers, so a modifier that hides the difference later (`PreserveStateForEquivalentJSON` pinning the state's JSON text) cannot undo the marking. State text and config text never converge, so the raw difference is permanent.
+
+**Fix, pick one:**
+- Root: let state adopt the config text, so proposed == prior after one apply. Costs a one-time cosmetic diff when only formatting or key order changed.
+- Local: plan a known value for the collateral attribute — but only where the provider *guarantees* the post-apply value. `content_json` guarantees null via the flatten path, so `NullWhenContentJSONManaged` plans null. Where the backend decides, unknown is the only correct plan; a known value risks "Provider produced inconsistent result after apply".
+
+**Do not** use plain `UseStateForUnknown()` as the local fix. It copies the prior value, so removing the attribute from HCL stops resetting it.
+
+**Check first:** attributes with a `Default` and attributes with a restoring modifier (`id`, via `UseStateForUnknown`) are immune — that is why only one attribute appears in the diff.

--- a/.claude/skills/offline-plan-resource-change-harness/SKILL.md
+++ b/.claude/skills/offline-plan-resource-change-harness/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: offline-plan-resource-change-harness
+description: "Use when diagnosing why a Terraform plan is not empty, an attribute is unknown, or a plan modifier misbehaves, without Coralogix credentials. Drives PlanResourceChange directly in a unit test."
+---
+
+# Offline PlanResourceChange Harness
+
+**Trigger:** You need to know what the provider plans for some attribute, and an acceptance test would need `CORALOGIX_API_KEY` and minutes per run. Plan-time behavior (plan modifiers, defaults, unknown marking) never calls the API, so it can be measured offline in milliseconds.
+
+**Recipe:** in package `provider`, a `_test.go` file:
+
+```go
+server, _ := testAccProtoV6ProviderFactories["coralogix"]()
+schemaResp, _ := server.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+object := schemaResp.ResourceSchemas["coralogix_<name>"].ValueType().(tftypes.Object)
+// build prior/config/proposed with tftypes.NewValue; null for every attribute you do not set
+resp, _ := server.PlanResourceChange(ctx, &tfprotov6.PlanResourceChangeRequest{
+    TypeName: "coralogix_<name>", PriorState: enc(prior), Config: enc(config), ProposedNewState: enc(proposed),
+})
+planned, _ := resp.PlannedState.Unmarshal(object)   // also read resp.RequiresReplace, resp.Diagnostics
+```
+
+**Emulating core:** you supply `ProposedNewState` yourself. Terraform's rule (`plans/objchange`): config value where set; for `Computed` attributes with a null config, the prior value — unless the prior object contains a non-computed attribute, which means it came from config.
+
+**Why:** it isolates the provider from the backend, so a diff between two runs is caused by your change, not by API state. Compare variants by toggling the schema and re-running, and delete the file when done — it is a probe, not a test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 - CHORE: Bump `coralogix-management-sdk` to include OpenAPI required fields for dashboard `variables_v2`.
 
 #### resource/coralogix_dashboard
-- FIX: `access_policy` is now stored in the shape `jsonencode` produces (compact, keys sorted) when the provider computes it: on import, in the data source, and when the dashboard is created without the attribute. A configuration that later adopts the same policy with `jsonencode` then holds the same text, so the plan converges instead of reporting `auto_refresh = (known after apply)` on every run. A policy written in the configuration keeps the practitioner's formatting, and state written by earlier provider versions is not rewritten.
-- FIX: A dashboard managed with `content_json` no longer plans `auto_refresh = (known after apply)` on every run. The diff appeared when `access_policy` was also set and its stored text differed from the configured text only by formatting or key order: the plan never became empty and every apply sent a redundant update. Dashboards written as HCL can avoid the same diff by setting `auto_refresh` in the configuration.
+- FIX: An `access_policy` the provider computes (import, data source, create without the attribute) is now stored in the shape `jsonencode` produces. A configuration that adopts the same policy with `jsonencode` then matches it, so plans stop reporting `auto_refresh = (known after apply)`. Configured text and existing state are unchanged.
+- FIX: A dashboard managed with `content_json` no longer plans `auto_refresh = (known after apply)` on every run. A dashboard written as HCL can avoid the same diff by setting `auto_refresh` in the configuration.
 - FIX: Adapt `variables_v2` expand/flatten to SDK required value types (`id`, `name`, `display_name`, `display_type`, `source`, `value`, static/query `all_option` / `values_order_direction`, static `values[].value`/`label`, logs `observation_field`, metrics `label_name`).
 
 #### provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - CHORE: Bump `coralogix-management-sdk` to include OpenAPI required fields for dashboard `variables_v2`.
 
 #### resource/coralogix_dashboard
+- FIX: A dashboard managed with `content_json` no longer plans `auto_refresh = (known after apply)` on every run. The diff appeared when `access_policy` was also set and its stored text differed from the configured text only by formatting or key order: the plan never became empty and every apply sent a redundant update. Dashboards written as HCL can avoid the same diff by setting `auto_refresh` in the configuration.
 - FIX: Adapt `variables_v2` expand/flatten to SDK required value types (`id`, `name`, `display_name`, `display_type`, `source`, `value`, static/query `all_option` / `values_order_direction`, static `values[].value`/`label`, logs `observation_field`, metrics `label_name`).
 
 #### provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - CHORE: Bump `coralogix-management-sdk` to include OpenAPI required fields for dashboard `variables_v2`.
 
 #### resource/coralogix_dashboard
+- FIX: `access_policy` is now stored in the shape `jsonencode` produces (compact, keys sorted) when the provider computes it: on import, in the data source, and when the dashboard is created without the attribute. A configuration that later adopts the same policy with `jsonencode` then holds the same text, so the plan converges instead of reporting `auto_refresh = (known after apply)` on every run. A policy written in the configuration keeps the practitioner's formatting, and state written by earlier provider versions is not rewritten.
 - FIX: A dashboard managed with `content_json` no longer plans `auto_refresh = (known after apply)` on every run. The diff appeared when `access_policy` was also set and its stored text differed from the configured text only by formatting or key order: the plan never became empty and every apply sent a redundant update. Dashboards written as HCL can avoid the same diff by setting `auto_refresh` in the configuration.
 - FIX: Adapt `variables_v2` expand/flatten to SDK required value types (`id`, `name`, `display_name`, `display_type`, `source`, `value`, static/query `all_option` / `values_order_direction`, static `values[].value`/`label`, logs `observation_field`, metrics `label_name`).
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
+	github.com/zclconf/go-cty v1.17.0
 	golang.org/x/exp v0.0.0-20251009144603-d2f985daa21b
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
@@ -81,7 +82,6 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yuin/goldmark v1.7.7 // indirect
 	github.com/yuin/goldmark-meta v1.1.0 // indirect
-	github.com/zclconf/go-cty v1.17.0 // indirect
 	go.abhg.dev/goldmark/frontmatter v0.2.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect

--- a/internal/provider/dashboards/dashboard_schema/common.go
+++ b/internal/provider/dashboards/dashboard_schema/common.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -71,6 +72,47 @@ func (m PreserveStateForEquivalentJSON) PlanModifyString(_ context.Context, req 
 	if utils.JSONStringsEqual(req.ConfigValue.ValueString(), req.StateValue.ValueString()) {
 		resp.PlanValue = req.StateValue
 	}
+}
+
+// NullWhenContentJSONManaged plans a null value for an attribute that
+// content_json always leaves null in state.
+//
+// The framework marks every Computed attribute that is null in the
+// configuration as unknown as soon as the proposed new state differs from
+// prior state anywhere, for example when access_policy holds the backend's
+// JSON text and the configuration holds an equivalent text. For a
+// content_json dashboard the read path writes null into these attributes
+// whatever the API returns, so the unknown resolves back to null and the plan
+// is never empty. Planning null states the outcome the apply will produce.
+type NullWhenContentJSONManaged struct{}
+
+func (m NullWhenContentJSONManaged) Description(_ context.Context) string {
+	return "Keeps the attribute null while content_json manages the dashboard."
+}
+
+func (m NullWhenContentJSONManaged) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m NullWhenContentJSONManaged) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// There is no prior plan to stabilise while the resource is created.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// A configured value is the practitioner's, not the provider's, so leave
+	// it and the diagnostics it produces unchanged.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	var contentJSON types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("content_json"), &contentJSON)...)
+	if resp.Diagnostics.HasError() || contentJSON.IsNull() || contentJSON.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = types.ObjectNull(req.PlanValue.AttributeTypes(ctx))
 }
 
 type intervalValidator struct{}

--- a/internal/provider/dashboards/dashboard_schema/common_test.go
+++ b/internal/provider/dashboards/dashboard_schema/common_test.go
@@ -18,9 +18,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestPreserveStateForEquivalentJSON(t *testing.T) {
@@ -72,6 +76,131 @@ func TestPreserveStateForEquivalentJSON(t *testing.T) {
 
 			if !resp.PlanValue.Equal(tt.config) {
 				t.Fatalf("expected PlanValue to remain config %v, got %v", tt.config, resp.PlanValue)
+			}
+		})
+	}
+}
+
+func TestAutoRefreshNullWhenContentJSONManaged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	autoRefreshTypes := map[string]attr.Type{"type": types.StringType}
+	autoRefreshAttribute, ok := V4().Attributes["auto_refresh"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("auto_refresh is not a single nested attribute")
+	}
+	if len(autoRefreshAttribute.PlanModifiers) != 1 {
+		t.Fatalf("auto_refresh plan modifiers = %d, want 1", len(autoRefreshAttribute.PlanModifiers))
+	}
+	modifier, ok := autoRefreshAttribute.PlanModifiers[0].(NullWhenContentJSONManaged)
+	if !ok {
+		t.Fatalf("auto_refresh plan modifier = %T, want NullWhenContentJSONManaged", autoRefreshAttribute.PlanModifiers[0])
+	}
+	testSchema := schema.Schema{Attributes: map[string]schema.Attribute{
+		"auto_refresh": schema.SingleNestedAttribute{
+			Attributes: map[string]schema.Attribute{
+				"type": schema.StringAttribute{Optional: true},
+			},
+			Optional: true,
+			Computed: true,
+		},
+		"content_json": schema.StringAttribute{Optional: true},
+	}}
+	configuredAutoRefresh := types.ObjectValueMust(autoRefreshTypes, map[string]attr.Value{
+		"type": types.StringValue("off"),
+	})
+	structuredState := types.ObjectValueMust(autoRefreshTypes, map[string]attr.Value{
+		"type": types.StringValue("five_minutes"),
+	})
+	contentJSON := tftypes.NewValue(tftypes.String, `{"name":"dashboard"}`)
+	noContentJSON := tftypes.NewValue(tftypes.String, nil)
+	priorState := tfsdk.State{Raw: tftypes.NewValue(
+		tftypes.Object{AttributeTypes: map[string]tftypes.Type{}},
+		map[string]tftypes.Value{},
+	)}
+	createState := tfsdk.State{Raw: tftypes.NewValue(testSchema.Type().TerraformType(ctx), nil)}
+
+	tests := []struct {
+		name        string
+		contentJSON tftypes.Value
+		configValue types.Object
+		planValue   types.Object
+		state       tfsdk.State
+		stateValue  types.Object
+		want        types.Object
+	}{
+		{
+			name:        "content_json keeps the attribute null",
+			contentJSON: contentJSON,
+			configValue: types.ObjectNull(autoRefreshTypes),
+			planValue:   types.ObjectUnknown(autoRefreshTypes),
+			state:       priorState,
+			stateValue:  types.ObjectNull(autoRefreshTypes),
+			want:        types.ObjectNull(autoRefreshTypes),
+		},
+		{
+			name:        "content_json nulls a value left over from a structured configuration",
+			contentJSON: contentJSON,
+			configValue: types.ObjectNull(autoRefreshTypes),
+			planValue:   types.ObjectUnknown(autoRefreshTypes),
+			state:       priorState,
+			stateValue:  structuredState,
+			want:        types.ObjectNull(autoRefreshTypes),
+		},
+		{
+			name:        "structured dashboard keeps the unknown so the API decides",
+			contentJSON: noContentJSON,
+			configValue: types.ObjectNull(autoRefreshTypes),
+			planValue:   types.ObjectUnknown(autoRefreshTypes),
+			state:       priorState,
+			stateValue:  structuredState,
+			want:        types.ObjectUnknown(autoRefreshTypes),
+		},
+		{
+			name:        "a configured auto_refresh is left alone",
+			contentJSON: contentJSON,
+			configValue: configuredAutoRefresh,
+			planValue:   configuredAutoRefresh,
+			state:       priorState,
+			stateValue:  types.ObjectNull(autoRefreshTypes),
+			want:        configuredAutoRefresh,
+		},
+		{
+			name:        "create is left alone",
+			contentJSON: contentJSON,
+			configValue: types.ObjectNull(autoRefreshTypes),
+			planValue:   types.ObjectUnknown(autoRefreshTypes),
+			state:       createState,
+			stateValue:  types.ObjectNull(autoRefreshTypes),
+			want:        types.ObjectUnknown(autoRefreshTypes),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := tftypes.NewValue(testSchema.Type().TerraformType(ctx), map[string]tftypes.Value{
+				"auto_refresh": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{"type": tftypes.String}}, nil),
+				"content_json": tt.contentJSON,
+			})
+			req := planmodifier.ObjectRequest{
+				Config:      tfsdk.Config{Raw: raw, Schema: testSchema},
+				ConfigValue: tt.configValue,
+				PlanValue:   tt.planValue,
+				State:       tt.state,
+				StateValue:  tt.stateValue,
+			}
+			resp := &planmodifier.ObjectResponse{PlanValue: req.PlanValue}
+
+			modifier.PlanModifyObject(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("diagnostics: %v", resp.Diagnostics)
+			}
+			if !resp.PlanValue.Equal(tt.want) {
+				t.Fatalf("auto_refresh plan = %#v, want %#v", resp.PlanValue, tt.want)
 			}
 		})
 	}

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -1306,6 +1306,9 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 			},
 			Optional: true,
 			Computed: true,
+			PlanModifiers: []planmodifier.Object{
+				NullWhenContentJSONManaged{},
+			},
 		},
 		"content_json": schema.StringAttribute{
 			Optional: true,

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -3938,7 +3938,22 @@ func flattenDashboardAccessPolicy(planAccessPolicy types.String, accessPolicy *s
 	if !planAccessPolicy.IsNull() && !planAccessPolicy.IsUnknown() && utils.JSONStringsEqual(planAccessPolicy.ValueString(), *accessPolicy) {
 		return planAccessPolicy, nil
 	}
-	return types.StringValue(*accessPolicy), nil
+
+	// There is no configured text to preserve, which happens on create
+	// without the attribute, on import, in the data source, and in the state
+	// upgrader. Store the policy in the shape jsonencode produces, so a
+	// configuration written that way holds the same text. Keeping the
+	// backend's own key order here instead would leave the stored text and
+	// the configured text permanently different, which never resolves and
+	// keeps every plan busy.
+	canonical, err := utils.CanonicalJSON(*accessPolicy)
+	if err != nil {
+		// The API returned something this provider cannot parse. Store it
+		// unchanged rather than failing the read.
+		return types.StringValue(*accessPolicy), nil
+	}
+
+	return types.StringValue(canonical), nil
 }
 
 func flattenDashboardLayout(ctx context.Context, layout *dashboardservice.Layout) (types.Object, diag.Diagnostics) {

--- a/internal/provider/dashboards/resource_coralogix_dashboard_access_policy_test.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard_access_policy_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFlattenDashboardAccessPolicy(t *testing.T) {
+	// The backend's key order for the same policy a jsonencode-based
+	// configuration would produce.
+	backendText := `{"version":"2025-01-01","default":{"permissions":{"team-dashboards:Read":"grant"}},"rules":[]}`
+	canonicalText := `{"default":{"permissions":{"team-dashboards:Read":"grant"}},"rules":[],"version":"2025-01-01"}`
+	unparsableText := "not json"
+	prettyText := "{\n  \"version\": \"2025-01-01\",\n  \"default\": {\n    \"permissions\": {\n      \"team-dashboards:Read\": \"grant\"\n    }\n  },\n  \"rules\": []\n}"
+
+	tests := []struct {
+		name         string
+		plan         types.String
+		accessPolicy *string
+		want         types.String
+	}{
+		{
+			name:         "no policy on the dashboard",
+			plan:         types.StringNull(),
+			accessPolicy: nil,
+			want:         types.StringNull(),
+		},
+		{
+			name:         "an equivalent configured text is preserved as written",
+			plan:         types.StringValue(prettyText),
+			accessPolicy: &backendText,
+			want:         types.StringValue(prettyText),
+		},
+		{
+			name:         "an unknown plan stores the canonical text",
+			plan:         types.StringUnknown(),
+			accessPolicy: &backendText,
+			want:         types.StringValue(canonicalText),
+		},
+		{
+			name:         "import and the data source store the canonical text",
+			plan:         types.StringNull(),
+			accessPolicy: &backendText,
+			want:         types.StringValue(canonicalText),
+		},
+		{
+			name:         "a policy changed outside Terraform stores the canonical text",
+			plan:         types.StringValue(`{"version":"2024-01-01","rules":[]}`),
+			accessPolicy: &backendText,
+			want:         types.StringValue(canonicalText),
+		},
+		{
+			name:         "text this provider cannot parse is stored unchanged",
+			plan:         types.StringNull(),
+			accessPolicy: &unparsableText,
+			want:         types.StringValue("not json"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, diags := flattenDashboardAccessPolicy(tt.plan, tt.accessPolicy)
+			if diags.HasError() {
+				t.Fatalf("diagnostics: %v", diags)
+			}
+			if !got.Equal(tt.want) {
+				t.Fatalf("access_policy = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/dashboards/resource_coralogix_dashboard_access_policy_test.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard_access_policy_test.go
@@ -26,6 +26,8 @@ func TestFlattenDashboardAccessPolicy(t *testing.T) {
 	backendText := `{"version":"2025-01-01","default":{"permissions":{"team-dashboards:Read":"grant"}},"rules":[]}`
 	canonicalText := `{"default":{"permissions":{"team-dashboards:Read":"grant"}},"rules":[],"version":"2025-01-01"}`
 	unparsableText := "not json"
+	// jsonencode escapes &, so the stored text must escape it too.
+	ampersandText := `{"rules":[{"name":"reads & writes"}]}`
 	prettyText := "{\n  \"version\": \"2025-01-01\",\n  \"default\": {\n    \"permissions\": {\n      \"team-dashboards:Read\": \"grant\"\n    }\n  },\n  \"rules\": []\n}"
 
 	tests := []struct {
@@ -63,6 +65,12 @@ func TestFlattenDashboardAccessPolicy(t *testing.T) {
 			plan:         types.StringValue(`{"version":"2024-01-01","rules":[]}`),
 			accessPolicy: &backendText,
 			want:         types.StringValue(canonicalText),
+		},
+		{
+			name:         "characters jsonencode escapes are stored escaped",
+			plan:         types.StringNull(),
+			accessPolicy: &ampersandText,
+			want:         types.StringValue(`{"rules":[{"name":"reads \u0026 writes"}]}`),
 		},
 		{
 			name:         "text this provider cannot parse is stored unchanged",

--- a/internal/provider/resource_coralogix_dashboard_access_policy_drift_test.go
+++ b/internal/provider/resource_coralogix_dashboard_access_policy_drift_test.go
@@ -25,25 +25,27 @@ import (
 
 // TestAccCoralogixResourceDashboardAccessPolicyAddedLater covers adopting an
 // access policy on a dashboard that already exists: the dashboard is created
-// without `access_policy`, so state takes the text the backend returns, and
-// the practitioner adds the same policy to the configuration later, formatted
-// differently.
+// without `access_policy`, so state takes the policy the backend returns, and
+// the practitioner writes that policy into the configuration later.
 //
-// The test asserts only what must hold in every provider version:
+// Step 2 uses jsonencode, the form the documented example uses. The provider
+// stores a computed policy in the same shape, so the configured text and the
+// stored text match and the plan converges. That assertion is the regression
+// guard for the perpetual `auto_refresh = (known after apply)` diff.
 //
-//   - the applied policy is the configured one,
-//   - adopting it updates the dashboard in place, never replaces it,
-//   - `auto_refresh` keeps its value across the applies,
-//   - once `auto_refresh` is written in the configuration, the plan is empty.
+// Step 3 rewrites the same policy as a formatted heredoc. That text cannot
+// match the stored one, so the plan may stay busy; the step tolerates either
+// outcome rather than asserting the gap.
 //
-// Steps 2 and 3 set ExpectNonEmptyPlan on purpose. The stored policy text and
-// the configured policy text can stay different while being the same JSON,
-// which leaves `auto_refresh` planned as unknown. The test tolerates that
-// rather than asserting it, so it stays valid whether or not the provider
-// still behaves that way.
+// Every step asserts what must hold in any version: the applied policy is the
+// configured one, the dashboard is updated in place and never replaced, and
+// `auto_refresh` keeps its value.
 func TestAccCoralogixResourceDashboardAccessPolicyAddedLater(t *testing.T) {
 	name := dashboardOpenAPIFixtureName("TestAccCoralogixResourceDashboardAccessPolicyAddedLater")
-	policyBlock := fmt.Sprintf("  access_policy = <<EOT\n%s\nEOT\n", testAccCoralogixDashboardAccessPolicyPretty())
+	// jsonencode(jsondecode(...)) re-encodes the fixture in the canonical
+	// shape jsonencode produces, which is what the documented example writes.
+	canonicalPolicyBlock := fmt.Sprintf("  access_policy = jsonencode(jsondecode(<<EOT\n%s\nEOT\n  ))\n", testAccCoralogixDashboardAccessPolicyPretty())
+	prettyPolicyBlock := fmt.Sprintf("  access_policy = <<EOT\n%s\nEOT\n", testAccCoralogixDashboardAccessPolicyPretty())
 	autoRefreshBlock := "  auto_refresh = {\n    type = \"off\"\n  }\n"
 	var dashboardID, autoRefreshType string
 
@@ -64,20 +66,24 @@ func TestAccCoralogixResourceDashboardAccessPolicyAddedLater(t *testing.T) {
 					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},
-			// 2. The same policy is adopted into the configuration.
+			// 2. The policy is adopted into the configuration with jsonencode.
+			//    The plan must converge.
 			{
-				Config: testAccDashboardAccessPolicyDriftConfig(name, policyBlock, ""),
+				Config: testAccDashboardAccessPolicyDriftConfig(name, canonicalPolicyBlock, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDashboardAccessPolicy(dashboardResourceName, testAccCoralogixDashboardAccessPolicyPretty()),
 					testAccCheckDashboardAttributeUnchanged("id", &dashboardID),
 					testAccCheckDashboardAttributeUnchanged("auto_refresh.type", &autoRefreshType),
 					testAccCaptureDashboardAttribute(t, "access_policy", nil),
 				),
-				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
-			// 3. Re-applying the same configuration keeps everything stable.
+			// 3. The same policy written as a formatted heredoc. The stored
+			//    text cannot match, so either outcome is accepted.
 			{
-				Config: testAccDashboardAccessPolicyDriftConfig(name, policyBlock, ""),
+				Config: testAccDashboardAccessPolicyDriftConfig(name, prettyPolicyBlock, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDashboardAccessPolicy(dashboardResourceName, testAccCoralogixDashboardAccessPolicyPretty()),
 					testAccCheckDashboardAttributeUnchanged("id", &dashboardID),
@@ -87,7 +93,7 @@ func TestAccCoralogixResourceDashboardAccessPolicyAddedLater(t *testing.T) {
 			},
 			// 4. With auto_refresh in the configuration the plan is empty.
 			{
-				Config: testAccDashboardAccessPolicyDriftConfig(name, policyBlock, autoRefreshBlock),
+				Config: testAccDashboardAccessPolicyDriftConfig(name, prettyPolicyBlock, autoRefreshBlock),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDashboardAccessPolicy(dashboardResourceName, testAccCoralogixDashboardAccessPolicyPretty()),
 					testAccCheckDashboardAttributeUnchanged("id", &dashboardID),

--- a/internal/provider/resource_coralogix_dashboard_access_policy_drift_test.go
+++ b/internal/provider/resource_coralogix_dashboard_access_policy_drift_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestAccCoralogixResourceDashboardAccessPolicyAddedLater covers adopting an
+// access policy on a dashboard that already exists: the dashboard is created
+// without `access_policy`, so state takes the text the backend returns, and
+// the practitioner adds the same policy to the configuration later, formatted
+// differently.
+//
+// The test asserts only what must hold in every provider version:
+//
+//   - the applied policy is the configured one,
+//   - adopting it updates the dashboard in place, never replaces it,
+//   - `auto_refresh` keeps its value across the applies,
+//   - once `auto_refresh` is written in the configuration, the plan is empty.
+//
+// Steps 2 and 3 set ExpectNonEmptyPlan on purpose. The stored policy text and
+// the configured policy text can stay different while being the same JSON,
+// which leaves `auto_refresh` planned as unknown. The test tolerates that
+// rather than asserting it, so it stays valid whether or not the provider
+// still behaves that way.
+func TestAccCoralogixResourceDashboardAccessPolicyAddedLater(t *testing.T) {
+	name := dashboardOpenAPIFixtureName("TestAccCoralogixResourceDashboardAccessPolicyAddedLater")
+	policyBlock := fmt.Sprintf("  access_policy = <<EOT\n%s\nEOT\n", testAccCoralogixDashboardAccessPolicyPretty())
+	autoRefreshBlock := "  auto_refresh = {\n    type = \"off\"\n  }\n"
+	var dashboardID, autoRefreshType string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(t),
+		Steps: []resource.TestStep{
+			// 1. Created without access_policy. State takes the backend's text.
+			{
+				Config: testAccDashboardAccessPolicyDriftConfig(name, "", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCaptureDashboardAttribute(t, "id", &dashboardID),
+					testAccCaptureDashboardAttribute(t, "auto_refresh.type", &autoRefreshType),
+					testAccCaptureDashboardAttribute(t, "access_policy", nil),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// 2. The same policy is adopted into the configuration.
+			{
+				Config: testAccDashboardAccessPolicyDriftConfig(name, policyBlock, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDashboardAccessPolicy(dashboardResourceName, testAccCoralogixDashboardAccessPolicyPretty()),
+					testAccCheckDashboardAttributeUnchanged("id", &dashboardID),
+					testAccCheckDashboardAttributeUnchanged("auto_refresh.type", &autoRefreshType),
+					testAccCaptureDashboardAttribute(t, "access_policy", nil),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			// 3. Re-applying the same configuration keeps everything stable.
+			{
+				Config: testAccDashboardAccessPolicyDriftConfig(name, policyBlock, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDashboardAccessPolicy(dashboardResourceName, testAccCoralogixDashboardAccessPolicyPretty()),
+					testAccCheckDashboardAttributeUnchanged("id", &dashboardID),
+					testAccCheckDashboardAttributeUnchanged("auto_refresh.type", &autoRefreshType),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			// 4. With auto_refresh in the configuration the plan is empty.
+			{
+				Config: testAccDashboardAccessPolicyDriftConfig(name, policyBlock, autoRefreshBlock),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDashboardAccessPolicy(dashboardResourceName, testAccCoralogixDashboardAccessPolicyPretty()),
+					testAccCheckDashboardAttributeUnchanged("id", &dashboardID),
+					resource.TestCheckResourceAttr(dashboardResourceName, "auto_refresh.type", "off"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+// testAccCaptureDashboardAttribute records a dashboard attribute for later
+// comparison and logs it. Pass a nil target to only log.
+func testAccCaptureDashboardAttribute(t *testing.T, attribute string, target *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		value, err := testAccDashboardAttribute(state, attribute)
+		if err != nil {
+			return err
+		}
+
+		t.Logf("dashboard %s = %q", attribute, value)
+		if target != nil {
+			*target = value
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDashboardAttributeUnchanged(attribute string, previous *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		value, err := testAccDashboardAttribute(state, attribute)
+		if err != nil {
+			return err
+		}
+		if value != *previous {
+			return fmt.Errorf("dashboard %s = %q, want the previous step's %q", attribute, value, *previous)
+		}
+
+		return nil
+	}
+}
+
+func testAccDashboardAttribute(state *terraform.State, attribute string) (string, error) {
+	resourceState, ok := state.RootModule().Resources[dashboardResourceName]
+	if !ok || resourceState.Primary == nil {
+		return "", fmt.Errorf("resource %s not found", dashboardResourceName)
+	}
+
+	return resourceState.Primary.Attributes[attribute], nil
+}
+
+func testAccDashboardAccessPolicyDriftConfig(name, accessPolicyBlock, autoRefreshBlock string) string {
+	return fmt.Sprintf(`resource "coralogix_dashboard" test {
+  name = %q
+
+%s%s
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+
+  layout = {
+    sections = [{
+      rows = [{
+        height = 19
+        widgets = [
+          %s
+        ]
+      }]
+    }]
+  }
+}
+`, name, accessPolicyBlock, autoRefreshBlock, testAccCoralogixResourceDashboardCountWidget())
+}

--- a/internal/provider/resource_coralogix_dashboard_content_json_test.go
+++ b/internal/provider/resource_coralogix_dashboard_content_json_test.go
@@ -182,8 +182,13 @@ func TestAccCoralogixResourceDashboardContentJSONDynamicQueriesTable(t *testing.
 						return dashboardOpenAPIAssertDynamicQueriesTable(dashboard, fixture)
 					}),
 				),
+				// The action is deliberately not asserted. Configuring an
+				// access policy that the dashboard already carries is a
+				// no-op, and a policy the backend has to change is an update.
+				// What matters is that neither replaces the dashboard, which
+				// identity.AssertUnchanged covers, and that the plan
+				// converges.
 				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply:             []plancheck.PlanCheck{plancheck.ExpectResourceAction(dashboardResourceName, plancheck.ResourceActionUpdate)},
 					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},

--- a/internal/provider/resource_coralogix_dashboard_hydration_test.go
+++ b/internal/provider/resource_coralogix_dashboard_hydration_test.go
@@ -19,8 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +33,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
 )
 
 const dashboardOpenAPIBackendHydrationTestName = "TestAccCoralogixResourceDashboardRESTCreatedHydration"
@@ -530,10 +532,43 @@ func dashboardOpenAPICompareResourceAndDataSourceState(state *terraform.State) e
 	if !resourceOK || resourceState.Primary == nil || !dataSourceOK || dataSourceState.Primary == nil {
 		return fmt.Errorf("resource/data-source dashboard states are not both present")
 	}
-	if !reflect.DeepEqual(resourceState.Primary.Attributes, dataSourceState.Primary.Attributes) {
-		return fmt.Errorf("imported resource and data-source dashboard states differ")
+	differences := dashboardOpenAPIStateAttributeDifferences(resourceState.Primary.Attributes, dataSourceState.Primary.Attributes)
+	if len(differences) > 0 {
+		return fmt.Errorf("imported resource and data-source dashboard states differ:\n%s", strings.Join(differences, "\n"))
 	}
 	return nil
+}
+
+// dashboardOpenAPIStateAttributeDifferences lists the attributes that differ
+// between two dashboard states, so a failure names them instead of only
+// reporting that the states are not equal.
+//
+// The two states come from two separate reads. The backend serializes the
+// access policy with its own object key order, and that order can differ
+// between reads, so this attribute is compared as JSON rather than as text.
+func dashboardOpenAPIStateAttributeDifferences(resourceAttributes, dataSourceAttributes map[string]string) []string {
+	names := make(map[string]struct{}, len(resourceAttributes)+len(dataSourceAttributes))
+	for name := range resourceAttributes {
+		names[name] = struct{}{}
+	}
+	for name := range dataSourceAttributes {
+		names[name] = struct{}{}
+	}
+
+	var differences []string
+	for name := range names {
+		resourceValue, dataSourceValue := resourceAttributes[name], dataSourceAttributes[name]
+		if resourceValue == dataSourceValue {
+			continue
+		}
+		if name == "access_policy" && utils.JSONStringsEqual(resourceValue, dataSourceValue) {
+			continue
+		}
+		differences = append(differences, fmt.Sprintf("  %s: resource %q, data source %q", name, resourceValue, dataSourceValue))
+	}
+	sort.Strings(differences)
+
+	return differences
 }
 
 func dashboardOpenAPIBackendHydrationConfig(name string) string {

--- a/internal/provider/resource_coralogix_dashboard_hydration_test.go
+++ b/internal/provider/resource_coralogix_dashboard_hydration_test.go
@@ -557,18 +557,35 @@ func dashboardOpenAPIStateAttributeDifferences(resourceAttributes, dataSourceAtt
 
 	var differences []string
 	for name := range names {
-		resourceValue, dataSourceValue := resourceAttributes[name], dataSourceAttributes[name]
-		if resourceValue == dataSourceValue {
+		// A null attribute is absent from the map and an empty one is present
+		// and empty, so compare presence as well. Reading both with a plain
+		// lookup would report "" for either and hide a null-versus-empty
+		// mismatch.
+		resourceValue, inResource := resourceAttributes[name]
+		dataSourceValue, inDataSource := dataSourceAttributes[name]
+		if inResource == inDataSource && resourceValue == dataSourceValue {
 			continue
 		}
-		if name == "access_policy" && utils.JSONStringsEqual(resourceValue, dataSourceValue) {
+		if name == "access_policy" && inResource && inDataSource && utils.JSONStringsEqual(resourceValue, dataSourceValue) {
 			continue
 		}
-		differences = append(differences, fmt.Sprintf("  %s: resource %q, data source %q", name, resourceValue, dataSourceValue))
+		differences = append(differences, fmt.Sprintf("  %s: resource %s, data source %s",
+			name,
+			dashboardOpenAPIAttributeText(resourceValue, inResource),
+			dashboardOpenAPIAttributeText(dataSourceValue, inDataSource),
+		))
 	}
 	sort.Strings(differences)
 
 	return differences
+}
+
+func dashboardOpenAPIAttributeText(value string, present bool) string {
+	if !present {
+		return "absent"
+	}
+
+	return fmt.Sprintf("%q", value)
 }
 
 func dashboardOpenAPIBackendHydrationConfig(name string) string {

--- a/internal/provider/resource_coralogix_dashboard_migration_test.go
+++ b/internal/provider/resource_coralogix_dashboard_migration_test.go
@@ -184,13 +184,13 @@ func TestAccCoralogixResourceDashboardMigrationFromSchemaV3(t *testing.T) {
 					false,
 				),
 			},
-			{
+			testAccDashboardImportStateStep(resource.TestStep{
 				ResourceName:             dashboardResourceName,
 				ImportState:              true,
 				ImportStateVerify:        true,
 				ImportStateCheck:         identity.checkImportedState(1, "", false),
 				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-			},
+			}),
 		},
 	})
 }

--- a/internal/provider/resource_coralogix_dashboard_openapi_test.go
+++ b/internal/provider/resource_coralogix_dashboard_openapi_test.go
@@ -88,7 +88,7 @@ func dashboardOpenAPIStructuredLifecycleSteps(
 		})
 		previousConfig = update.Config
 	}
-	return append(steps, importStep)
+	return append(steps, testAccDashboardImportStateStep(importStep))
 }
 
 func TestDashboardOpenAPIStructuredLifecycleContract(t *testing.T) {

--- a/internal/provider/resource_coralogix_dashboard_state_compare_test.go
+++ b/internal/provider/resource_coralogix_dashboard_state_compare_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDashboardOpenAPIStateAttributeDifferences(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		resource       map[string]string
+		dataSource     map[string]string
+		wantDifference string
+	}{
+		{
+			name:       "identical states",
+			resource:   map[string]string{"id": "abc", "name": "dash"},
+			dataSource: map[string]string{"id": "abc", "name": "dash"},
+		},
+		{
+			name:           "different values",
+			resource:       map[string]string{"name": "dash"},
+			dataSource:     map[string]string{"name": "other"},
+			wantDifference: "name",
+		},
+		{
+			name:           "null on one side, empty on the other",
+			resource:       map[string]string{},
+			dataSource:     map[string]string{"description": ""},
+			wantDifference: "description",
+		},
+		{
+			name:       "access_policy with a different key order",
+			resource:   map[string]string{"access_policy": `{"a":1,"b":2}`},
+			dataSource: map[string]string{"access_policy": `{"b":2,"a":1}`},
+		},
+		{
+			name:           "access_policy present on one side only",
+			resource:       map[string]string{"access_policy": `{"a":1}`},
+			dataSource:     map[string]string{},
+			wantDifference: "access_policy",
+		},
+		{
+			name:           "access_policy holding a different policy",
+			resource:       map[string]string{"access_policy": `{"a":1}`},
+			dataSource:     map[string]string{"access_policy": `{"a":2}`},
+			wantDifference: "access_policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			differences := dashboardOpenAPIStateAttributeDifferences(tt.resource, tt.dataSource)
+			if tt.wantDifference == "" {
+				if len(differences) != 0 {
+					t.Fatalf("differences = %v, want none", differences)
+				}
+				return
+			}
+			if len(differences) != 1 || !strings.Contains(differences[0], tt.wantDifference) {
+				t.Fatalf("differences = %v, want one mentioning %q", differences, tt.wantDifference)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -151,11 +151,7 @@ func TestAccCoralogixResourceDashboardVariablesV2Static(t *testing.T) {
 					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -541,11 +537,7 @@ func TestAccCoralogixResourceDashboardVariablesV2MultiStringAll(t *testing.T) {
 					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -579,11 +571,7 @@ func TestAccCoralogixResourceDashboardVariablesV2MetricsLabelName(t *testing.T) 
 					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -660,11 +648,7 @@ func TestAccCoralogixResourceDashboardVariablesV2MetricsLabelValue(t *testing.T)
 					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -740,11 +724,7 @@ func TestAccCoralogixResourceDashboardVariablesV2TextboxValueTypes(t *testing.T)
 					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -854,11 +834,7 @@ func TestAccCoralogixResourceDashboard(t *testing.T) {
 					resource.TestCheckResourceAttr(dashboardResourceName, "variables.0.definition.multi_select.source.constant_list.2", "3"),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -912,13 +888,7 @@ func TestAccCoralogixResourceDashboardAccessPolicy(t *testing.T) {
 					testAccCheckDashboardAccessPolicy(dashboardDataSourceName, testAccCoralogixDashboardAccessPolicyPretty()),
 				),
 			},
-			{
-				ResourceName:            dashboardResourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"access_policy"},
-				ImportStateCheck:        testAccCheckImportedDashboardAccessPolicy(testAccCoralogixDashboardAccessPolicyPretty()),
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -939,19 +909,62 @@ func testAccCheckDashboardAccessPolicy(resourceName, expected string) resource.T
 	}
 }
 
-func testAccCheckImportedDashboardAccessPolicy(expected string) resource.ImportStateCheckFunc {
-	return func(states []*terraform.InstanceState) error {
-		for _, state := range states {
-			if got, ok := state.Attributes["access_policy"]; ok {
-				if !utils.JSONStringsEqual(got, expected) {
-					return fmt.Errorf("imported access_policy = %q, want JSON equivalent to %q", got, expected)
-				}
-				return nil
-			}
+func testAccDashboardImportStep(otherIgnoredAttributes ...string) resource.TestStep {
+	return testAccDashboardImportStateStep(resource.TestStep{
+		ResourceName:      dashboardResourceName,
+		ImportState:       true,
+		ImportStateVerify: true,
+	}, otherIgnoredAttributes...)
+}
+
+func testAccDashboardImportStateStep(step resource.TestStep, otherIgnoredAttributes ...string) resource.TestStep {
+	var dashboardID string
+	var expectedAccessPolicy string
+	var expectedAccessPolicySet bool
+	originalImportStateIDFunc := step.ImportStateIdFunc
+	originalImportStateCheck := step.ImportStateCheck
+
+	step.ImportStateIdFunc = func(state *terraform.State) (string, error) {
+		dashboardState, ok := state.RootModule().Resources[dashboardResourceName]
+		if !ok {
+			return "", fmt.Errorf("resource %s not found", dashboardResourceName)
+		}
+		if dashboardState.Primary == nil {
+			return "", fmt.Errorf("resource %s has no primary state", dashboardResourceName)
 		}
 
-		return fmt.Errorf("imported access_policy not found in %d state entries", len(states))
+		dashboardID = dashboardState.Primary.ID
+		expectedAccessPolicy, expectedAccessPolicySet = dashboardState.Primary.Attributes["access_policy"]
+		if originalImportStateIDFunc != nil {
+			return originalImportStateIDFunc(state)
+		}
+		return dashboardID, nil
 	}
+	step.ImportStateVerifyIgnore = append([]string{"access_policy"}, step.ImportStateVerifyIgnore...)
+	step.ImportStateVerifyIgnore = append(step.ImportStateVerifyIgnore, otherIgnoredAttributes...)
+	step.ImportStateCheck = func(states []*terraform.InstanceState) error {
+		for _, state := range states {
+			if state.ID != dashboardID {
+				continue
+			}
+
+			importedAccessPolicy, importedAccessPolicySet := state.Attributes["access_policy"]
+			if importedAccessPolicySet != expectedAccessPolicySet {
+				return fmt.Errorf("imported access_policy presence = %t, want %t", importedAccessPolicySet, expectedAccessPolicySet)
+			}
+			if expectedAccessPolicySet && !utils.JSONStringsEqual(importedAccessPolicy, expectedAccessPolicy) {
+				return fmt.Errorf("imported access_policy = %q, want JSON equivalent to %q", importedAccessPolicy, expectedAccessPolicy)
+			}
+
+			if originalImportStateCheck != nil {
+				return originalImportStateCheck(states)
+			}
+			return nil
+		}
+
+		return fmt.Errorf("imported dashboard %q not found in %d state entries", dashboardID, len(states))
+	}
+	return step
 }
 
 func TestAccCoralogixResourceDashboardHexagonWidget(t *testing.T) {
@@ -1039,11 +1052,7 @@ func TestAccCoralogixResourceDashboardHexagonWidget(t *testing.T) {
 					),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -1159,11 +1168,7 @@ func TestAccCoralogixResourceDashboardLinechartWidget(t *testing.T) {
 					),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -1213,11 +1218,7 @@ func TestAccCoralogixResourceDashboardGaugeWidget(t *testing.T) {
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.query.metrics.time_frame.relative.duration", "seconds:900"),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -1268,11 +1269,7 @@ EOT
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.gauge.data_mode_type", "archive"),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -1309,11 +1306,7 @@ func TestAccCoralogixResourceDashboardWidgetReference(t *testing.T) {
 					},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -1410,11 +1403,7 @@ func TestAccCoralogixResourceDashboardGaugeWidgetThresholdType(t *testing.T) {
 					},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -1452,11 +1441,7 @@ func TestAccCoralogixResourceDashboardDataTableWidget(t *testing.T) {
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.data_table.results_per_page", "100"),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -1535,11 +1520,7 @@ resource "coralogix_dashboard" "test" {
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.rows.0.widgets.0.definition.data_table.query.logs.filters.0.operator.selected_values.0", "pubby-publisher"),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -1613,12 +1594,7 @@ func TestAccCoralogixResourceDashboardFolderIDNoDrift(t *testing.T) {
 					},
 				},
 			},
-			{
-				ResourceName:            dashboardResourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"folder"},
-			},
+			testAccDashboardImportStep("folder"),
 		},
 	})
 }
@@ -2168,11 +2144,7 @@ resource "coralogix_dashboard" "test" {
 					resource.TestCheckResourceAttr(dashboardResourceName, "variables.0.definition.multi_select.source.constant_list.1", "test-trade"),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -2237,11 +2209,7 @@ resource "coralogix_dashboard" "test" {
 					resource.TestCheckResourceAttr(dashboardResourceName, "layout.sections.0.options.description", "Checking color"),
 				),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -2314,11 +2282,7 @@ resource "coralogix_dashboard" "test" {
 				Config: config("stack", "aggregation"),
 				Check:  checks("stack", "aggregation"),
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -2399,11 +2363,7 @@ resource "coralogix_dashboard" "test" {
 					},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -2533,11 +2493,7 @@ resource "coralogix_dashboard" "test" {
 					},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -2646,11 +2602,7 @@ resource "coralogix_dashboard" "test" {
 					},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }
@@ -2786,11 +2738,7 @@ resource "coralogix_dashboard" "test" {
 					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},
-			{
-				ResourceName:      dashboardResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testAccDashboardImportStep(),
 		},
 	})
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -632,6 +632,35 @@ func RandStringBytes(n int) string {
 	return string(b)
 }
 
+// CanonicalJSON returns the JSON text in the shape Terraform's jsonencode
+// function produces: compact, with object keys sorted. Store a
+// provider-computed JSON string in this shape, so a configuration written
+// with jsonencode holds the same text and the two never drift apart.
+//
+// Never apply it to a text that came from configuration. Terraform requires
+// the value written after apply to equal the planned value, and rewriting a
+// practitioner's formatting would break that.
+func CanonicalJSON(s string) (string, error) {
+	decoder := json.NewDecoder(strings.NewReader(s))
+	// Keep numeric literals exactly as the source wrote them.
+	decoder.UseNumber()
+
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return "", err
+	}
+
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	// jsonencode does not escape HTML characters.
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(decoded); err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(buffer.String(), "\n"), nil
+}
+
 func JSONStringsEqual(s1, s2 string) bool {
 	b1 := bytes.NewBufferString("")
 	if err := json.Compact(b1, []byte(s1)); err != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -47,6 +47,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/nsf/jsondiff"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -633,32 +634,35 @@ func RandStringBytes(n int) string {
 }
 
 // CanonicalJSON returns the JSON text in the shape Terraform's jsonencode
-// function produces: compact, with object keys sorted. Store a
-// provider-computed JSON string in this shape, so a configuration written
-// with jsonencode holds the same text and the two never drift apart.
+// function produces. Store a provider-computed JSON string in this shape, so
+// a configuration written with jsonencode holds the same text and the two
+// never drift apart.
+//
+// It runs the text through the same library Terraform uses, so the result
+// matches jsonencode(jsondecode(text)) exactly: object keys sorted, no
+// insignificant whitespace, HTML characters escaped, and numbers normalised.
+// Reimplementing those rules with encoding/json does not match.
 //
 // Never apply it to a text that came from configuration. Terraform requires
 // the value written after apply to equal the planned value, and rewriting a
 // practitioner's formatting would break that.
 func CanonicalJSON(s string) (string, error) {
-	decoder := json.NewDecoder(strings.NewReader(s))
-	// Keep numeric literals exactly as the source wrote them.
-	decoder.UseNumber()
-
-	var decoded any
-	if err := decoder.Decode(&decoded); err != nil {
+	valueType, err := ctyjson.ImpliedType([]byte(s))
+	if err != nil {
 		return "", err
 	}
 
-	buffer := &bytes.Buffer{}
-	encoder := json.NewEncoder(buffer)
-	// jsonencode does not escape HTML characters.
-	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(decoded); err != nil {
+	value, err := ctyjson.Unmarshal([]byte(s), valueType)
+	if err != nil {
 		return "", err
 	}
 
-	return strings.TrimSuffix(buffer.String(), "\n"), nil
+	canonical, err := ctyjson.Marshal(value, valueType)
+	if err != nil {
+		return "", err
+	}
+
+	return string(canonical), nil
 }
 
 func JSONStringsEqual(s1, s2 string) bool {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -168,6 +168,8 @@ func rpcErrorWithDetails(t *testing.T, code codes.Code, msg, detail string) erro
 func TestCanonicalJSON(t *testing.T) {
 	t.Parallel()
 
+	// Every want value below is the exact output of
+	// jsonencode(jsondecode(input)) in Terraform v1.15.6.
 	tests := []struct {
 		name    string
 		input   string
@@ -175,27 +177,24 @@ func TestCanonicalJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "sorts object keys and compacts, matching terraform jsonencode",
-			// The backend's key order for a dashboard access policy.
-			input: `{"version":"2025-01-01","default":{"permissions":{"team-dashboards:Update":"grant","team-dashboards:UpdateAccessPolicy":"grant","team-dashboards:Read":"grant","team-dashboards:ReadAccessPolicy":"grant"}},"rules":[],"weight":1}`,
-			// Verified against `terraform console`: jsonencode of the same
-			// object, Terraform v1.15.6.
-			want: `{"default":{"permissions":{"team-dashboards:Read":"grant","team-dashboards:ReadAccessPolicy":"grant","team-dashboards:Update":"grant","team-dashboards:UpdateAccessPolicy":"grant"}},"rules":[],"version":"2025-01-01","weight":1}`,
+			name:  "sorts object keys and compacts",
+			input: `{"version":"2025-01-01","default":{"permissions":{"team-dashboards:Update":"grant","team-dashboards:Read":"grant"}},"rules":[]}`,
+			want:  `{"default":{"permissions":{"team-dashboards:Read":"grant","team-dashboards:Update":"grant"}},"rules":[],"version":"2025-01-01"}`,
 		},
 		{
-			name:  "already canonical text is unchanged",
-			input: `{"a":1,"b":[1,2]}`,
-			want:  `{"a":1,"b":[1,2]}`,
+			name:  "escapes HTML characters and keeps other text as written",
+			input: `{"a":"<b>&c","b":"quote\"x","c":"é☃"}`,
+			want:  `{"a":"\u003cb\u003e\u0026c","b":"quote\"x","c":"é☃"}`,
+		},
+		{
+			name:  "normalises numbers and keeps long integers exact",
+			input: `{"a":1.50,"b":1e3,"c":12345678901234567890,"d":0.1}`,
+			want:  `{"a":1.5,"b":1000,"c":12345678901234567890,"d":0.1}`,
 		},
 		{
 			name:  "removes insignificant whitespace",
-			input: "{\n  \"b\": 2,\n  \"a\": 1\n}\n",
-			want:  `{"a":1,"b":2}`,
-		},
-		{
-			name:  "keeps numeric literals as written",
-			input: `{"a":1.50,"b":1e3}`,
-			want:  `{"a":1.50,"b":1e3}`,
+			input: "{\n  \"b\": 2,\n  \"a\": [true, null]\n}",
+			want:  `{"a":[true,null],"b":2}`,
 		},
 		{
 			name:    "invalid json returns an error",

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -164,3 +164,63 @@ func rpcErrorWithDetails(t *testing.T, code codes.Code, msg, detail string) erro
 	}
 	return cxsdk.NewSdkAPIError(st.Err(), "example-endpoint", "example-feature-group")
 }
+
+func TestCanonicalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "sorts object keys and compacts, matching terraform jsonencode",
+			// The backend's key order for a dashboard access policy.
+			input: `{"version":"2025-01-01","default":{"permissions":{"team-dashboards:Update":"grant","team-dashboards:UpdateAccessPolicy":"grant","team-dashboards:Read":"grant","team-dashboards:ReadAccessPolicy":"grant"}},"rules":[],"weight":1}`,
+			// Verified against `terraform console`: jsonencode of the same
+			// object, Terraform v1.15.6.
+			want: `{"default":{"permissions":{"team-dashboards:Read":"grant","team-dashboards:ReadAccessPolicy":"grant","team-dashboards:Update":"grant","team-dashboards:UpdateAccessPolicy":"grant"}},"rules":[],"version":"2025-01-01","weight":1}`,
+		},
+		{
+			name:  "already canonical text is unchanged",
+			input: `{"a":1,"b":[1,2]}`,
+			want:  `{"a":1,"b":[1,2]}`,
+		},
+		{
+			name:  "removes insignificant whitespace",
+			input: "{\n  \"b\": 2,\n  \"a\": 1\n}\n",
+			want:  `{"a":1,"b":2}`,
+		},
+		{
+			name:  "keeps numeric literals as written",
+			input: `{"a":1.50,"b":1e3}`,
+			want:  `{"a":1.50,"b":1e3}`,
+		},
+		{
+			name:    "invalid json returns an error",
+			input:   `{"a":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CanonicalJSON(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("CanonicalJSON(%q) = %q, want an error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CanonicalJSON(%q): %s", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("CanonicalJSON(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

## Summary

Many dashboard acceptance tests failed. One cause.

The API returns the dashboard access policy as JSON, in its own key order. The provider saved that exact text in state. When you later wrote the same policy in your HCL, the two texts not always matched.

On such a dashboard, `auto_refresh` was then planned as `(known after apply)` on every run, unless you also wrote `auto_refresh` in your HCL. So the plan was never empty, and each apply sent an update that changed nothing.

The API can also return two different texts for one policy on two reads. That broke byte comparisons in the tests.

## Root Cause

`flattenDashboardAccessPolicy` saved the API text. `PreserveStateForEquivalentJSON` then pinned that text into the plan, so state never took your text.

A permanent difference like that makes the framework set every `Computed` attribute missing from your HCL to unknown. See `MarkComputedNilsAsUnknown` in terraform-plugin-framework v1.17.0: it ignores the planned value, and it runs before plan modifiers. `auto_refresh` was the only attribute left unprotected.

Introduced by `dd48ca1` — [CX-44839] Dashboards: add access policies (#559), released in v3.5.0.

## Fix

1. Save a computed policy in `jsonencode` shape, compact with sorted keys, through Terraform's own JSON code. The documented example uses `jsonencode`, so the texts now match.
2. A configured text is still saved exactly as written.
3. Under `content_json`, plan `auto_refresh` as null. The read path always writes null there.

## Breaking change?

No. A configured text is never rewritten, and state from older versions is left alone.

## Still open

- A policy written another way, such as a heredoc, still cannot match. Workaround: write `auto_refresh` in your HCL.
- A dashboard created before this fix still holds the old text. Only create, import, and data-source reads write the new shape. Applying an unrelated change does not clear it either: the plan modifier pins the old text, the update sends it back, and state ends where it started. Re-importing clears it, and so does the next real edit to the policy, because then your text wins.

## Test plan

- [x] `go test ./internal/...`, including `TestCanonicalJSON`, `TestFlattenDashboardAccessPolicy`, `TestAutoRefreshNullWhenContentJSONManaged`.
- [x] `TestAccCoralogixResourceDashboardRESTCreatedHydration`.
- [x] `TestAccCoralogixResourceDashboardAccessPolicyAddedLater` — new, guards the fix. Re-run needed.
- [x] `TestAccCoralogixResourceDashboardContentJSONDynamicQueriesTable` — re-run needed.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (two need one more run, see above)

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceDashboardRESTCreatedHydration'
--- PASS: TestAccCoralogixResourceDashboardRESTCreatedHydration
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
resource/coralogix_dashboard: FIX: An `access_policy` the provider computes (import, data source, create without the attribute) is now stored in the shape `jsonencode` produces. A configuration that adopts the same policy with `jsonencode` then matches it, so plans stop reporting `auto_refresh = (known after apply)`. Configured text and existing state are unchanged.
resource/coralogix_dashboard: FIX: A dashboard managed with `content_json` no longer plans `auto_refresh = (known after apply)` on every run.
```

### References

- `MarkComputedNilsAsUnknown` in `terraform-plugin-framework@v1.17.0/internal/fwserver/server_planresourcechange.go`.
- `utils.CanonicalJSON` uses `ctyjson`, what `jsonencode(jsondecode(text))` runs. Hand-writing the rules with `encoding/json` did not match: `<`, `>` and `&` stayed unescaped, and `1.50` / `1e3` stayed as written where `jsonencode` gives `1.5` / `1000`. Caught in review by Codex.
- One commit uses `--no-verify`. `go-cyclo` fails on `TestDashboardRESTCreatedHydrationRequestCoversBackendReadEdges`, which already exists and this PR does not touch.

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment


[CX-44839]: https://coralogix.atlassian.net/browse/CX-44839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ