### PR TITLE
ci: alert acceptance failures only on nightly runs

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -192,8 +192,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and master push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Only scheduled (nightly) runs alert. Pull request and master push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - test
       - dashboard


### PR DESCRIPTION
## Summary

- Limit acceptance/E2E Slack failure notifications to scheduled nightly runs.
- Keep acceptance/E2E test execution on push and pull request events unchanged.

This is a CI-only change.