### PR TITLE
fix(dashboards): allow a widget title with a markdown definition (CX-55498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - FEAT: `dynamic.query_definitions[*].id` is now settable instead of read-only. It is still generated when omitted. Setting it explicitly is what makes `time_series_lines_multi.query_display_settings[*].query_id` usable at all: that attribute requires the id of the query it styles, which previously could be neither chosen nor known when the configuration was written.
 - FIX: `data.coralogix_dashboard` no longer fails to return a dashboard whose widgets use an attribute with a custom value type. Deriving the data-source schema from the resource's dropped `CustomType` for numeric attributes, so the data source declared a plain type while reads produced the custom one. Affects any resource whose data source derives its schema this way.
 - DOC: Note that time-series visualizations need `promql_query_type = "range"`. An instant query returns a single point, so the chart renders empty while the configuration looks correct.
+- FIX: A widget can now set a `title` together with a `markdown` definition. The Coralogix UI always gives a markdown widget a title, so a dashboard exported from the UI failed to validate.
 
 #### resource/coralogix_connector
 - FEAT: Add support for the `eventbridge` connector type.

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -659,7 +659,7 @@ Read-Only:
 - `description` (String) Widget description.
 - `id` (String)
 - `reference` (Attributes) Reference to a widget on another dashboard. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--reference))
-- `title` (String) Widget title. Required for all inline widgets except markdown.
+- `title` (String) Widget title. Required for all inline widgets except markdown, where it is optional.
 - `width` (Number) Deprecated: the widget appearance.width field is ignored by the API and has no effect.
 
 <a id="nestedatt--layout--sections--rows--widgets--definition"></a>

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -1936,7 +1936,7 @@ Optional:
 - `description` (String) Widget description.
 - `id` (String)
 - `reference` (Attributes) Reference to a widget on another dashboard. Exactly one of `definition` or `reference` must be set. (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--reference))
-- `title` (String) Widget title. Required for all inline widgets except markdown.
+- `title` (String) Widget title. Required for all inline widgets except markdown, where it is optional.
 - `width` (Number, Deprecated) Deprecated: the widget appearance.width field is ignored by the API and has no effect.
 
 <a id="nestedatt--layout--sections--rows--widgets--definition"></a>

--- a/internal/provider/dashboards/dashboard_oneof_validation_test.go
+++ b/internal/provider/dashboards/dashboard_oneof_validation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -155,7 +156,15 @@ func dashboardObjectConfigNull(ctx context.Context, t *testing.T, objectType att
 
 func dashboardValidateObject(t *testing.T, ctx context.Context, cfg types.Object, at path.Path, validators []validator.Object) []diagDetail {
 	t.Helper()
-	req := validator.ObjectRequest{ConfigValue: cfg, Path: at}
+	return dashboardValidateObjectRequest(t, ctx, validator.ObjectRequest{ConfigValue: cfg, Path: at}, validators)
+}
+
+// dashboardValidateObjectRequest runs validators against a fully-formed
+// request. Cross-attribute validators (ConflictsWith, AlsoRequires) read
+// req.Config and req.PathExpression, so they need more than the ConfigValue
+// that dashboardValidateObject fills in.
+func dashboardValidateObjectRequest(t *testing.T, ctx context.Context, req validator.ObjectRequest, validators []validator.Object) []diagDetail {
+	t.Helper()
 	resp := &validator.ObjectResponse{}
 	for _, v := range validators {
 		v.ValidateObject(ctx, req, resp)
@@ -195,15 +204,39 @@ func dashboardMustType[T any](t *testing.T, v any, what string) T {
 // source.manual.strategy.range) without repeating the same
 // build-a-map/range/if-else shape at each level.
 func dashboardChildValue(objType tftypes.Object, setName string, value tftypes.Value) tftypes.Value {
+	return dashboardRawObject(objType, map[string]tftypes.Value{setName: value})
+}
+
+// dashboardRawObject builds a tftypes.Value for objType with every name in
+// set populated to its given value and every other attribute null. It is the
+// multi-attribute generalization of dashboardChildValue, needed when one
+// object carries two populated attributes (a widget with both "title" and
+// "definition", say).
+func dashboardRawObject(objType tftypes.Object, set map[string]tftypes.Value) tftypes.Value {
 	raw := make(map[string]tftypes.Value, len(objType.AttributeTypes))
 	for name, childType := range objType.AttributeTypes {
-		if name == setName {
+		if value, ok := set[name]; ok {
 			raw[name] = value
 		} else {
 			raw[name] = tftypes.NewValue(childType, nil)
 		}
 	}
 	return tftypes.NewValue(objType, raw)
+}
+
+// dashboardSingleElementList wraps elem in a one-element list, the shape every
+// ListNestedAttribute level of the layout tree takes.
+func dashboardSingleElementList(elem tftypes.Value) tftypes.Value {
+	return tftypes.NewValue(tftypes.List{ElementType: elem.Type()}, []tftypes.Value{elem})
+}
+
+// dashboardListElementObject returns the object type of a
+// ListNestedAttribute's element, failing the test if attrType is not a list
+// of objects.
+func dashboardListElementObject(t *testing.T, attrType tftypes.Type, what string) tftypes.Object {
+	t.Helper()
+	list := dashboardMustType[tftypes.List](t, attrType, what)
+	return dashboardMustType[tftypes.Object](t, list.ElementType, what+" element")
 }
 
 // dashboardRequireDetailNames fails the test unless detail names every one
@@ -507,4 +540,82 @@ func attrTypesOf(t *testing.T, attrs map[string]schema.Attribute) map[string]att
 		out[name] = attribute.GetType()
 	}
 	return out
+}
+
+// TestDashboardMarkdownWidgetAllowsTitle guards a widget's right to carry both
+// a "title" and a "markdown" definition. The markdown branch used
+// to hold objectvalidator.ConflictsWith(title), which made every
+// UI-authored markdown widget (the UI always sets a title) impossible to
+// express in Terraform. Unlike the oneof tests above, a cross-attribute
+// validator reads the whole config, so this builds a real tfsdk.Config down
+// the layout tree and runs the markdown attribute's own validators against it.
+func TestDashboardMarkdownWidgetAllowsTitle(t *testing.T) {
+	ctx := context.Background()
+	root := dashboardschema.V4()
+
+	markdown := dashboardMustType[schema.SingleNestedAttribute](t,
+		dashboardResolveAttribute(t, root.Attributes, "layout", "sections", "rows", "widgets", "definition", "markdown"),
+		"widget definition.markdown")
+
+	rootType := dashboardMustType[tftypes.Object](t, root.Type().TerraformType(ctx), "dashboard schema type")
+	layoutType := dashboardMustType[tftypes.Object](t, rootType.AttributeTypes["layout"], "layout type")
+	sectionType := dashboardListElementObject(t, layoutType.AttributeTypes["sections"], "sections type")
+	rowType := dashboardListElementObject(t, sectionType.AttributeTypes["rows"], "rows type")
+	widgetType := dashboardListElementObject(t, rowType.AttributeTypes["widgets"], "widgets type")
+	definitionType := dashboardMustType[tftypes.Object](t, widgetType.AttributeTypes["definition"], "definition type")
+	markdownType := dashboardMustType[tftypes.Object](t, definitionType.AttributeTypes["markdown"], "markdown type")
+
+	markdownValue := dashboardRawObject(markdownType, map[string]tftypes.Value{
+		"markdown_text": tftypes.NewValue(tftypes.String, "## release notes"),
+	})
+	markdownPath := path.Root("layout").AtName("sections").AtListIndex(0).
+		AtName("rows").AtListIndex(0).
+		AtName("widgets").AtListIndex(0).
+		AtName("definition").AtName("markdown")
+	markdownExpression := path.MatchRoot("layout").AtName("sections").AtListIndex(0).
+		AtName("rows").AtListIndex(0).
+		AtName("widgets").AtListIndex(0).
+		AtName("definition").AtName("markdown")
+
+	// configWithTitle builds a whole-dashboard config holding a single
+	// markdown widget whose title is the given raw value.
+	configWithTitle := func(title tftypes.Value) tfsdk.Config {
+		widget := dashboardRawObject(widgetType, map[string]tftypes.Value{
+			"title":      title,
+			"definition": dashboardRawObject(definitionType, map[string]tftypes.Value{"markdown": markdownValue}),
+		})
+		row := dashboardRawObject(rowType, map[string]tftypes.Value{"widgets": dashboardSingleElementList(widget)})
+		section := dashboardRawObject(sectionType, map[string]tftypes.Value{"rows": dashboardSingleElementList(row)})
+		layout := dashboardRawObject(layoutType, map[string]tftypes.Value{"sections": dashboardSingleElementList(section)})
+		return tfsdk.Config{
+			Schema: root,
+			Raw:    dashboardRawObject(rootType, map[string]tftypes.Value{"layout": layout}),
+		}
+	}
+
+	configValue, err := markdown.GetType().ValueFromTerraform(ctx, markdownValue)
+	if err != nil {
+		t.Fatalf("build markdown config value: %s", err)
+	}
+	markdownObject := dashboardMustType[types.Object](t, configValue, "markdown config value")
+
+	for _, testCase := range []struct {
+		name  string
+		title tftypes.Value
+	}{
+		{name: "title_set", title: tftypes.NewValue(tftypes.String, "Release notes")},
+		{name: "title_omitted", title: tftypes.NewValue(tftypes.String, nil)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			diagnostics := dashboardValidateObjectRequest(t, ctx, validator.ObjectRequest{
+				Config:         configWithTitle(testCase.title),
+				ConfigValue:    markdownObject,
+				Path:           markdownPath,
+				PathExpression: markdownExpression,
+			}, markdown.Validators)
+			if len(diagnostics) != 0 {
+				t.Fatalf("expected no diagnostics for a markdown widget with title %v, got: %v", testCase.title, diagnostics)
+			}
+		})
+	}
 }

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -109,7 +109,7 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 													},
 													"title": schema.StringAttribute{
 														Optional:            true,
-														MarkdownDescription: "Widget title. Required for all inline widgets except markdown.",
+														MarkdownDescription: "Widget title. Required for all inline widgets except markdown, where it is optional.",
 													},
 													"description": schema.StringAttribute{
 														Optional:            true,
@@ -829,11 +829,6 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																	"tooltip_text": schema.StringAttribute{
 																		Optional: true,
 																	},
-																},
-																Validators: []validator.Object{
-																	objectvalidator.ConflictsWith(
-																		path.MatchRelative().AtParent().AtParent().AtName("title"),
-																	),
 																},
 																Optional: true,
 															},

--- a/internal/provider/resource_coralogix_dashboard_migration_test.go
+++ b/internal/provider/resource_coralogix_dashboard_migration_test.go
@@ -34,6 +34,15 @@ const (
 	dashboardMigrationProviderSource  = "registry.terraform.io/coralogix/coralogix"
 	dashboardMigrationGRPCVersion     = "= 3.6.0"
 	dashboardMigrationSchemaV3Version = "= 2.1.2"
+
+	// The external providers below reject a widget "title" next to a
+	// "markdown" definition, so the shared config generator must leave the
+	// title out. Step 1 is planned and applied by the external provider, and
+	// every later step reuses the same config to assert a no-op upgrade, so
+	// the title cannot appear in any of them. A titled markdown widget is
+	// covered against the local provider by
+	// TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries instead.
+	dashboardMigrationMarkdownTitleUnsupported = ""
 )
 
 type dashboardMigrationIdentity struct {
@@ -218,7 +227,7 @@ func dashboardMigrationExternalProvider(version string) map[string]resource.Exte
 }
 
 func dashboardMigrationV360Config(name, folderName, description, accessPolicy string, includeMarkdown bool, widgets []dashboardStructuredWidgetSpec) string {
-	dashboard := strings.TrimSuffix(dashboardOpenAPIStructuredDashboardConfigForWidgets(name, "logs", includeMarkdown, false, widgets), "}\n")
+	dashboard := strings.TrimSuffix(dashboardOpenAPIStructuredDashboardConfigForWidgets(name, "logs", includeMarkdown, false, dashboardMigrationMarkdownTitleUnsupported, widgets), "}\n")
 	dashboard = strings.Replace(
 		dashboard,
 		`  description = "Exercises every structured dashboard widget query carrier."`,

--- a/internal/provider/resource_coralogix_dashboard_openapi_test.go
+++ b/internal/provider/resource_coralogix_dashboard_openapi_test.go
@@ -17,10 +17,13 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -230,11 +233,11 @@ func dashboardOpenAPIRunStructuredQueryScenario(t *testing.T, queryBranch string
 
 	steps := dashboardOpenAPIStructuredLifecycleSteps(
 		dashboardOpenAPILifecyclePhase{
-			Config: dashboardOpenAPIStructuredDashboardConfigForWidgets(dashboardName, queryBranch, includeMarkdown, false, widgets),
+			Config: dashboardOpenAPIStructuredDashboardConfigForWidgets(dashboardName, queryBranch, includeMarkdown, false, dashboardOpenAPIMarkdownTitle(false), widgets),
 			Check:  checks(false, dashboardIdentity.Capture()),
 		},
 		[]dashboardOpenAPILifecyclePhase{{
-			Config: dashboardOpenAPIStructuredDashboardConfigForWidgets(dashboardName, queryBranch, includeMarkdown, true, widgets),
+			Config: dashboardOpenAPIStructuredDashboardConfigForWidgets(dashboardName, queryBranch, includeMarkdown, true, dashboardOpenAPIMarkdownTitle(true), widgets),
 			Check:  checks(true, dashboardIdentity.AssertUnchanged()),
 		}},
 		resource.TestStep{
@@ -631,11 +634,18 @@ func dashboardOpenAPIStructuredDashboardConfigVariant(name, queryBranch string, 
 		queryBranch,
 		includeMarkdown,
 		updated,
+		dashboardOpenAPIMarkdownTitle(updated),
 		dashboardOpenAPIStructuredWidgetsForBranch(queryBranch),
 	)
 }
 
-func dashboardOpenAPIStructuredDashboardConfigForWidgets(name, queryBranch string, includeMarkdown, updated bool, widgetSpecs []dashboardStructuredWidgetSpec) string {
+// dashboardOpenAPIStructuredDashboardConfigForWidgets builds a dashboard
+// config covering widgetSpecs, optionally followed by a markdown widget titled
+// markdownTitle. An empty markdownTitle omits the title attribute entirely,
+// which configs applied by an older external provider need: a markdown widget
+// could not carry a title before this provider version, so such a provider
+// rejects the pair at plan time. See dashboardMigrationV360Config.
+func dashboardOpenAPIStructuredDashboardConfigForWidgets(name, queryBranch string, includeMarkdown, updated bool, markdownTitle string, widgetSpecs []dashboardStructuredWidgetSpec) string {
 	widgets := ""
 	for index, widget := range widgetSpecs {
 		if index > 0 {
@@ -644,15 +654,18 @@ func dashboardOpenAPIStructuredDashboardConfigForWidgets(name, queryBranch strin
 		widgets += dashboardOpenAPIStructuredWidgetConfig(widget.name, queryBranch, updated)
 	}
 	if includeMarkdown {
+		titleAttribute := ""
+		if markdownTitle != "" {
+			titleAttribute = fmt.Sprintf("\n          title = %q", markdownTitle)
+		}
 		widgets += fmt.Sprintf(`,
-        {
-          title = %q
+        {%s
           definition = {
             markdown = {
               markdown_text = %q
             }
           }
-        }`, dashboardOpenAPIMarkdownTitle(updated), dashboardOpenAPIMarkdownText(updated))
+        }`, titleAttribute, dashboardOpenAPIMarkdownText(updated))
 	}
 
 	return fmt.Sprintf(`
@@ -1098,4 +1111,47 @@ func boolToInt(value bool) int {
 		return 1
 	}
 	return 0
+}
+
+// TestDashboardOpenAPIStructuredConfigMarkdownTitle pins both markdown widget
+// shapes the generator has to produce. The titled shape is what the local
+// provider is tested against; the untitled shape is what
+// dashboardMigrationV360Config needs, because the external providers it pins
+// reject a title next to a markdown definition. Emitting a title there fails
+// TestAccCoralogixResourceDashboardMigrationFromV360 at step 1, in the
+// external provider's plan, which is a slow and confusing way to learn it.
+func TestDashboardOpenAPIStructuredConfigMarkdownTitle(t *testing.T) {
+	widgets := dashboardOpenAPIStructuredWidgetsForBranch("logs")
+
+	for _, testCase := range []struct {
+		name          string
+		markdownTitle string
+		wantMarkdown  string
+	}{
+		{
+			name:          "titled",
+			markdownTitle: dashboardOpenAPIMarkdownTitle(false),
+			wantMarkdown: `        {
+          title = "markdown title"
+          definition = {
+            markdown = {`,
+		},
+		{
+			name:          "untitled_for_external_provider",
+			markdownTitle: dashboardMigrationMarkdownTitleUnsupported,
+			wantMarkdown: `        {
+          definition = {
+            markdown = {`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			config := dashboardOpenAPIStructuredDashboardConfigForWidgets("dashboard", "logs", true, false, testCase.markdownTitle, widgets)
+			if !strings.Contains(config, testCase.wantMarkdown) {
+				t.Fatalf("markdown widget block not found in config:\nwant:\n%s\ngot:\n%s", testCase.wantMarkdown, config)
+			}
+			if _, diagnostics := hclsyntax.ParseConfig([]byte(config), testCase.name+".tf", hcl.InitialPos); diagnostics.HasErrors() {
+				t.Fatalf("generated config is invalid HCL:\n%s", diagnostics.Error())
+			}
+		})
+	}
 }

--- a/internal/provider/resource_coralogix_dashboard_openapi_test.go
+++ b/internal/provider/resource_coralogix_dashboard_openapi_test.go
@@ -317,8 +317,11 @@ func dashboardOpenAPIStructuredQueryStateChecks(queryBranch string, includeMarkd
 	}
 
 	if includeMarkdown {
-		markdownPath := fmt.Sprintf("layout.sections.0.rows.0.widgets.%d.definition.markdown.markdown_text", len(widgets))
-		checks = append(checks, resource.TestCheckResourceAttr(dashboardResourceName, markdownPath, dashboardOpenAPIMarkdownText(updated)))
+		markdownWidgetPath := fmt.Sprintf("layout.sections.0.rows.0.widgets.%d", len(widgets))
+		checks = append(checks,
+			resource.TestCheckResourceAttr(dashboardResourceName, markdownWidgetPath+".definition.markdown.markdown_text", dashboardOpenAPIMarkdownText(updated)),
+			resource.TestCheckResourceAttr(dashboardResourceName, markdownWidgetPath+".title", dashboardOpenAPIMarkdownTitle(updated)),
+		)
 	}
 
 	return checks
@@ -422,15 +425,27 @@ func dashboardOpenAPIAssertStructuredQueryWidgets(dashboard *dashboardservice.Da
 	}
 
 	if includeMarkdown {
-		definition := widgets[len(widgetSpecs)].GetDefinition()
-		if err := dashboardOpenAPIAssertOneOfBranch(&definition, "WidgetDefinition", "markdown", dashboardID, fixture); err != nil {
-			return err
-		}
-		if definition.Markdown == nil || definition.Markdown.GetMarkdownText() != dashboardOpenAPIMarkdownText(updated) {
-			return fmt.Errorf("dashboard fixture %q (dashboard %q): markdown typed field did not round-trip", fixture, dashboardID)
-		}
+		return dashboardOpenAPIAssertMarkdownWidget(&widgets[len(widgetSpecs)], dashboardID, fixture, updated)
 	}
 
+	return nil
+}
+
+// dashboardOpenAPIAssertMarkdownWidget checks that a markdown widget
+// round-trips both its text and its title. The title matters on its own: the
+// provider used to reject a title next to a markdown definition, so a
+// UI-authored markdown widget could not be expressed in Terraform.
+func dashboardOpenAPIAssertMarkdownWidget(widget *dashboardservice.Widget, dashboardID, fixture string, updated bool) error {
+	definition := widget.GetDefinition()
+	if err := dashboardOpenAPIAssertOneOfBranch(&definition, "WidgetDefinition", "markdown", dashboardID, fixture); err != nil {
+		return err
+	}
+	if definition.Markdown == nil || definition.Markdown.GetMarkdownText() != dashboardOpenAPIMarkdownText(updated) {
+		return fmt.Errorf("dashboard fixture %q (dashboard %q): markdown typed field did not round-trip", fixture, dashboardID)
+	}
+	if wantTitle := dashboardOpenAPIMarkdownTitle(updated); widget.GetTitle() != wantTitle {
+		return fmt.Errorf("dashboard fixture %q (dashboard %q): markdown widget title = %q, want %q", fixture, dashboardID, widget.GetTitle(), wantTitle)
+	}
 	return nil
 }
 
@@ -631,12 +646,13 @@ func dashboardOpenAPIStructuredDashboardConfigForWidgets(name, queryBranch strin
 	if includeMarkdown {
 		widgets += fmt.Sprintf(`,
         {
+          title = %q
           definition = {
             markdown = {
               markdown_text = %q
             }
           }
-        }`, dashboardOpenAPIMarkdownText(updated))
+        }`, dashboardOpenAPIMarkdownTitle(updated), dashboardOpenAPIMarkdownText(updated))
 	}
 
 	return fmt.Sprintf(`
@@ -986,6 +1002,16 @@ func dashboardOpenAPIPromQLQuery(updated bool) string {
 		return "vector(2)"
 	}
 	return "vector(1)"
+}
+
+// dashboardOpenAPIMarkdownTitle pairs a widget title with the markdown
+// definition. A titled markdown widget is what the Coralogix UI produces, and
+// the provider used to reject that combination at validate time.
+func dashboardOpenAPIMarkdownTitle(updated bool) string {
+	if updated {
+		return "updated markdown title"
+	}
+	return "markdown title"
 }
 
 func dashboardOpenAPIMarkdownText(updated bool) string {


### PR DESCRIPTION
### Description

## Summary

A dashboard widget can now set a `title` together with a `markdown` definition. The provider rejected that pair at validate time, so no markdown widget authored in the Coralogix UI could be expressed in Terraform.

## Root Cause

A single validator on the `markdown` branch of the widget definition, in `dashboard_schema/v4.go:dashboardSchemaAttributesV4`:

```go
"markdown": schema.SingleNestedAttribute{
    Attributes: map[string]schema.Attribute{ "markdown_text": ..., "tooltip_text": ... },
    Validators: []validator.Object{
        objectvalidator.ConflictsWith(
            path.MatchRelative().AtParent().AtParent().AtName("title"),
        ),
    },
    Optional: true,
},
```

`title` lives on the widget, not on the definition branch, so this made the two mutually exclusive. The Coralogix UI sets a title on every markdown widget, so any dashboard containing one failed `terraform validate`:

```
Error: Invalid Attribute Combination
Attribute "layout.sections[0].rows[0].widgets[0].title" cannot be specified
when "layout.sections[0].rows[0].widgets[0].definition.markdown" is specified
```

Nothing else was involved. `title` is read by `expandWidget` and `flattenWidget`, and neither looks at which definition branch is set, so no conversion code needed to change.

## Why was it introduced

`a057517` (#144, 2023-09-22, "patch - making title optional for markdown-widget"). That commit flipped the widget `title` from `Required` to `Optional` and then added `objectvalidator.AlsoRequires(title)` to five widget branches to preserve the requirement where it still applied. The `markdown` branch received `objectvalidator.ConflictsWith(title)` in the same commit — a validator that forbids a title, where the intent was to permit an omitted one. `AlsoRequires` and `ConflictsWith` are not opposites: the correct expression of "optional here" is no validator at all.

The mistake survived three later moves of the code (`7953421` #358, `fe1b096` #400, and the `v4` schema split) because each one carried the block along verbatim.

## Breaking change?

No.

- Removing a `ConflictsWith` can only widen what validates. Every configuration that passed before still passes.
- `title` is plain `Optional` — no `Computed`, no plan modifier — so an omitted title stays null. Nothing defaults or hydrates it.
- No state shape change, so no schema version bump. All widget types share one widget object type, so a titleless markdown widget already stored `title = null`.
- No `AlsoRequires(title)` was added to `markdown`, so a title remains optional there.

## Test plan

- [x] `TestDashboardMarkdownWidgetAllowsTitle` — offline regression guard. Builds a real `tfsdk.Config` down the layout tree (a cross-attribute validator reads the whole config, not just its own value) and runs the `markdown` attribute's own validators, pulled from `dashboardschema.V4()`. Two cases: `title` set, and `title` omitted for backward compatibility. Verified to be a real guard — restoring the validator makes the `title_set` case fail; removing it passes. Runs in `make test`, no credentials needed.
- [x] `TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/line-and-table` — the markdown widget now carries a title through apply, update, an empty second plan, and import-verify.
- [x] `make test` — full unit suite green.
- [x] Live API probe — a markdown widget with a title is accepted and echoed back; a markdown widget without one comes back with the field absent. Both probe dashboards deleted afterwards.
- [x] The Coralogix UI renders the title on a markdown widget. Needs a human looking at a live dashboard; not automatable here.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries'

=== RUN   TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries
=== PAUSE TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries
=== CONT  TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries
=== RUN   TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/line-and-table
=== PAUSE TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/line-and-table
=== RUN   TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/gauge-and-bars
=== PAUSE TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/gauge-and-bars
=== RUN   TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/horizontal-and-hexagon
=== PAUSE TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/horizontal-and-hexagon
=== CONT  TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/line-and-table
=== CONT  TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/horizontal-and-hexagon
=== CONT  TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/gauge-and-bars
--- PASS: TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries (0.00s)
    --- PASS: TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/horizontal-and-hexagon (14.05s)
    --- PASS: TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/line-and-table (15.13s)
    --- PASS: TestAccCoralogixResourceDashboardOpenAPIWidgetLogsQueries/gauge-and-bars (16.37s)
PASS
ok  	github.com/coralogix/terraform-provider-coralogix/internal/provider	17.145s
```

`line-and-table` is the group that carries the markdown widget (`includeMarkdown` is only true for the logs branch).

### Release Note

```release-note
resource/coralogix_dashboard: A widget can now set a `title` together with a `markdown` definition. The Coralogix UI always gives a markdown widget a title, so a dashboard exported from the UI failed to validate.
```
