### PR TITLE
fix(dashboards): preserve empty filter selection type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_dashboard
+- FIX: Preserve the difference between filter selections that select all values and list selections that contain zero values.
+
 # Release 3.10.0
 
 #### resource/coralogix_connector

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -549,7 +549,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -568,7 +569,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -595,7 +597,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -744,7 +747,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -763,7 +767,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -790,7 +795,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -880,7 +886,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -955,7 +962,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1031,7 +1039,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1195,7 +1204,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1214,7 +1224,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1241,7 +1252,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1307,7 +1319,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1412,7 +1425,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1476,7 +1490,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1641,7 +1656,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1720,7 +1736,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1912,7 +1929,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1931,7 +1949,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -1958,7 +1977,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2024,7 +2044,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2100,7 +2121,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2164,7 +2186,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2297,7 +2320,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2316,7 +2340,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2343,7 +2368,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2430,7 +2456,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2496,7 +2523,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2571,7 +2599,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2695,7 +2724,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2714,7 +2744,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2741,7 +2772,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2831,7 +2863,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2906,7 +2939,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -2982,7 +3016,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3132,7 +3167,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3151,7 +3187,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3178,7 +3215,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3265,7 +3303,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3321,7 +3360,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3396,7 +3436,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3548,7 +3589,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3567,7 +3609,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3594,7 +3637,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3684,7 +3728,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3759,7 +3804,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 
@@ -3835,7 +3881,8 @@ Read-Only:
 
 Read-Only:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 - `type` (String) The type of the operator. Can be one of `equals` or `not_equals`.
 
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -1549,7 +1549,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--filters--source--logs--observation_field"></a>
@@ -1583,7 +1584,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -1613,7 +1615,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -1768,7 +1771,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--bar_chart--query--data_prime--filters--logs--observation_field"></a>
@@ -1802,7 +1806,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -1832,7 +1837,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -1925,7 +1931,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--bar_chart--query--logs--filters--observation_field"></a>
@@ -2018,7 +2025,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -2097,7 +2105,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -2246,7 +2255,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--data_table--query--data_prime--filters--logs--observation_field"></a>
@@ -2280,7 +2290,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -2310,7 +2321,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -2373,7 +2385,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--data_table--query--logs--filters--observation_field"></a>
@@ -2502,7 +2515,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -2569,7 +2583,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -2767,7 +2782,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--dynamic--query_definitions--query--logs--filters--observation_field"></a>
@@ -2864,7 +2880,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3059,7 +3076,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--gauge--query--data_prime--filters--logs--observation_field"></a>
@@ -3093,7 +3111,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3123,7 +3142,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3212,7 +3232,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--gauge--query--logs--filters--observation_field"></a>
@@ -3286,7 +3307,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3353,7 +3375,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3475,7 +3498,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--hexagon--query--data_prime--filters--logs--observation_field"></a>
@@ -3509,7 +3533,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3539,7 +3564,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3629,7 +3655,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--hexagon--query--logs--filters--observation_field"></a>
@@ -3713,7 +3740,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3791,7 +3819,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3929,7 +3958,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--horizontal_bar_chart--query--data_prime--filters--logs--observation_field"></a>
@@ -3963,7 +3993,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -3993,7 +4024,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -4086,7 +4118,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--horizontal_bar_chart--query--logs--filters--observation_field"></a>
@@ -4179,7 +4212,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -4258,7 +4292,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -4403,7 +4438,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--line_chart--query_definitions--query--data_prime--filters--logs--observation_field"></a>
@@ -4437,7 +4473,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -4467,7 +4504,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -4557,7 +4595,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--line_chart--query_definitions--query--logs--filters--observation_field"></a>
@@ -4631,7 +4670,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -4709,7 +4749,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -4875,7 +4916,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--pie_chart--query--data_prime--filters--logs--observation_field"></a>
@@ -4909,7 +4951,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -4939,7 +4982,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -5032,7 +5076,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 <a id="nestedatt--layout--sections--rows--widgets--definition--pie_chart--query--logs--filters--observation_field"></a>
@@ -5125,7 +5170,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 
@@ -5204,7 +5250,8 @@ Required:
 
 Optional:
 
-- `selected_values` (List of String) the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.
+- `selected_values` (List of String) Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.
+- `selection_type` (String) How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.
 
 
 

--- a/internal/provider/dashboards/dashboard_widgets/attrs.go
+++ b/internal/provider/dashboards/dashboard_widgets/attrs.go
@@ -120,7 +120,8 @@ func SpansFilterModelAttr() map[string]attr.Type {
 
 func FilterOperatorModelAttr() map[string]attr.Type {
 	return map[string]attr.Type{
-		"type": types.StringType,
+		"type":           types.StringType,
+		"selection_type": types.StringType,
 		"selected_values": types.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -983,6 +983,7 @@ func (s spansFieldValidator) ValidateObject(ctx context.Context, request validat
 
 type FilterOperatorModel struct {
 	Type           types.String `tfsdk:"type"`
+	SelectionType  types.String `tfsdk:"selection_type"`
 	SelectedValues types.List   `tfsdk:"selected_values"` //types.String
 }
 
@@ -1008,10 +1009,33 @@ func (f filterOperatorValidator) ValidateObject(ctx context.Context, req validat
 		return
 	}
 
-	if filter.Type.ValueString() == "not_equals" &&
-		(filter.SelectedValues.IsNull() || (!filter.SelectedValues.IsUnknown() && len(filter.SelectedValues.Elements()) == 0)) {
+	selectionType := knownFilterSelectionType(filter.SelectionType)
+	if filter.Type.ValueString() == "not_equals" && selectionType == filterSelectionTypeAll {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic("filter operator validation failed", "when type is `not_equals`, `selection_type` must be `list`"))
+	}
+
+	if selectionType == filterSelectionTypeAll && filterSelectedValuesAreKnownNonEmpty(filter.SelectedValues) {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic("filter operator validation failed", "when selection_type is `all`, `selected_values` must be empty"))
+	}
+
+	if filter.Type.ValueString() == "not_equals" && filterSelectedValuesAreMissing(filter.SelectedValues) {
 		resp.Diagnostics.Append(diag.NewErrorDiagnostic("filter operator validation failed", "when type is `not_equals`, `selected_values` must contain at least one value"))
 	}
+}
+
+func knownFilterSelectionType(value types.String) string {
+	if value.IsNull() || value.IsUnknown() {
+		return ""
+	}
+	return value.ValueString()
+}
+
+func filterSelectedValuesAreKnownNonEmpty(value types.List) bool {
+	return !value.IsNull() && !value.IsUnknown() && len(value.Elements()) != 0
+}
+
+func filterSelectedValuesAreMissing(value types.List) bool {
+	return value.IsNull() || (!value.IsUnknown() && len(value.Elements()) == 0)
 }
 
 type LegendModel struct {
@@ -1525,12 +1549,14 @@ func FlattenFilterOperator(operator *dashboardservice.FilterOperator) (*FilterOp
 		case operator.Equals.Selection != nil && operator.Equals.Selection.All != nil:
 			return &FilterOperatorModel{
 				Type:           types.StringValue("equals"),
+				SelectionType:  types.StringValue(filterSelectionTypeAll),
 				SelectedValues: types.ListValueMust(types.StringType, []attr.Value{}),
 			}, nil
 		case operator.Equals.Selection != nil && operator.Equals.Selection.List != nil:
 			return &FilterOperatorModel{
 				Type:           types.StringValue("equals"),
-				SelectedValues: utils.StringSliceToTypeStringList(operator.Equals.Selection.List.GetValues()),
+				SelectionType:  types.StringValue(filterSelectionTypeList),
+				SelectedValues: flattenFilterSelectedValues(operator.Equals.Selection.List.GetValues()),
 			}, nil
 		default:
 			return nil, diag.NewErrorDiagnostic("Error Flatten Logs Filter Operator Equals", "unknown logs filter operator equals selection type")
@@ -1540,7 +1566,8 @@ func FlattenFilterOperator(operator *dashboardservice.FilterOperator) (*FilterOp
 		case operator.NotEquals.Selection != nil && operator.NotEquals.Selection.List != nil:
 			return &FilterOperatorModel{
 				Type:           types.StringValue("not_equals"),
-				SelectedValues: utils.StringSliceToTypeStringList(operator.NotEquals.Selection.List.GetValues()),
+				SelectionType:  types.StringValue(filterSelectionTypeList),
+				SelectedValues: flattenFilterSelectedValues(operator.NotEquals.Selection.List.GetValues()),
 			}, nil
 		default:
 			return nil, diag.NewErrorDiagnostic("Error Flatten Logs Filter Operator NotEquals", "unknown logs filter operator not_equals selection type")
@@ -1548,6 +1575,13 @@ func FlattenFilterOperator(operator *dashboardservice.FilterOperator) (*FilterOp
 	default:
 		return nil, diag.NewErrorDiagnostic("Error Flatten Logs Filter Operator", "unknown logs filter operator type")
 	}
+}
+
+func flattenFilterSelectedValues(values []string) types.List {
+	if len(values) == 0 {
+		return types.ListValueMust(types.StringType, []attr.Value{})
+	}
+	return utils.StringSliceToTypeStringList(values)
 }
 
 func FlattenMetricsFilters(ctx context.Context, filters []dashboardservice.MetricsFilter) (types.List, diag.Diagnostics) {

--- a/internal/provider/dashboards/dashboard_widgets/common_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/common_test.go
@@ -253,6 +253,7 @@ func TestExpandLegendOmitsUnsetPlacement(t *testing.T) {
 func TestFilterOperatorEqualsAllRoundTripUsesEmptyList(t *testing.T) {
 	configured := &FilterOperatorModel{
 		Type:           types.StringValue("equals"),
+		SelectionType:  types.StringNull(),
 		SelectedValues: types.ListValueMust(types.StringType, []attr.Value{}),
 	}
 
@@ -271,6 +272,59 @@ func TestFilterOperatorEqualsAllRoundTripUsesEmptyList(t *testing.T) {
 	if flattened.SelectedValues.IsNull() || flattened.SelectedValues.IsUnknown() || len(flattened.SelectedValues.Elements()) != 0 {
 		t.Fatalf("expected a known empty selected_values list, got %s", flattened.SelectedValues)
 	}
+	if flattened.SelectionType.ValueString() != filterSelectionTypeAll {
+		t.Fatalf("selection_type = %q, want %q", flattened.SelectionType.ValueString(), filterSelectionTypeAll)
+	}
+}
+
+func TestFilterOperatorEqualsListEmptyRoundTripStaysList(t *testing.T) {
+	apiOperator := &dashboardservice.FilterOperator{
+		Equals: &dashboardservice.FilterEquals{Selection: &dashboardservice.EqualsSelection{
+			List: &dashboardservice.EqualsSelectionListSelection{Values: []string{}},
+		}},
+	}
+
+	flattened, diagnostic := FlattenFilterOperator(apiOperator)
+	if diagnostic != nil {
+		t.Fatalf("flattening equals-list filter operator: %s", diagnostic.Detail())
+	}
+	if flattened.SelectionType.ValueString() != filterSelectionTypeList {
+		t.Fatalf("selection_type = %q, want %q", flattened.SelectionType.ValueString(), filterSelectionTypeList)
+	}
+	if flattened.SelectedValues.IsNull() || flattened.SelectedValues.IsUnknown() || len(flattened.SelectedValues.Elements()) != 0 {
+		t.Fatalf("expected a known empty selected_values list, got %s", flattened.SelectedValues)
+	}
+
+	expanded, diags := expandFilterOperator(context.Background(), flattened)
+	if diags.HasError() {
+		t.Fatalf("expanding equals-list filter operator: %v", diags)
+	}
+	if expanded == nil || expanded.Equals == nil || expanded.Equals.Selection == nil || expanded.Equals.Selection.List == nil {
+		t.Fatalf("expected equals-list REST selection, got %#v", expanded)
+	}
+	if expanded.Equals.Selection.All != nil {
+		t.Fatalf("empty list selection expanded as all: %#v", expanded.Equals.Selection)
+	}
+}
+
+func TestFilterOperatorLegacyListRoundTripResolvesSelectionType(t *testing.T) {
+	configured := &FilterOperatorModel{
+		Type:           types.StringValue("equals"),
+		SelectionType:  types.StringNull(),
+		SelectedValues: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
+	}
+
+	expanded, diags := expandFilterOperator(context.Background(), configured)
+	if diags.HasError() {
+		t.Fatalf("expanding legacy equals-list filter operator: %v", diags)
+	}
+	flattened, diagnostic := FlattenFilterOperator(expanded)
+	if diagnostic != nil {
+		t.Fatalf("flattening legacy equals-list filter operator: %s", diagnostic.Detail())
+	}
+	if flattened.SelectionType.ValueString() != filterSelectionTypeList {
+		t.Fatalf("selection_type = %q, want %q", flattened.SelectionType.ValueString(), filterSelectionTypeList)
+	}
 }
 
 func TestFilterOperatorValidatorRejectsEmptyNotEqualsSelection(t *testing.T) {
@@ -280,6 +334,7 @@ func TestFilterOperatorValidatorRejectsEmptyNotEqualsSelection(t *testing.T) {
 	} {
 		config := types.ObjectValueMust(FilterOperatorModelAttr(), map[string]attr.Value{
 			"type":            types.StringValue("not_equals"),
+			"selection_type":  types.StringNull(),
 			"selected_values": selectedValues,
 		})
 		request := validator.ObjectRequest{ConfigValue: config}
@@ -290,6 +345,43 @@ func TestFilterOperatorValidatorRejectsEmptyNotEqualsSelection(t *testing.T) {
 		if !response.Diagnostics.HasError() {
 			t.Fatalf("expected an error for not_equals with selected_values %s", selectedValues)
 		}
+	}
+}
+
+func TestFilterOperatorValidatorRejectsInvalidAllSelections(t *testing.T) {
+	tests := []struct {
+		name           string
+		operatorType   string
+		selectedValues types.List
+	}{
+		{
+			name:           "not_equals_cannot_select_all",
+			operatorType:   "not_equals",
+			selectedValues: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
+		},
+		{
+			name:           "all_cannot_have_selected_values",
+			operatorType:   "equals",
+			selectedValues: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := types.ObjectValueMust(FilterOperatorModelAttr(), map[string]attr.Value{
+				"type":            types.StringValue(tt.operatorType),
+				"selection_type":  types.StringValue(filterSelectionTypeAll),
+				"selected_values": tt.selectedValues,
+			})
+			request := validator.ObjectRequest{ConfigValue: config}
+			response := &validator.ObjectResponse{}
+
+			filterOperatorValidator{}.ValidateObject(context.Background(), request, response)
+
+			if !response.Diagnostics.HasError() {
+				t.Fatal("expected an invalid all selection to be rejected")
+			}
+		})
 	}
 }
 

--- a/internal/provider/dashboards/dashboard_widgets/dynamic_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic_test.go
@@ -176,6 +176,7 @@ func TestDynamicWidgetSpansAndDataPrimeQueryFullFidelityRoundTrip(t *testing.T) 
 				}),
 				"operator": types.ObjectValueMust(FilterOperatorModelAttr(), map[string]attr.Value{
 					"type":            types.StringValue("equals"),
+					"selection_type":  types.StringValue(filterSelectionTypeList),
 					"selected_values": types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
 				}),
 			}),

--- a/internal/provider/dashboards/dashboard_widgets/filter_selection_type.go
+++ b/internal/provider/dashboards/dashboard_widgets/filter_selection_type.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_widgets
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	filterSelectionTypeAll  = "all"
+	filterSelectionTypeList = "list"
+)
+
+// filterSelectionTypeFromSelectedValues preserves the legacy meaning of an
+// omitted selection_type. It derives the planned value from selected_values
+// instead of retaining a computed value from prior state.
+type filterSelectionTypeFromSelectedValues struct{}
+
+func (m filterSelectionTypeFromSelectedValues) Description(_ context.Context) string {
+	return "When selection_type is omitted, an empty selected_values list selects all values and a non-empty list selects those values."
+}
+
+func (m filterSelectionTypeFromSelectedValues) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m filterSelectionTypeFromSelectedValues) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.ConfigValue.IsUnknown() || !req.ConfigValue.IsNull() {
+		return
+	}
+
+	var selectedValues types.List
+	diags := req.Plan.GetAttribute(ctx, req.Path.ParentPath().AtName("selected_values"), &selectedValues)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	if selectedValues.IsUnknown() {
+		resp.PlanValue = types.StringUnknown()
+		return
+	}
+	if selectedValues.IsNull() || len(selectedValues.Elements()) == 0 {
+		resp.PlanValue = types.StringValue(filterSelectionTypeAll)
+		return
+	}
+	resp.PlanValue = types.StringValue(filterSelectionTypeList)
+}

--- a/internal/provider/dashboards/dashboard_widgets/filter_selection_type_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/filter_selection_type_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_widgets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestFilterSelectionTypeFromSelectedValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := schema.Schema{Attributes: map[string]schema.Attribute{
+		"selection_type":  schema.StringAttribute{Optional: true, Computed: true},
+		"selected_values": schema.ListAttribute{Optional: true, Computed: true, ElementType: types.StringType},
+	}}
+
+	tests := []struct {
+		name            string
+		configSelection types.String
+		planSelection   types.String
+		stateSelection  types.String
+		selectedValues  tftypes.Value
+		want            types.String
+	}{
+		{
+			name:            "omitted_empty_overrides_prior_list",
+			configSelection: types.StringNull(),
+			planSelection:   types.StringValue(filterSelectionTypeList),
+			stateSelection:  types.StringValue(filterSelectionTypeList),
+			selectedValues:  filterSelectedValuesTerraformValue([]string{}),
+			want:            types.StringValue(filterSelectionTypeAll),
+		},
+		{
+			name:            "omitted_non_empty_overrides_prior_all",
+			configSelection: types.StringNull(),
+			planSelection:   types.StringValue(filterSelectionTypeAll),
+			stateSelection:  types.StringValue(filterSelectionTypeAll),
+			selectedValues:  filterSelectedValuesTerraformValue([]string{"api"}),
+			want:            types.StringValue(filterSelectionTypeList),
+		},
+		{
+			name:            "explicit_list_is_preserved",
+			configSelection: types.StringValue(filterSelectionTypeList),
+			planSelection:   types.StringValue(filterSelectionTypeList),
+			stateSelection:  types.StringValue(filterSelectionTypeAll),
+			selectedValues:  filterSelectedValuesTerraformValue([]string{}),
+			want:            types.StringValue(filterSelectionTypeList),
+		},
+		{
+			name:            "unknown_values_keep_selection_unknown",
+			configSelection: types.StringNull(),
+			planSelection:   types.StringUnknown(),
+			stateSelection:  types.StringValue(filterSelectionTypeAll),
+			selectedValues:  tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, tftypes.UnknownValue),
+			want:            types.StringUnknown(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := tftypes.NewValue(s.Type().TerraformType(ctx), map[string]tftypes.Value{
+				"selection_type":  filterSelectionTypeTerraformValue(tt.planSelection),
+				"selected_values": tt.selectedValues,
+			})
+			req := planmodifier.StringRequest{
+				Path:        path.Root("selection_type"),
+				ConfigValue: tt.configSelection,
+				PlanValue:   tt.planSelection,
+				StateValue:  tt.stateSelection,
+				Plan:        tfsdk.Plan{Schema: s, Raw: raw},
+			}
+			resp := &planmodifier.StringResponse{PlanValue: tt.planSelection}
+
+			filterSelectionTypeFromSelectedValues{}.PlanModifyString(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("diagnostics: %v", resp.Diagnostics)
+			}
+			if !resp.PlanValue.Equal(tt.want) {
+				t.Fatalf("plan = %#v, want %#v", resp.PlanValue, tt.want)
+			}
+		})
+	}
+}
+
+func filterSelectionTypeTerraformValue(value types.String) tftypes.Value {
+	if value.IsUnknown() {
+		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	}
+	if value.IsNull() {
+		return tftypes.NewValue(tftypes.String, nil)
+	}
+	return tftypes.NewValue(tftypes.String, value.ValueString())
+}
+
+func filterSelectedValuesTerraformValue(values []string) tftypes.Value {
+	elements := make([]tftypes.Value, 0, len(values))
+	for _, value := range values {
+		elements = append(elements, tftypes.NewValue(tftypes.String, value))
+	}
+	return tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, elements)
+}

--- a/internal/provider/dashboards/dashboard_widgets/filters.go
+++ b/internal/provider/dashboards/dashboard_widgets/filters.go
@@ -207,6 +207,17 @@ func expandFilterOperator(ctx context.Context, operator *FilterOperatorModel) (*
 	if diags.HasError() {
 		return nil, diags
 	}
+	selectionType := operator.SelectionType.ValueString()
+	if operator.SelectionType.IsNull() || operator.SelectionType.IsUnknown() {
+		if operator.SelectedValues.IsUnknown() {
+			diags.Append(diag.NewErrorDiagnostic("Error expand filter operator", "cannot determine the selection type because selected_values is unknown"))
+			return nil, diags
+		}
+		selectionType = filterSelectionTypeList
+		if len(selectedValues) == 0 {
+			selectionType = filterSelectionTypeAll
+		}
+	}
 
 	switch operator.Type.ValueString() {
 	case "equals":
@@ -215,13 +226,33 @@ func expandFilterOperator(ctx context.Context, operator *FilterOperatorModel) (*
 				Selection: &dashboardservice.EqualsSelection{},
 			},
 		}
-		if len(selectedValues) != 0 {
-			filterOperator.Equals.Selection.List = &dashboardservice.EqualsSelectionListSelection{Values: selectedValues}
-		} else {
+		switch selectionType {
+		case filterSelectionTypeAll:
+			if len(selectedValues) != 0 {
+				diags.Append(diag.NewErrorDiagnostic("Error expand filter operator", "selected_values must be empty when selection_type is `all`"))
+				return nil, diags
+			}
 			filterOperator.Equals.Selection.All = map[string]interface{}{}
+		case filterSelectionTypeList:
+			if operator.SelectedValues.IsUnknown() {
+				diags.Append(diag.NewErrorDiagnostic("Error expand filter operator", "cannot expand a list selection because selected_values is unknown"))
+				return nil, diags
+			}
+			filterOperator.Equals.Selection.List = &dashboardservice.EqualsSelectionListSelection{Values: selectedValues}
+		default:
+			diags.Append(diag.NewErrorDiagnostic("Error expand filter operator", fmt.Sprintf("unknown selection type %s", selectionType)))
+			return nil, diags
 		}
 		return filterOperator, nil
 	case "not_equals":
+		if selectionType != filterSelectionTypeList {
+			diags.Append(diag.NewErrorDiagnostic("Error expand filter operator", "when type is `not_equals`, selection_type must be `list`"))
+			return nil, diags
+		}
+		if operator.SelectedValues.IsUnknown() {
+			diags.Append(diag.NewErrorDiagnostic("Error expand filter operator", "cannot expand a list selection because selected_values is unknown"))
+			return nil, diags
+		}
 		return &dashboardservice.FilterOperator{
 			NotEquals: &dashboardservice.FilterNotEquals{
 				Selection: &dashboardservice.NotEqualsSelection{

--- a/internal/provider/dashboards/dashboard_widgets/schema.go
+++ b/internal/provider/dashboards/dashboard_widgets/schema.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -386,12 +387,23 @@ func FilterOperatorSchema() schema.SingleNestedAttribute {
 				},
 				MarkdownDescription: "The type of the operator. Can be one of `equals` or `not_equals`.",
 			},
+			"selection_type": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(filterSelectionTypeAll, filterSelectionTypeList),
+				},
+				PlanModifiers: []planmodifier.String{
+					filterSelectionTypeFromSelectedValues{},
+				},
+				MarkdownDescription: "How the operator selects values. Use `all` to select every value. Use `list` to select only `selected_values`. If omitted, an empty legacy `selected_values` list means `all`.",
+			},
 			"selected_values": schema.ListAttribute{
 				ElementType:         types.StringType,
 				Optional:            true,
 				Computed:            true,
 				Default:             listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
-				MarkdownDescription: "the values to filter by. When the type is `equals`, this field is optional, the filter will match only the selected values, and all the values if not set. When the type is `not_equals`, this field is required, and the filter will match spans without the selected values.",
+				MarkdownDescription: "Values to filter by. For `equals`, set `selection_type` to `list` to represent an empty selection. If `selection_type` is omitted, an empty list selects all values for backward compatibility. For `not_equals`, this list must contain at least one value.",
 			},
 		},
 		Validators: []validator.Object{

--- a/internal/provider/resource_coralogix_dashboard_filter_selection_test.go
+++ b/internal/provider/resource_coralogix_dashboard_filter_selection_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestDashboardFilterSelectionConfigParses(t *testing.T) {
+	_, diagnostics := hclsyntax.ParseConfig([]byte(dashboardFilterSelectionConfig("dashboard")), "filter-selection.tf", hcl.InitialPos)
+	if diagnostics.HasErrors() {
+		t.Fatalf("filter selection config does not parse: %s", diagnostics.Error())
+	}
+}
+
+func TestAccCoralogixResourceDashboardFilterSelectionTypes(t *testing.T) {
+	name := dashboardOpenAPIFixtureName(t.Name())
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(t),
+		Steps: []resource.TestStep{{
+			Config: dashboardFilterSelectionConfig(name),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+			},
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttrSet(dashboardResourceName, "id"),
+				resource.TestCheckResourceAttr(dashboardResourceName, "filters.0.source.metrics.operator.selection_type", "all"),
+				resource.TestCheckResourceAttr(dashboardResourceName, "filters.0.source.metrics.operator.selected_values.#", "0"),
+				resource.TestCheckResourceAttr(dashboardResourceName, "filters.1.source.metrics.operator.selection_type", "list"),
+				resource.TestCheckResourceAttr(dashboardResourceName, "filters.1.source.metrics.operator.selected_values.#", "0"),
+			),
+		}},
+	})
+}
+
+func dashboardFilterSelectionConfig(name string) string {
+	return fmt.Sprintf(`
+resource "coralogix_dashboard" "test" {
+  name        = %q
+  description = "Filter selection round-trip"
+  time_frame  = { relative = { duration = "seconds:900" } }
+  layout = {
+    sections = [{ rows = [{
+      height = 10
+      widgets = [{
+        title = "filter-selection"
+        definition = { line_chart = {
+          query_definitions = [{
+            query = { logs = { aggregations = [{ type = "count" }] } }
+          }]
+          legend = { is_visible = false }
+        } }
+      }]
+    }] }]
+  }
+  filters = [
+    {
+      source = { metrics = {
+        metric_name = "http_requests_total"
+        label       = "service"
+        operator    = { type = "equals", selected_values = [] }
+      } }
+    },
+    {
+      source = { metrics = {
+        metric_name = "http_requests_total"
+        label       = "service"
+        operator    = { type = "equals", selection_type = "list", selected_values = [] }
+      } }
+    },
+  ]
+}
+`, name)
+}


### PR DESCRIPTION
## Summary

- Add an optional and computed `selection_type` discriminator to dashboard filter operators.
- Preserve the API distinction between `Selection.All` and `Selection.List(values=[])`.
- Keep the legacy behavior when `selection_type` is omitted.
- Add validation, planning, round-trip tests, generated documentation, and a changelog entry.

## Problem

The dashboard API has two different selection branches:

- `Selection.All` selects every value.
- `Selection.List(values=[])` selects zero values.

The provider previously represented both branches as `selected_values = []`. A later expand could therefore convert an API empty-list selection into `Selection.All`. This silently changed the filter meaning.

Live EU2 verification confirmed that the API preserves these branches. The dashboard UI also shows different states: `All` has "Select all" enabled, while `List([])` shows zero selected values.

## Behavior after this change

| API or configuration | Terraform state | Expanded API branch |
| --- | --- | --- |
| API `Selection.All` | `selection_type = "all"`, `selected_values = []` | `Selection.All` |
| API `Selection.List([])` | `selection_type = "list"`, `selected_values = []` | `Selection.List([])` |
| Legacy `selected_values = []` with no discriminator | planned as `selection_type = "all"` | `Selection.All` |
| Legacy non-empty `selected_values` with no discriminator | planned as `selection_type = "list"` | `Selection.List(values)` |

A custom plan modifier derives the discriminator when it is omitted. It does not retain an incompatible computed value from prior state. This keeps existing configurations backward compatible.

The validator also rejects these invalid combinations:

- `type = "not_equals"` with `selection_type = "all"`.
- `selection_type = "all"` with non-empty `selected_values`.

## Tests

- Added unit coverage for legacy All, legacy List, API All, and API `List([])` round trips.
- Added plan-modifier coverage that verifies omitted configuration overrides incompatible prior state.
- Added validator coverage for invalid `all` combinations.
- Added an acceptance scenario for legacy All and explicit empty List, including an empty follow-up plan check.
- `go test ./... -count=1`
- Pre-commit checks: Gitleaks, gofmt, goimports, go vet, go-cyclo, unit tests, build, and go mod tidy.
- `golangci-lint run --new-from-rev=HEAD ./...`
