### PR TITLE
fix: deactivate shared archive targets during destroy

### DIFF
--- a/internal/provider/logs/resource_coralogix_archive_logs.go
+++ b/internal/provider/logs/resource_coralogix_archive_logs.go
@@ -17,7 +17,6 @@ package logs
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
@@ -262,6 +261,26 @@ func (r *ArchiveLogsResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 func (r *ArchiveLogsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// This API doesn't support deletion :(
-	log.Printf("[INFO] coralogix_archive_logs cannot be deleted")
+	var state *ArchiveLogsResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteRequest := extractArchiveLogs(ArchiveLogsResourceModel{
+		Active: types.BoolValue(false),
+		Bucket: state.Bucket,
+		Region: state.Region,
+	})
+	_, httpResponse, err := r.client.
+		S3TargetServiceSetTarget(ctx).
+		SetTargetResponse(deleteRequest).
+		Execute()
+	if err != nil && !cxsdkOpenapi.IsNotFound(cxsdkOpenapi.NewAPIError(httpResponse, err)) {
+		resp.Diagnostics.AddError(
+			"Error deactivating coralogix_archive_logs",
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Delete", deleteRequest),
+		)
+	}
 }

--- a/internal/provider/metrics/resource_coralogix_archive_metrics.go
+++ b/internal/provider/metrics/resource_coralogix_archive_metrics.go
@@ -314,7 +314,15 @@ func (r *ArchiveMetricsResource) Update(ctx context.Context, req resource.Update
 }
 
 func (r *ArchiveMetricsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-
+	_, httpResponse, err := r.client.
+		MetricsConfiguratorPublicServiceDisableArchive(ctx).
+		Execute()
+	if err != nil && !cxsdkOpenapi.IsNotFound(cxsdkOpenapi.NewAPIError(httpResponse, err)) {
+		resp.Diagnostics.AddError(
+			"Error deactivating coralogix_archive_metrics",
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Delete", nil),
+		)
+	}
 }
 
 func flattenArchiveMetrics(ctx context.Context, metricConfig *ams.TenantConfigV2, id string) (*ArchiveMetricsResourceModel, diag.Diagnostics) {

--- a/internal/provider/resource_coralogix_archive_logs_test.go
+++ b/internal/provider/resource_coralogix_archive_logs_test.go
@@ -15,9 +15,13 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var (
@@ -28,6 +32,7 @@ func TestAccCoralogixResourceResourceArchiveLogs(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckArchiveLogsDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCoralogixResourceArchiveLogs(),
@@ -50,6 +55,31 @@ func TestAccCoralogixResourceResourceArchiveLogs(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckArchiveLogsDestroy(_ *terraform.State) error {
+	clientSet, err := testAccNewClientSet()
+	if err != nil {
+		return err
+	}
+
+	result, httpResponse, err := clientSet.
+		ArchiveLogs().
+		S3TargetServiceGetTarget(context.Background()).
+		Execute()
+	if err != nil {
+		apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+		if cxsdkOpenapi.IsNotFound(apiErr) {
+			return nil
+		}
+		return fmt.Errorf("error reading archive logs target after destroy: %w", apiErr)
+	}
+
+	archiveSpec := result.Target.GetArchiveSpec()
+	if archiveSpec.GetIsActive() {
+		return fmt.Errorf("archive logs target is still active after destroy")
+	}
+	return nil
 }
 
 func testAccCoralogixResourceArchiveLogs() string {

--- a/internal/provider/resource_coralogix_archive_metrics_test.go
+++ b/internal/provider/resource_coralogix_archive_metrics_test.go
@@ -15,11 +15,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var (
@@ -34,6 +37,7 @@ func TestAccCoralogixResourceResourceArchiveMetrics(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckArchiveMetricsDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCoralogixResourceArchiveMetrics(),
@@ -49,6 +53,30 @@ func TestAccCoralogixResourceResourceArchiveMetrics(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckArchiveMetricsDestroy(_ *terraform.State) error {
+	clientSet, err := testAccNewClientSet()
+	if err != nil {
+		return err
+	}
+
+	result, httpResponse, err := clientSet.
+		ArchiveMetrics().
+		MetricsConfiguratorPublicServiceGetTenantConfig(context.Background()).
+		Execute()
+	if err != nil {
+		apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+		if cxsdkOpenapi.IsNotFound(apiErr) {
+			return nil
+		}
+		return fmt.Errorf("error reading archive metrics configuration after destroy: %w", apiErr)
+	}
+
+	if result.TenantConfig != nil && !result.TenantConfig.GetDisabled() {
+		return fmt.Errorf("archive metrics target is still active after destroy")
+	}
+	return nil
 }
 
 func testAccCoralogixResourceArchiveMetrics() string {


### PR DESCRIPTION
## Summary

- Deactivate the shared archive logs target during Terraform destroy.
- Disable the shared archive metrics target during Terraform destroy.
- Verify both remote targets are inactive after acceptance test cleanup.

## Testing

- `go test ./internal/provider -run 'TestAccCoralogixResourceResourceArchive(Logs|Metrics)$' -count=1`\n- Repository commit hooks passed.