### PR TITLE
feat(alerts): add EQUALS and NOT_EQUALS threshold condition types (CX-54815)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_alert
+- FEAT: Add `EQUALS` and `NOT_EQUALS` condition types for logs and metric threshold alerts.
+
 #### resource/coralogix_dashboard
 - FEAT: Add the `stat_card` visualization to the `dynamic` widget: the `title`, `label` and `primary_value` elements (each reading a field, using template text, or showing the color-mapping result), display-name template variables, and `color_label_mapping` with its `range`, `value` and `regex` variants. Note that opening a `dynamic` `stat` widget in the Coralogix UI rewrites it to a `stat_card`. Releases 3.10.0 and 3.10.1 could not read the result, so `plan`, `apply` and `destroy` all failed against such a dashboard.
 - FIX: `unit` now accepts `percent` and `datetime_iso`, which the API supports but the shared unit map omitted; the gauge unit map was also missing `datetime_iso`. A widget saved with either unit — by the Coralogix UI, for example — read back as null, and the next apply overwrote it with `unspecified`. Affects every widget type exposing a `unit`, not only `dynamic`.

--- a/docs/data-sources/alert.md
+++ b/docs/data-sources/alert.md
@@ -667,7 +667,7 @@ Read-Only:
 
 Read-Only:
 
-- `condition_type` (String) Condition to evaluate the threshold with. Valid values: ["LESS_THAN" "MORE_THAN"].
+- `condition_type` (String) Condition to evaluate the threshold with. Valid values: ["EQUALS" "LESS_THAN" "MORE_THAN" "NOT_EQUALS"].
 - `threshold` (Number)
 - `time_window` (String) Time window to evaluate the threshold with. Valid values: ["10_MINUTES" "12_HOURS" "15_MINUTES" "1_HOUR" "20_MINUTES" "24_HOURS" "2_HOURS" "30_MINUTES" "36_HOURS" "4_HOURS" "5_MINUTES" "6_HOURS"].
 
@@ -949,7 +949,7 @@ Read-Only:
 
 Read-Only:
 
-- `condition_type` (String) Condition to evaluate the threshold with. Valid values: ["LESS_THAN" "LESS_THAN_OR_EQUALS" "MORE_THAN" "MORE_THAN_OR_EQUALS"].
+- `condition_type` (String) Condition to evaluate the threshold with. Valid values: ["EQUALS" "LESS_THAN" "LESS_THAN_OR_EQUALS" "MORE_THAN" "MORE_THAN_OR_EQUALS" "NOT_EQUALS"].
 - `for_over_pct` (Number) Percentage of metrics over the threshold. 0 means 'for at least once', 100 means 'for at least'.
 - `of_the_last` (String) Time window to evaluate the threshold with. Valid values: ["10_MINUTES" "12_HOURS" "15_MINUTES" "1_HOUR" "1_MINUTE" "20_MINUTES" "24_HOURS" "2_HOURS" "30_MINUTES" "36_HOURS" "4_HOURS" "5_MINUTES" "6_HOURS"].
 Or having valid time duration - Supported units: y, w, d, h, m, s, ms.

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -1291,7 +1291,7 @@ Required:
 
 Required:
 
-- `condition_type` (String) Condition to evaluate the threshold with. Valid values: ["LESS_THAN" "MORE_THAN"].
+- `condition_type` (String) Condition to evaluate the threshold with. Valid values: ["EQUALS" "LESS_THAN" "MORE_THAN" "NOT_EQUALS"].
 - `threshold` (Number)
 - `time_window` (String) Time window to evaluate the threshold with. Valid values: ["10_MINUTES" "12_HOURS" "15_MINUTES" "1_HOUR" "20_MINUTES" "24_HOURS" "2_HOURS" "30_MINUTES" "36_HOURS" "4_HOURS" "5_MINUTES" "6_HOURS"].
 
@@ -1648,7 +1648,7 @@ Required:
 
 Required:
 
-- `condition_type` (String) Condition to evaluate the threshold with. Valid values: ["LESS_THAN" "LESS_THAN_OR_EQUALS" "MORE_THAN" "MORE_THAN_OR_EQUALS"].
+- `condition_type` (String) Condition to evaluate the threshold with. Valid values: ["EQUALS" "LESS_THAN" "LESS_THAN_OR_EQUALS" "MORE_THAN" "MORE_THAN_OR_EQUALS" "NOT_EQUALS"].
 - `for_over_pct` (Number) Percentage of metrics over the threshold. 0 means 'for at least once', 100 means 'for at least'.
 - `of_the_last` (String) Time window to evaluate the threshold with. Valid values: ["10_MINUTES" "12_HOURS" "15_MINUTES" "1_HOUR" "1_MINUTE" "20_MINUTES" "24_HOURS" "2_HOURS" "30_MINUTES" "36_HOURS" "4_HOURS" "5_MINUTES" "6_HOURS"].
 Or having valid time duration - Supported units: y, w, d, h, m, s, ms.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824133534-79f38d837aea
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c h1:zWTINNZMXUGkdO5rB3Ld0y6uwz0usyFCMoCfx/860Eg=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824133534-79f38d837aea h1:IcFo3jw0pgsdKzXdLsPssFgZMF3FDepPUeqVgsHtx30=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824133534-79f38d837aea/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5 h1:mqmL/WJA8Cdzim6r3jmXY8uiPn9KX4AvqxjEPDRXKj4=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/alerts/alert_types/common.go
+++ b/internal/provider/alerts/alert_types/common.go
@@ -131,7 +131,7 @@ var (
 	NoDataPolicyStateSchemaToProtoMap = utils.ReverseMap(NoDataPolicyStateProtoToSchemaMap)
 	// Preferred user-facing values (docs + descriptions). UNSPECIFIED remains accepted
 	// with a deprecation warning for one or more releases.
-	ValidNoDataPolicyStates = []string{"OK", "ALERTING", "KEEP_LAST", "NO_DATA"}
+	ValidNoDataPolicyStates    = []string{"OK", "ALERTING", "KEEP_LAST", "NO_DATA"}
 	AcceptedNoDataPolicyStates = append(append([]string{}, ValidNoDataPolicyStates...), "UNSPECIFIED")
 
 	LogsRatioTimeWindowValueProtoToSchemaMap = map[alerts.LogsRatioTimeWindowValue]string{
@@ -268,6 +268,8 @@ var (
 	LogsThresholdConditionMap = map[alerts.LogsThresholdConditionType]string{
 		alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_UNSPECIFIED: "MORE_THAN",
 		alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_LESS_THAN:                "LESS_THAN",
+		alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_EQUALS:                   "EQUALS",
+		alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_NOT_EQUALS:               "NOT_EQUALS",
 	}
 	LogsThresholdConditionToProtoMap = utils.ReverseMap(LogsThresholdConditionMap)
 	LogsThresholdConditionValues     = utils.GetValues(LogsThresholdConditionMap)
@@ -291,6 +293,8 @@ var (
 		alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_LESS_THAN:                "LESS_THAN",
 		alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_EQUALS:      "MORE_THAN_OR_EQUALS",
 		alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_LESS_THAN_OR_EQUALS:      "LESS_THAN_OR_EQUALS",
+		alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_EQUALS:                   "EQUALS",
+		alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_NOT_EQUALS:               "NOT_EQUALS",
 	}
 	MetricsThresholdConditionValues     = utils.GetValues(MetricsThresholdConditionMap)
 	MetricsThresholdConditionToProtoMap = utils.ReverseMap(MetricsThresholdConditionMap)

--- a/internal/provider/resource_coralogix_alert_test.go
+++ b/internal/provider/resource_coralogix_alert_test.go
@@ -1273,6 +1273,67 @@ func TestAccCoralogixResourceAlert_metric_more_than_or_equals(t *testing.T) {
 	)
 }
 
+func TestAccCoralogixResourceAlert_logs_equals(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAlertDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceAlertLogsEquals(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(alertResourceName, "name", "logs-equals alert example"),
+					resource.TestCheckResourceAttr(alertResourceName, "type_definition.logs_threshold.rules.0.condition.threshold", "100"),
+					resource.TestCheckResourceAttr(alertResourceName, "type_definition.logs_threshold.rules.0.condition.time_window", "10_MINUTES"),
+					resource.TestCheckResourceAttr(alertResourceName, "type_definition.logs_threshold.rules.0.condition.condition_type", "EQUALS"),
+				),
+			},
+			{
+				ResourceName: alertResourceName,
+				ImportState:  true,
+			},
+			{
+				Config: testAccCoralogixResourceAlertLogsEqualsUpdated(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(alertResourceName, "name", "logs-equals alert example updated"),
+					resource.TestCheckResourceAttr(alertResourceName, "type_definition.logs_threshold.rules.0.condition.condition_type", "NOT_EQUALS"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func TestAccCoralogixResourceAlert_metric_equals(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAlertDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoralogixResourceAlertMetricEquals(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(alertResourceName, "name", "metric-equals alert example"),
+					resource.TestCheckResourceAttr(alertResourceName, "type_definition.metric_threshold.rules.0.condition.threshold", "0"),
+					resource.TestCheckResourceAttr(alertResourceName, "type_definition.metric_threshold.rules.0.condition.condition_type", "EQUALS"),
+				),
+			},
+			{
+				ResourceName: alertResourceName,
+				ImportState:  true,
+			},
+			{
+				Config: testAccCoralogixResourceAlertMetricEqualsUpdated(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(alertResourceName, "name", "metric-equals alert example updated"),
+					resource.TestCheckResourceAttr(alertResourceName, "type_definition.metric_threshold.rules.0.condition.condition_type", "NOT_EQUALS"),
+				),
+			},
+		},
+	},
+	)
+}
+
 func TestAccCoralogixResourceAlert_tracing_immediate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -3515,6 +3576,126 @@ func testAccCoralogixResourceAlertMetricMoreThanOrEqualsUpdated() string {
         missing_values = {
             replace_with_zero = true
         }
+    }
+  }
+}
+`
+}
+
+func testAccCoralogixResourceAlertLogsEquals() string {
+	return `resource "coralogix_alert" "test" {
+  name        = "logs-equals alert example"
+  description = "Example of logs-equals alert from terraform"
+  priority    = "P2"
+
+  type_definition = {
+    logs_threshold = {
+      logs_filter = {
+        simple_filter = {
+          lucene_query = "level:ERROR"
+        }
+      }
+      rules = [{
+        condition = {
+          threshold      = 100
+          time_window    = "10_MINUTES"
+          condition_type = "EQUALS"
+        }
+        override = {
+          priority = "P2"
+        }
+      }]
+    }
+  }
+}
+`
+}
+
+func testAccCoralogixResourceAlertLogsEqualsUpdated() string {
+	return `resource "coralogix_alert" "test" {
+  name        = "logs-equals alert example updated"
+  description = "Example of logs-equals alert from terraform updated"
+  priority    = "P2"
+
+  type_definition = {
+    logs_threshold = {
+      logs_filter = {
+        simple_filter = {
+          lucene_query = "level:ERROR"
+        }
+      }
+      rules = [{
+        condition = {
+          threshold      = 100
+          time_window    = "10_MINUTES"
+          condition_type = "NOT_EQUALS"
+        }
+        override = {
+          priority = "P2"
+        }
+      }]
+    }
+  }
+}
+`
+}
+
+func testAccCoralogixResourceAlertMetricEquals() string {
+	return `resource "coralogix_alert" "test" {
+  name        = "metric-equals alert example"
+  description = "Example of metric-equals alert from terraform"
+  priority    = "P3"
+
+  type_definition = {
+    metric_threshold = {
+      metric_filter = {
+        promql = "sum(rate(http_requests_total[5m]))"
+      }
+      rules = [{
+        condition = {
+          threshold      = 0
+          for_over_pct   = 100
+          of_the_last    = "5_MINUTES"
+          condition_type = "EQUALS"
+        }
+        override = {
+          priority = "P3"
+        }
+      }]
+      missing_values = {
+        replace_with_zero = true
+      }
+    }
+  }
+}
+`
+}
+
+func testAccCoralogixResourceAlertMetricEqualsUpdated() string {
+	return `resource "coralogix_alert" "test" {
+  name        = "metric-equals alert example updated"
+  description = "Example of metric-equals alert from terraform updated"
+  priority    = "P3"
+
+  type_definition = {
+    metric_threshold = {
+      metric_filter = {
+        promql = "sum(rate(http_requests_total[5m]))"
+      }
+      rules = [{
+        condition = {
+          threshold      = 0
+          for_over_pct   = 100
+          of_the_last    = "5_MINUTES"
+          condition_type = "NOT_EQUALS"
+        }
+        override = {
+          priority = "P3"
+        }
+      }]
+      missing_values = {
+        replace_with_zero = true
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

## Summary
Add `EQUALS` and `NOT_EQUALS` condition types for logs and metric threshold `coralogix_alert`s so Terraform can express exact-match and not-equal thresholds ([CX-54815](https://coralogix.atlassian.net/browse/CX-54815)).

## Root Cause
This is additive API surface, not a defect. The Management API already accepts `LOGS_THRESHOLD_CONDITION_TYPE_EQUALS` / `NOT_EQUALS` and `METRIC_THRESHOLD_CONDITION_TYPE_EQUALS` / `NOT_EQUALS`. Terraform only mapped `MORE_THAN` / `LESS_THAN` (and the existing more-than-or-equals / less-than-or-equals variants) in `internal/provider/alerts/alert_types/common.go` (`LogsThresholdConditionMap`, `MetricsThresholdConditionMap`), so valid HCL using `EQUALS` / `NOT_EQUALS` was rejected at plan time.

## Why was it introduced
The maps were written when those were the only threshold operators on the public IAC surface. EQUALS / NOT_EQUALS landed in the alerts API later and were never added to the provider maps.

## Breaking change?
No. Existing `MORE_THAN` / `LESS_THAN` (and or-equals) configs are unchanged. New enum values are additive.

## Risks
- **Wrong enum string vs API:** mitigated by mapping to the OpenAPI constants from the pinned SDK and live EU2 acc tests that create, update EQUALS→NOT_EQUALS, and import.
- **SDK pin of an unreleased commit:** `go.mod` uses `v1.9.4-0.20260824133534-79f38d837aea`. Merge the SDK PR first, or keep the pseudo-version until a tagged SDK release.

## Changes
| File | Change |
| --- | --- |
| `internal/provider/alerts/alert_types/common.go` | Map Terraform `EQUALS` / `NOT_EQUALS` for logs and metric threshold conditions |
| `internal/provider/resource_coralogix_alert_test.go` | Acc tests `TestAccCoralogixResourceAlert_logs_equals` and `TestAccCoralogixResourceAlert_metric_equals` |
| `go.mod` / `go.sum` | Pin `coralogix-management-sdk` `79f38d837aea` |
| `CHANGELOG.md` | Unreleased FEAT for `resource/coralogix_alert` |
| `docs/resources/alert.md`, `docs/data-sources/alert.md` | Regenerated enum docs |

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ TF_ACC=1 CORALOGIX_ENV=EU2 go test ./internal/provider/... -run 'TestAccCoralogixResourceAlert_logs_equals|TestAccCoralogixResourceAlert_metric_equals' -v -timeout 30m

--- PASS: TestAccCoralogixResourceAlert_logs_equals
--- PASS: TestAccCoralogixResourceAlert_metric_equals
```

Both tests create with `EQUALS`, update to `NOT_EQUALS`, and import.

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
resource/coralogix_alert: Add EQUALS and NOT_EQUALS condition types for logs and metric threshold alerts.
```

### References
- [CX-54815](https://coralogix.atlassian.net/browse/CX-54815)
- Depends on SDK commit `79f38d837aea` (equals/not-equals aliases + generated enums)

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment


Made with [Cursor](https://cursor.com)

[CX-54815]: https://coralogix.atlassian.net/browse/CX-54815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-54815]: https://coralogix.atlassian.net/browse/CX-54815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ