### PR TITLE
test: reset up shared archive targets

### DIFF
--- a/internal/provider/resource_coralogix_archive_logs_test.go
+++ b/internal/provider/resource_coralogix_archive_logs_test.go
@@ -15,9 +15,15 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	archiveLogs "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/target_service"
+	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var (
@@ -26,8 +32,9 @@ var (
 
 func TestAccCoralogixResourceResourceArchiveLogs(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccArchivePreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckArchiveLogsDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCoralogixResourceArchiveLogs(),
@@ -66,4 +73,121 @@ func testAccCoralogixResourceArchiveLogsUpdate() string {
  		active = false
 }
 `
+}
+
+func testAccArchivePreCheck(t *testing.T) {
+	testAccPreCheck(t)
+	if err := testAccCleanupArchiveTargets(); err != nil {
+		t.Fatalf("error cleaning archive targets before test: %s", err)
+	}
+}
+
+func testAccCleanupArchiveTargets() error {
+	clientSet, err := testAccNewClientSet()
+	if err != nil {
+		return err
+	}
+
+	if err := testAccDisableArchiveMetrics(clientSet); err != nil {
+		return err
+	}
+	return testAccDisableArchiveLogs(clientSet)
+}
+
+func testAccDisableArchiveMetrics(clientSet *clientset.ClientSet) error {
+	_, httpResponse, err := clientSet.
+		ArchiveMetrics().
+		MetricsConfiguratorPublicServiceDisableArchive(context.Background()).
+		Execute()
+	if err != nil && !cxsdkOpenapi.IsNotFound(cxsdkOpenapi.NewAPIError(httpResponse, err)) {
+		return fmt.Errorf("error deactivating archive metrics configuration: %w", cxsdkOpenapi.NewAPIError(httpResponse, err))
+	}
+	return nil
+}
+
+func testAccDisableArchiveLogs(clientSet *clientset.ClientSet) error {
+	result, httpResponse, err := clientSet.
+		ArchiveLogs().
+		S3TargetServiceGetTarget(context.Background()).
+		Execute()
+	if err != nil {
+		apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+		if cxsdkOpenapi.IsNotFound(apiErr) {
+			return nil
+		}
+		return fmt.Errorf("error reading archive logs target: %w", apiErr)
+	}
+
+	s3Target, ok := result.Target.GetS3Ok()
+	if !ok {
+		return fmt.Errorf("archive logs target is not an S3 target")
+	}
+
+	_, httpResponse, err = clientSet.
+		ArchiveLogs().
+		S3TargetServiceSetTarget(context.Background()).
+		SetTargetResponse(archiveLogs.SetTargetResponse{
+			IsActive: false,
+			S3:       *s3Target,
+		}).
+		Execute()
+	if err != nil && !cxsdkOpenapi.IsNotFound(cxsdkOpenapi.NewAPIError(httpResponse, err)) {
+		return fmt.Errorf("error deactivating archive logs target: %w", cxsdkOpenapi.NewAPIError(httpResponse, err))
+	}
+	return nil
+}
+
+func testAccCheckArchiveLogsDestroy(_ *terraform.State) error {
+	clientSet, err := testAccNewClientSet()
+	if err != nil {
+		return err
+	}
+	if err := testAccDisableArchiveLogs(clientSet); err != nil {
+		return fmt.Errorf("error deactivating archive logs target after destroy: %w", err)
+	}
+
+	result, httpResponse, err := clientSet.
+		ArchiveLogs().
+		S3TargetServiceGetTarget(context.Background()).
+		Execute()
+	if err != nil {
+		apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+		if cxsdkOpenapi.IsNotFound(apiErr) {
+			return nil
+		}
+		return fmt.Errorf("error reading archive logs target after destroy: %w", apiErr)
+	}
+
+	archiveSpec := result.Target.GetArchiveSpec()
+	if archiveSpec.GetIsActive() {
+		return fmt.Errorf("archive logs target is still active after destroy")
+	}
+	return nil
+}
+
+func testAccCheckArchiveMetricsDestroy(_ *terraform.State) error {
+	clientSet, err := testAccNewClientSet()
+	if err != nil {
+		return err
+	}
+	if err := testAccDisableArchiveMetrics(clientSet); err != nil {
+		return fmt.Errorf("error deactivating archive metrics configuration after destroy: %w", err)
+	}
+
+	result, httpResponse, err := clientSet.
+		ArchiveMetrics().
+		MetricsConfiguratorPublicServiceGetTenantConfig(context.Background()).
+		Execute()
+	if err != nil {
+		apiErr := cxsdkOpenapi.NewAPIError(httpResponse, err)
+		if cxsdkOpenapi.IsNotFound(apiErr) {
+			return nil
+		}
+		return fmt.Errorf("error reading archive metrics configuration after destroy: %w", apiErr)
+	}
+
+	if result.TenantConfig != nil && !result.TenantConfig.GetDisabled() {
+		return fmt.Errorf("archive metrics target is still active after destroy")
+	}
+	return nil
 }

--- a/internal/provider/resource_coralogix_archive_metrics_test.go
+++ b/internal/provider/resource_coralogix_archive_metrics_test.go
@@ -32,8 +32,9 @@ func TestAccCoralogixResourceResourceArchiveMetrics(t *testing.T) {
 		t.Skip("ARCHIVE_BUCKET must be set for this acceptance test")
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccArchivePreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckArchiveMetricsDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCoralogixResourceArchiveMetrics(),


### PR DESCRIPTION
## Summary

- Reset shared archive targets before archive acceptance tests.
- Clean up and verify both targets after the tests.
- Keep cleanup in test code only.

## Why this helps

The archive configuration is shared by the tenant. A previous test can leave it active. The next test can then fail because the same bucket is already assigned to another archive type.

The cleanup disables archive metrics and archive logs before each test. It also disables the archive target after each test and verifies that it is inactive.

## Limitation

Concurrent tests can still interfere with each other if they use the same tenant at the same time.

## Testing

- Focused archive acceptance tests compile locally.
- Live account tests were not run locally.