### PR TITLE
feat(dashboards): add hash_colors to the line, bar and pie widgets

### DIFF
--- a/.claude/skills/frozen-prior-schema-must-not-share-helpers/SKILL.md
+++ b/.claude/skills/frozen-prior-schema-must-not-share-helpers/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: frozen-prior-schema-must-not-share-helpers
+description: "Use when adding an attribute to a coralogix_dashboard widget schema, to check no prior schema version (dashboard_schema/v1..v3) shares the helper you are editing. Prior schemas decode old state and must stay frozen."
+---
+
+# A frozen prior schema must not share a schema helper
+
+**Trigger:** You are about to widen a schema helper such as `LineChartSchema()`. Before editing,
+check who else calls it:
+
+```bash
+rg "LineChartSchema\(\)" internal/provider/dashboards/dashboard_schema
+```
+
+If a `v1.go`..`v3.go` calls it, your new attribute lands in that prior version too.
+
+**Fix:** Give the prior version its own frozen copy and point it there. Name it for the version
+it serves, keep it in the same package, and say in a comment that it must not be redirected back:
+
+```go
+// v3.go
+"line_chart": dashboardwidgets.LineChartSchemaV3(),   // frozen snapshot, not the shared helper
+```
+
+Guard it with a test that counts the attribute in each schema version, asserting 0 for the frozen
+one and the real count for the current one. Prove the freeze by diffing
+`dashboardschema.V3().Type().TerraformType(ctx).String()` against `master`; it must be identical.
+
+**Why:** Prior schema versions exist only to decode state written by older provider releases.
+Widening one changes how that old state is interpreted. Most prior versions in this repo declare
+widgets inline for exactly this reason — a shared helper is the exception, and it is the one that
+bites. Duplication is correct here: a frozen snapshot is meant to drift from the current schema.

--- a/.claude/skills/frozen-prior-schema-must-not-share-helpers/SKILL.md
+++ b/.claude/skills/frozen-prior-schema-must-not-share-helpers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frozen-prior-schema-must-not-share-helpers
-description: "Use when adding an attribute to a coralogix_dashboard widget schema, to check no prior schema version (dashboard_schema/v1..v3) shares the helper you are editing. Prior schemas decode old state and must stay frozen."
+description: "Use when widening a shared coralogix_dashboard widget schema helper like LineChartSchema(). Checks whether dashboard_schema/v1..v3 also use it; prior schemas must stay frozen."
 ---
 
 # A frozen prior schema must not share a schema helper

--- a/.claude/skills/schema-attribute-needs-matching-attr-type-map/SKILL.md
+++ b/.claude/skills/schema-attribute-needs-matching-attr-type-map/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: schema-attribute-needs-matching-attr-type-map
+description: "Use when adding an attribute to a coralogix_dashboard widget and every apply, read or state upgrade then fails with 'Value Conversion Error' at 'Path: layout'. Points at the hand-maintained attr.Type map that must be widened too."
+---
+
+# A new schema attribute needs a matching attr.Type map entry
+
+**Trigger:** You added an attribute to a widget schema. The build passes, but tests or applies
+fail with `Value Conversion Error` and `Path: layout`, listing two near-identical type dumps.
+
+**Fix:** Widen every hand-written `map[string]attr.Type` that describes the same object, not just
+the schema. For dashboards that is `widgetModelAttr()` in
+`internal/provider/dashboards/resource_coralogix_dashboard.go`:
+
+```go
+"color_scheme": types.StringType,
+"hash_colors":  types.BoolType,   // add next to the neighbours you copied in the schema
+```
+
+Grep both sides before you start; a widget may be described in more than one place:
+
+```bash
+rg '"<new_attribute>"' internal/provider/dashboards        # schema sites
+rg '"<sibling_attribute>": types\.' internal/provider/dashboards   # attr.Type map sites
+```
+
+To find the mismatch fast, diff the two type dumps from the error rather than reading them.
+
+**Why:** `layout` is a `types.List` of widget objects. The framework builds the element type from
+the attr.Type map and the state type from the schema. It rejects any object whose two descriptions
+differ, even by one attribute. Whether the Go model field is a struct pointer or a `types.Object`
+does not matter — what matters is that some ancestor is a list or object described by a hand-written
+map, which is true of every dashboard widget.

--- a/.claude/skills/schema-attribute-needs-matching-attr-type-map/SKILL.md
+++ b/.claude/skills/schema-attribute-needs-matching-attr-type-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: schema-attribute-needs-matching-attr-type-map
-description: "Use when adding an attribute to a coralogix_dashboard widget and every apply, read or state upgrade then fails with 'Value Conversion Error' at 'Path: layout'. Points at the hand-maintained attr.Type map that must be widened too."
+description: "Use when a coralogix_dashboard apply or state upgrade fails with 'Value Conversion Error' at 'Path: layout' after adding a widget attribute. Widen the hand-written attr.Type map too."
 ---
 
 # A new schema attribute needs a matching attr.Type map entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 #### resource/coralogix_dashboard
+- FEAT: Add `hash_colors` to `line_chart` query definitions, `bar_chart`, `horizontal_bar_chart` and `pie_chart`. Each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`. The `dynamic` widget visualizations already had the attribute; they now share one description.
 - FIX: Bound the `dynamic` widget's numeric attributes to what the API documents. `max_bars_per_chart`, `max_slices_per_bar` and a table column `width` require at least 1, and the bar and time-series `decimal_precision` is limited to 0 to 15. A table column width also no longer accepts a negative value.
 - FEAT: Add the `gauge` and `pie_chart` visualizations to the `dynamic` widget, including the gauge's arc display and thresholds and the pie chart's label definition.
 - FIX: Every list the `gauge` and `pie_chart` visualizations expose rejects an explicit empty value at plan time instead of failing the apply with an inconsistent-result error.

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -686,6 +686,7 @@ Read-Only:
 - `colors_by` (String) Which dimension the bar colors follow. Can be one of stack, group_by, aggregation, query, category.
 - `data_mode_type` (String)
 - `group_name_template` (String)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `max_bars_per_chart` (Number)
 - `query` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--bar_chart--query))
 - `scale_type` (String)
@@ -1894,7 +1895,7 @@ Read-Only:
 - `decimal_precision` (Number)
 - `display_on_bar` (Boolean)
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--horizontal_bars--legend))
 - `max_bars_per_chart` (Number)
 - `max_slices_per_bar` (Number)
@@ -1960,7 +1961,7 @@ Read-Only:
 - `decimal_precision` (Number)
 - `display_on_bar` (Boolean)
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--horizontal_bars_multi--legend))
 - `max_bars_per_chart` (Number)
 - `query_field_settings` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--horizontal_bars_multi--query_field_settings))
@@ -2048,7 +2049,7 @@ Read-Only:
 - `custom_unit` (String)
 - `decimal_precision` (Number) How many digits to show after the decimal point. Valid values are 0 to 15.
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `label_definition` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--pie_chart--label_definition))
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--pie_chart--legend))
 - `max_slices_per_chart` (Number) The most slices to draw on the chart. Must be at least 1.
@@ -2610,7 +2611,7 @@ Read-Only:
 - `color_scheme` (String)
 - `custom_unit` (String)
 - `decimal_precision` (Number)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--time_series_bars--legend))
 - `max_slices_per_bar` (Number)
 - `scale_type` (String) The scale type. Valid values are: linear, logarithmic, unspecified.
@@ -2683,7 +2684,7 @@ Read-Only:
 - `connect_nulls` (Boolean)
 - `custom_unit` (String)
 - `decimal_precision` (Number)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--time_series_lines--legend))
 - `scale_type` (String) The scale type. Valid values are: linear, logarithmic, unspecified.
 - `series_count_limit` (Number)
@@ -2780,7 +2781,7 @@ Read-Only:
 - `color_scheme` (String)
 - `custom_unit` (String)
 - `decimal_precision` (Number)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `query_id` (String) The `id` of the query in `query_definitions` these settings style. Set that `id` explicitly, since a generated one is not known when the configuration is written.
 - `scale_type` (String) The scale type. Valid values are: linear, logarithmic, unspecified.
 - `series_count_limit` (Number)
@@ -2842,7 +2843,7 @@ Read-Only:
 - `custom_unit` (String)
 - `decimal_precision` (Number)
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--vertical_bars--legend))
 - `max_bars_per_chart` (Number)
 - `max_slices_per_bar` (Number)
@@ -2907,7 +2908,7 @@ Read-Only:
 - `custom_unit` (String)
 - `decimal_precision` (Number)
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--vertical_bars_multi--legend))
 - `max_bars_per_chart` (Number)
 - `query_field_settings` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--vertical_bars_multi--query_field_settings))
@@ -3788,6 +3789,7 @@ Read-Only:
 - `data_mode_type` (String)
 - `display_on_bar` (Boolean)
 - `group_name_template` (String)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `max_bars_per_chart` (Number)
 - `query` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--horizontal_bar_chart--query))
 - `scale_type` (String)
@@ -4231,6 +4233,7 @@ Read-Only:
 
 - `color_scheme` (String)
 - `data_mode_type` (String)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `id` (String)
 - `is_visible` (Boolean)
 - `name` (String)
@@ -4641,6 +4644,7 @@ Read-Only:
 - `color_scheme` (String) The color scheme. Can be one of classic, severity, cold, negative, green, red, blue.
 - `data_mode_type` (String)
 - `group_name_template` (String)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `label_definition` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--pie_chart--label_definition))
 - `max_slices_per_chart` (Number)
 - `min_slice_percentage` (Number)

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -78,6 +78,7 @@ resource "coralogix_dashboard" "dashboard" {
                         scale_type         = "linear"
                         series_count_limit = 100
                         unit               = "milliseconds"
+                        hash_colors        = true
                         resolution = {
                           interval = "seconds:900"
                         }
@@ -506,6 +507,7 @@ resource "coralogix_dashboard" "dashboard" {
                         }
                       }
                     }
+                    hash_colors = true
                     xaxis = {
                       time = {
                         interval          = "1h0m5s"
@@ -1963,6 +1965,7 @@ Optional:
 - `colors_by` (String) Which dimension the bar colors follow. Can be one of stack, group_by, aggregation, query, category.
 - `data_mode_type` (String)
 - `group_name_template` (String)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `max_bars_per_chart` (Number)
 - `query` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--bar_chart--query))
 - `scale_type` (String)
@@ -3291,7 +3294,7 @@ Optional:
 - `decimal_precision` (Number)
 - `display_on_bar` (Boolean)
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--horizontal_bars--legend))
 - `max_bars_per_chart` (Number)
 - `max_slices_per_bar` (Number)
@@ -3357,7 +3360,7 @@ Optional:
 - `decimal_precision` (Number)
 - `display_on_bar` (Boolean)
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--horizontal_bars_multi--legend))
 - `max_bars_per_chart` (Number)
 - `query_field_settings` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--horizontal_bars_multi--query_field_settings))
@@ -3448,7 +3451,7 @@ Optional:
 - `custom_unit` (String)
 - `decimal_precision` (Number) How many digits to show after the decimal point. Valid values are 0 to 15.
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `label_definition` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--pie_chart--label_definition))
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--pie_chart--legend))
 - `max_slices_per_chart` (Number) The most slices to draw on the chart. Must be at least 1.
@@ -4016,7 +4019,7 @@ Optional:
 - `color_scheme` (String)
 - `custom_unit` (String)
 - `decimal_precision` (Number)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--time_series_bars--legend))
 - `max_slices_per_bar` (Number)
 - `scale_type` (String) The scale type. Valid values are: linear, logarithmic, unspecified.
@@ -4089,7 +4092,7 @@ Optional:
 - `connect_nulls` (Boolean)
 - `custom_unit` (String)
 - `decimal_precision` (Number)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--time_series_lines--legend))
 - `scale_type` (String) The scale type. Valid values are: linear, logarithmic, unspecified.
 - `series_count_limit` (Number)
@@ -4190,7 +4193,7 @@ Optional:
 - `color_scheme` (String)
 - `custom_unit` (String)
 - `decimal_precision` (Number)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `scale_type` (String) The scale type. Valid values are: linear, logarithmic, unspecified.
 - `series_count_limit` (Number)
 - `series_name_template` (String)
@@ -4251,7 +4254,7 @@ Optional:
 - `custom_unit` (String)
 - `decimal_precision` (Number)
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--vertical_bars--legend))
 - `max_bars_per_chart` (Number)
 - `max_slices_per_bar` (Number)
@@ -4316,7 +4319,7 @@ Optional:
 - `custom_unit` (String)
 - `decimal_precision` (Number)
 - `group_name_template` (String)
-- `hash_colors` (Boolean)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `legend` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--vertical_bars_multi--legend))
 - `max_bars_per_chart` (Number)
 - `query_field_settings` (Attributes List) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--dynamic--visualization--vertical_bars_multi--query_field_settings))
@@ -5287,6 +5290,7 @@ Optional:
 - `data_mode_type` (String)
 - `display_on_bar` (Boolean)
 - `group_name_template` (String)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `max_bars_per_chart` (Number)
 - `query` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--horizontal_bar_chart--query))
 - `scale_type` (String)
@@ -5768,6 +5772,7 @@ Optional:
 
 - `color_scheme` (String)
 - `data_mode_type` (String)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `is_visible` (Boolean)
 - `name` (String)
 - `resolution` (Attributes) (see [below for nested schema](#nestedatt--layout--sections--rows--widgets--definition--line_chart--query_definitions--resolution))
@@ -6235,6 +6240,7 @@ Optional:
 - `color_scheme` (String) The color scheme. Can be one of classic, severity, cold, negative, green, red, blue.
 - `data_mode_type` (String)
 - `group_name_template` (String)
+- `hash_colors` (Boolean) When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.
 - `max_slices_per_chart` (Number)
 - `min_slice_percentage` (Number)
 - `show_legend` (Boolean)

--- a/examples/resources/coralogix_dashboard/resource.tf
+++ b/examples/resources/coralogix_dashboard/resource.tf
@@ -63,6 +63,7 @@ resource "coralogix_dashboard" "dashboard" {
                         scale_type         = "linear"
                         series_count_limit = 100
                         unit               = "milliseconds"
+                        hash_colors        = true
                         resolution = {
                           interval = "seconds:900"
                         }
@@ -491,6 +492,7 @@ resource "coralogix_dashboard" "dashboard" {
                         }
                       }
                     }
+                    hash_colors = true
                     xaxis = {
                       time = {
                         interval          = "1h0m5s"

--- a/internal/provider/dashboards/dashboard_schema/v3.go
+++ b/internal/provider/dashboards/dashboard_schema/v3.go
@@ -113,7 +113,7 @@ func dashboardSchemaAttributesV3() map[string]schema.Attribute {
 													"definition": schema.SingleNestedAttribute{
 														Required: true,
 														Attributes: map[string]schema.Attribute{
-															"line_chart": dashboardwidgets.LineChartSchema(),
+															"line_chart": dashboardwidgets.LineChartSchemaV3(),
 															"hexagon":    dashboardwidgets.HexagonSchema(),
 															"data_table": schema.SingleNestedAttribute{
 																Attributes: map[string]schema.Attribute{

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -444,6 +444,7 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																		},
 																		Description: fmt.Sprintf("The color scheme. Can be one of %s.", strings.Join(dashboardwidgets.DashboardValidColorSchemes, ", ")),
 																	},
+																	"hash_colors": dashboardwidgets.HashColorsSchema(),
 																	"data_mode_type": schema.StringAttribute{
 																		Optional: true,
 																		Computed: true,
@@ -629,6 +630,7 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																		},
 																		Description: fmt.Sprintf("The color scheme. Can be one of %s.", strings.Join(dashboardwidgets.DashboardValidColorSchemes, ", ")),
 																	},
+																	"hash_colors": dashboardwidgets.HashColorsSchema(),
 																	"data_mode_type": schema.StringAttribute{
 																		Optional: true,
 																		Computed: true,
@@ -805,6 +807,7 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 																		},
 																		Description: fmt.Sprintf("The color scheme. Can be one of %s.", strings.Join(dashboardwidgets.DashboardValidColorSchemes, ", ")),
 																	},
+																	"hash_colors": dashboardwidgets.HashColorsSchema(),
 																	"data_mode_type": schema.StringAttribute{
 																		Optional: true,
 																		Computed: true,

--- a/internal/provider/dashboards/dashboard_widgets/common.go
+++ b/internal/provider/dashboards/dashboard_widgets/common.go
@@ -589,6 +589,7 @@ type LineChartQueryDefinitionModel struct {
 	Name               types.String         `tfsdk:"name"`
 	IsVisible          types.Bool           `tfsdk:"is_visible"`
 	ColorScheme        types.String         `tfsdk:"color_scheme"`
+	HashColors         types.Bool           `tfsdk:"hash_colors"`
 	Resolution         types.Object         `tfsdk:"resolution"` //LineChartResolutionModel
 	DataModeType       types.String         `tfsdk:"data_mode_type"`
 }
@@ -760,6 +761,7 @@ type PieChartModel struct {
 	GroupNameTemplate  types.String                  `tfsdk:"group_name_template"`
 	Unit               types.String                  `tfsdk:"unit"`
 	ColorScheme        types.String                  `tfsdk:"color_scheme"`
+	HashColors         types.Bool                    `tfsdk:"hash_colors"`
 	DataModeType       types.String                  `tfsdk:"data_mode_type"`
 }
 
@@ -830,6 +832,7 @@ type BarChartModel struct {
 	Unit              types.String                  `tfsdk:"unit"`
 	SortBy            types.String                  `tfsdk:"sort_by"`
 	ColorScheme       types.String                  `tfsdk:"color_scheme"`
+	HashColors        types.Bool                    `tfsdk:"hash_colors"`
 	DataModeType      types.String                  `tfsdk:"data_mode_type"`
 }
 
@@ -918,6 +921,7 @@ type HorizontalBarChartModel struct {
 	YAxisViewBy       types.String                  `tfsdk:"y_axis_view_by"`
 	SortBy            types.String                  `tfsdk:"sort_by"`
 	ColorScheme       types.String                  `tfsdk:"color_scheme"`
+	HashColors        types.Bool                    `tfsdk:"hash_colors"`
 	DataModeType      types.String                  `tfsdk:"data_mode_type"`
 }
 

--- a/internal/provider/dashboards/dashboard_widgets/dynamic_bars.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic_bars.go
@@ -163,10 +163,8 @@ func dynamicVerticalBarsSchema() schema.Attribute {
 			"group_name_template": schema.StringAttribute{
 				Optional: true,
 			},
-			"hash_colors": schema.BoolAttribute{
-				Optional: true,
-			},
-			"legend": LegendSchema(),
+			"hash_colors": HashColorsSchema(),
+			"legend":      LegendSchema(),
 			"max_bars_per_chart": schema.Int64Attribute{
 				Optional: true,
 				Validators: []validator.Int64{
@@ -275,10 +273,8 @@ func dynamicVerticalBarsMultiSchema() schema.Attribute {
 			"group_name_template": schema.StringAttribute{
 				Optional: true,
 			},
-			"hash_colors": schema.BoolAttribute{
-				Optional: true,
-			},
-			"legend": LegendSchema(),
+			"hash_colors": HashColorsSchema(),
+			"legend":      LegendSchema(),
 			"max_bars_per_chart": schema.Int64Attribute{
 				Optional: true,
 				Validators: []validator.Int64{
@@ -352,10 +348,8 @@ func dynamicHorizontalBarsSchema() schema.Attribute {
 			"group_name_template": schema.StringAttribute{
 				Optional: true,
 			},
-			"hash_colors": schema.BoolAttribute{
-				Optional: true,
-			},
-			"legend": LegendSchema(),
+			"hash_colors": HashColorsSchema(),
+			"legend":      LegendSchema(),
 			"max_bars_per_chart": schema.Int64Attribute{
 				Optional: true,
 				Validators: []validator.Int64{
@@ -467,10 +461,8 @@ func dynamicHorizontalBarsMultiSchema() schema.Attribute {
 			"group_name_template": schema.StringAttribute{
 				Optional: true,
 			},
-			"hash_colors": schema.BoolAttribute{
-				Optional: true,
-			},
-			"legend": LegendSchema(),
+			"hash_colors": HashColorsSchema(),
+			"legend":      LegendSchema(),
 			"max_bars_per_chart": schema.Int64Attribute{
 				Optional: true,
 				Validators: []validator.Int64{

--- a/internal/provider/dashboards/dashboard_widgets/dynamic_gauge_pie.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic_gauge_pie.go
@@ -176,9 +176,7 @@ func dynamicPieChartSchema() schema.Attribute {
 			"group_name_template": schema.StringAttribute{
 				Optional: true,
 			},
-			"hash_colors": schema.BoolAttribute{
-				Optional: true,
-			},
+			"hash_colors": HashColorsSchema(),
 			"label_definition": schema.SingleNestedAttribute{
 				Optional: true,
 				Attributes: map[string]schema.Attribute{

--- a/internal/provider/dashboards/dashboard_widgets/dynamic_time_series.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic_time_series.go
@@ -70,10 +70,8 @@ func dynamicTimeSeriesLinesSchema() schema.Attribute {
 					int64validator.Between(0, 15),
 				},
 			},
-			"hash_colors": schema.BoolAttribute{
-				Optional: true,
-			},
-			"legend": LegendSchema(),
+			"hash_colors": HashColorsSchema(),
+			"legend":      LegendSchema(),
 			"scale_type": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
@@ -218,10 +216,8 @@ func dynamicTimeSeriesBarsSchema() schema.Attribute {
 					int64validator.Between(0, 15),
 				},
 			},
-			"hash_colors": schema.BoolAttribute{
-				Optional: true,
-			},
-			"legend": LegendSchema(),
+			"hash_colors": HashColorsSchema(),
+			"legend":      LegendSchema(),
 			"max_slices_per_bar": schema.Int64Attribute{
 				Optional: true,
 				Validators: []validator.Int64{
@@ -675,9 +671,7 @@ func dynamicQueryDisplaySettingsSchema() schema.Attribute {
 						int64validator.Between(0, 15),
 					},
 				},
-				"hash_colors": schema.BoolAttribute{
-					Optional: true,
-				},
+				"hash_colors": HashColorsSchema(),
 				"query_id": schema.StringAttribute{
 					Required:            true,
 					MarkdownDescription: "The `id` of the query in `query_definitions` these settings style. Set that `id` explicitly, since a generated one is not known when the configuration is written.",

--- a/internal/provider/dashboards/dashboard_widgets/hash_colors_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/hash_colors_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_widgets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// hashColorsCases is shared by every hash_colors round-trip test. A null value must reach the
+// API as an absent field, because the provider models hash_colors as a plain Optional bool.
+var hashColorsCases = map[string]types.Bool{
+	"true":  types.BoolValue(true),
+	"false": types.BoolValue(false),
+	"null":  types.BoolNull(),
+}
+
+func TestLineChartQueryDefinitionHashColorsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	for name, hashColors := range hashColorsCases {
+		t.Run(name, func(t *testing.T) {
+			model := &LineChartQueryDefinitionModel{
+				ID: types.StringValue("11111111-1111-1111-1111-111111111111"),
+				Query: &LineChartQueryModel{
+					Metrics: &QueryMetricsModel{
+						PromqlQuery: types.StringValue("http_requests_total"),
+						Filters:     types.ListNull(types.ObjectType{AttrTypes: MetricsFilterModelAttr()}),
+					},
+				},
+				Resolution: types.ObjectNull(lineChartQueryResolutionModelAttr()),
+				HashColors: hashColors,
+			}
+
+			expanded, diags := expandLineChartQueryDefinition(ctx, model)
+			if diags.HasError() {
+				t.Fatalf("expandLineChartQueryDefinition() diagnostics = %v", diags)
+			}
+			assertHashColorsPointer(t, expanded.HashColors, hashColors)
+
+			flattened, diags := flattenLineChartQueryDefinition(ctx, expanded)
+			if diags.HasError() {
+				t.Fatalf("flattenLineChartQueryDefinition() diagnostics = %v", diags)
+			}
+			if !flattened.HashColors.Equal(hashColors) {
+				t.Fatalf("round-tripped hash_colors = %v, want %v", flattened.HashColors, hashColors)
+			}
+		})
+	}
+}
+
+// The attr-type map must list hash_colors, otherwise converting the model into the
+// types.List element type panics with a struct/object mismatch.
+func TestLineChartQueryDefinitionModelAttrCoversHashColors(t *testing.T) {
+	ctx := context.Background()
+	attrTypes := lineChartQueryDefinitionModelAttr()
+
+	if got, ok := attrTypes["hash_colors"]; !ok || !got.Equal(types.BoolType) {
+		t.Fatalf("lineChartQueryDefinitionModelAttr()[\"hash_colors\"] = %v, ok = %t, want types.BoolType", got, ok)
+	}
+
+	model := LineChartQueryDefinitionModel{
+		ID:         types.StringValue("11111111-1111-1111-1111-111111111111"),
+		Resolution: types.ObjectNull(lineChartQueryResolutionModelAttr()),
+		HashColors: types.BoolValue(true),
+	}
+	object, diags := types.ObjectValueFrom(ctx, attrTypes, &model)
+	if diags.HasError() {
+		t.Fatalf("types.ObjectValueFrom() diagnostics = %v", diags)
+	}
+	if _, diags := types.ListValue(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{object}); diags.HasError() {
+		t.Fatalf("types.ListValue() diagnostics = %v", diags)
+	}
+}
+
+func assertHashColorsPointer(t *testing.T, got *bool, want types.Bool) {
+	t.Helper()
+	if want.IsNull() {
+		if got != nil {
+			t.Fatalf("expanded HashColors = %t, want nil so the field is omitted from the request", *got)
+		}
+		return
+	}
+	if got == nil {
+		t.Fatalf("expanded HashColors = nil, want %t", want.ValueBool())
+	}
+	if *got != want.ValueBool() {
+		t.Fatalf("expanded HashColors = %t, want %t", *got, want.ValueBool())
+	}
+}

--- a/internal/provider/dashboards/dashboard_widgets/linechart.go
+++ b/internal/provider/dashboards/dashboard_widgets/linechart.go
@@ -187,6 +187,7 @@ func LineChartSchema() schema.Attribute {
 								stringvalidator.OneOf(DashboardValidColorSchemes...),
 							},
 						},
+						"hash_colors": HashColorsSchema(),
 						"resolution": schema.SingleNestedAttribute{
 							Attributes: map[string]schema.Attribute{
 								"interval": schema.StringAttribute{
@@ -328,6 +329,7 @@ func lineChartQueryDefinitionModelAttr() map[string]attr.Type {
 		"name":                 types.StringType,
 		"is_visible":           types.BoolType,
 		"color_scheme":         types.StringType,
+		"hash_colors":          types.BoolType,
 		"resolution": types.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"interval":          types.StringType,
@@ -420,6 +422,7 @@ func flattenLineChartQueryDefinition(ctx context.Context, definition *dashboards
 		Name:               utils.StringPointerToTypeString(definition.Name),
 		IsVisible:          types.BoolPointerValue(definition.IsVisible),
 		ColorScheme:        utils.StringPointerToTypeString(definition.ColorScheme),
+		HashColors:         types.BoolPointerValue(definition.HashColors),
 		Resolution:         resolution,
 		DataModeType:       types.StringValue(DashboardProtoToSchemaDataModeType[definition.GetDataModeType()]),
 	}, nil
@@ -731,6 +734,7 @@ func expandLineChartQueryDefinition(ctx context.Context, queryDefinition *LineCh
 		Name:               utils.TypeStringToStringPointer(queryDefinition.Name),
 		IsVisible:          queryDefinition.IsVisible.ValueBoolPointer(),
 		ColorScheme:        utils.TypeStringToStringPointer(queryDefinition.ColorScheme),
+		HashColors:         queryDefinition.HashColors.ValueBoolPointer(),
 		Resolution:         resolution,
 		DataModeType:       OptionalEnumPointer(queryDefinition.DataModeType, DashboardSchemaToProtoDataModeType),
 	}, nil

--- a/internal/provider/dashboards/dashboard_widgets/linechart_v3.go
+++ b/internal/provider/dashboards/dashboard_widgets/linechart_v3.go
@@ -1,0 +1,209 @@
+// Copyright 2025 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_widgets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// LineChartSchemaV3 is a frozen copy of the line chart schema as it stood at resource schema
+// version 3. Schema v3 is only ever used to decode prior state, so its shape must not change.
+//
+// Do not add attributes here and do not redirect this to LineChartSchema(). It was split from
+// the shared helper precisely so that widening the current schema cannot alter v3.
+func LineChartSchemaV3() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"legend": LegendSchema(),
+			"tooltip": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"show_labels": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(false),
+					},
+					"type": schema.StringAttribute{
+						Optional: true,
+						Validators: []validator.String{
+							stringvalidator.OneOf(DashboardValidTooltipTypes...),
+						},
+						MarkdownDescription: fmt.Sprintf("The tooltip type. Valid values are: %s.", strings.Join(DashboardValidTooltipTypes, ", ")),
+					},
+				},
+				Optional: true,
+			},
+			"stacked_line": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(DashboardValidLineChartStackedLineOptions...),
+				},
+				Default:             stringdefault.StaticString(utils.UNSPECIFIED),
+				MarkdownDescription: fmt.Sprintf("Option to show lines as stacked. Possible values: %v", strings.Join(DashboardValidLineChartStackedLineOptions, ", ")),
+			},
+			"query_definitions": schema.ListNestedAttribute{
+				Required: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true, PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseNonNullStateForUnknown(),
+							},
+						},
+						"query": schema.SingleNestedAttribute{
+							Attributes: map[string]schema.Attribute{
+								"logs": schema.SingleNestedAttribute{
+									Attributes: map[string]schema.Attribute{
+										"lucene_query": schema.StringAttribute{
+											Optional: true,
+										},
+										"group_by": schema.ListAttribute{
+											ElementType: types.StringType,
+											Optional:    true,
+										},
+										"filters":      LogsFiltersSchema(),
+										"aggregations": LogsAggregationsSchema(),
+										"time_frame":   TimeFrameSchema(),
+									},
+									Optional: true,
+								},
+								"metrics": schema.SingleNestedAttribute{
+									Attributes: map[string]schema.Attribute{
+										"promql_query": schema.StringAttribute{
+											Required: true,
+										},
+										"filters": MetricFiltersSchema(),
+										"promql_query_type": schema.StringAttribute{
+											Optional: true,
+											Computed: true,
+											Default:  stringdefault.StaticString(utils.UNSPECIFIED),
+										},
+										"time_frame": TimeFrameSchema(),
+									},
+									Optional: true,
+								},
+								"spans": schema.SingleNestedAttribute{
+									Attributes: map[string]schema.Attribute{
+										"lucene_query": schema.StringAttribute{
+											Optional: true,
+										},
+										"group_by":     SpansFieldsSchema(),
+										"aggregations": SpansAggregationsSchema(),
+										"filters":      SpansFilterSchema(),
+										"time_frame":   TimeFrameSchema(),
+									},
+									Optional: true,
+								},
+								"data_prime": schema.SingleNestedAttribute{
+									Attributes: map[string]schema.Attribute{
+										"query": schema.StringAttribute{
+											Optional: true,
+										},
+										"filters": schema.ListNestedAttribute{
+											NestedObject: schema.NestedAttributeObject{
+												Attributes: FiltersSourceSchema(),
+												Validators: []validator.Object{
+													ExactlyOneOfChildren("logs", "metrics", "spans"),
+												},
+											},
+											Optional: true,
+										},
+										"time_frame": TimeFrameSchema(),
+									},
+									Optional: true,
+								},
+							},
+							Required: true,
+							Validators: []validator.Object{
+								ExactlyOneOfChildren("logs", "metrics", "spans", "data_prime"),
+							},
+						},
+						"series_name_template": schema.StringAttribute{
+							Optional: true,
+						},
+						"series_count_limit": schema.Int64Attribute{
+							Optional: true,
+						},
+						"unit": UnitSchema(),
+						"scale_type": schema.StringAttribute{
+							Optional: true,
+							Computed: true,
+							Validators: []validator.String{
+								stringvalidator.OneOf(DashboardValidScaleTypes...),
+							},
+							Default:             stringdefault.StaticString(utils.UNSPECIFIED),
+							MarkdownDescription: fmt.Sprintf("The scale type. Valid values are: %s.", strings.Join(DashboardValidScaleTypes, ", ")),
+						},
+						"name": schema.StringAttribute{
+							Optional: true,
+						},
+						"is_visible": schema.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(true),
+						},
+						"color_scheme": schema.StringAttribute{
+							Optional: true,
+							Validators: []validator.String{
+								stringvalidator.OneOf(DashboardValidColorSchemes...),
+							},
+						},
+						"resolution": schema.SingleNestedAttribute{
+							Attributes: map[string]schema.Attribute{
+								"interval": schema.StringAttribute{
+									Optional: true,
+								},
+								"buckets_presented": schema.Int64Attribute{
+									Optional: true,
+								},
+							},
+							Optional: true,
+							Validators: []validator.Object{
+								ExactlyOneOfChildren("interval", "buckets_presented"),
+							},
+						},
+						"data_mode_type": schema.StringAttribute{
+							Optional: true,
+							Computed: true,
+							Validators: []validator.String{
+								stringvalidator.OneOf(DashboardValidDataModeTypes...),
+							},
+							Default: stringdefault.StaticString(utils.UNSPECIFIED),
+						},
+					},
+				},
+			},
+		},
+		Validators: []validator.Object{
+			objectvalidator.AlsoRequires(
+				path.MatchRelative().AtParent().AtParent().AtName("title"),
+			),
+		},
+	}
+}

--- a/internal/provider/dashboards/dashboard_widgets/schema.go
+++ b/internal/provider/dashboards/dashboard_widgets/schema.go
@@ -423,3 +423,10 @@ func ColorsBySchema() schema.StringAttribute {
 		MarkdownDescription: fmt.Sprintf("What colors are derived from. Valid values are: %s.", strings.Join(DashboardValidColorsBy, ", ")),
 	}
 }
+
+func HashColorsSchema() schema.BoolAttribute {
+	return schema.BoolAttribute{
+		Optional:            true,
+		MarkdownDescription: "When true, each series takes a color from a hash of its name, and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.",
+	}
+}

--- a/internal/provider/dashboards/hash_colors_test.go
+++ b/internal/provider/dashboards/hash_colors_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"strings"
+	"testing"
+
+	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+	dashboardschema "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_schema"
+	dashboardwidgets "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_widgets"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// hashColorsCases drives every classic-widget round-trip below. A null value must reach the API
+// as an absent field, because the provider models hash_colors as a plain Optional bool. Nothing
+// may substitute false for "not set", or removing the attribute from HCL would show a diff.
+var hashColorsCases = map[string]types.Bool{
+	"true":  types.BoolValue(true),
+	"false": types.BoolValue(false),
+	"null":  types.BoolNull(),
+}
+
+func TestPieChartHashColorsRoundTrip(t *testing.T) {
+	ctx := t.Context()
+
+	for name, hashColors := range hashColorsCases {
+		t.Run(name, func(t *testing.T) {
+			expanded, diags := expandPieChart(ctx, &dashboardwidgets.PieChartModel{HashColors: hashColors})
+			if diags.HasError() {
+				t.Fatalf("expandPieChart() diagnostics = %v", diags)
+			}
+			assertExpandedHashColors(t, expanded.PieChart.HashColors, hashColors)
+
+			flattened, diags := flattenPieChart(ctx, expanded.PieChart)
+			if diags.HasError() {
+				t.Fatalf("flattenPieChart() diagnostics = %v", diags)
+			}
+			assertFlattenedHashColors(t, flattened.PieChart.HashColors, hashColors)
+		})
+	}
+}
+
+func TestBarChartHashColorsRoundTrip(t *testing.T) {
+	ctx := t.Context()
+
+	for name, hashColors := range hashColorsCases {
+		t.Run(name, func(t *testing.T) {
+			model := &dashboardwidgets.BarChartModel{
+				XAxis:      &dashboardwidgets.BarChartXAxisModel{Value: &dashboardwidgets.BarChartXAxisValueModel{}},
+				HashColors: hashColors,
+			}
+
+			expanded, diags := expandBarChart(ctx, model)
+			if diags.HasError() {
+				t.Fatalf("expandBarChart() diagnostics = %v", diags)
+			}
+			assertExpandedHashColors(t, expanded.BarChart.HashColors, hashColors)
+
+			flattened, diags := flattenBarChart(ctx, expanded.BarChart)
+			if diags.HasError() {
+				t.Fatalf("flattenBarChart() diagnostics = %v", diags)
+			}
+			assertFlattenedHashColors(t, flattened.BarChart.HashColors, hashColors)
+		})
+	}
+}
+
+func TestHorizontalBarChartHashColorsRoundTrip(t *testing.T) {
+	ctx := t.Context()
+
+	for name, hashColors := range hashColorsCases {
+		t.Run(name, func(t *testing.T) {
+			expanded, diags := expandHorizontalBarChart(ctx, &dashboardwidgets.HorizontalBarChartModel{HashColors: hashColors})
+			if diags.HasError() {
+				t.Fatalf("expandHorizontalBarChart() diagnostics = %v", diags)
+			}
+			assertExpandedHashColors(t, expanded.HorizontalBarChart.HashColors, hashColors)
+
+			flattened, diags := flattenHorizontalBarChart(ctx, expanded.HorizontalBarChart)
+			if diags.HasError() {
+				t.Fatalf("flattenHorizontalBarChart() diagnostics = %v", diags)
+			}
+			assertFlattenedHashColors(t, flattened.HorizontalBarChart.HashColors, hashColors)
+		})
+	}
+}
+
+// A dashboard created before hash_colors existed comes back from the API without the field.
+// Reading it must leave the attribute null, not false, or the first plan after an upgrade drifts.
+func TestClassicWidgetHashColorsStaysNullWhenAPIOmitsIt(t *testing.T) {
+	flattened, diags := flattenPieChart(t.Context(), &dashboardservice.WidgetsPieChart{})
+	if diags.HasError() {
+		t.Fatalf("flattenPieChart() diagnostics = %v", diags)
+	}
+	if !flattened.PieChart.HashColors.IsNull() {
+		t.Fatalf("flattened hash_colors = %v, want null when the API omits the field", flattened.PieChart.HashColors)
+	}
+}
+
+func assertExpandedHashColors(t *testing.T, got *bool, want types.Bool) {
+	t.Helper()
+	if want.IsNull() {
+		if got != nil {
+			t.Fatalf("expanded HashColors = %t, want nil so the field is omitted from the request", *got)
+		}
+		return
+	}
+	if got == nil {
+		t.Fatalf("expanded HashColors = nil, want %t", want.ValueBool())
+	}
+	if *got != want.ValueBool() {
+		t.Fatalf("expanded HashColors = %t, want %t", *got, want.ValueBool())
+	}
+}
+
+func assertFlattenedHashColors(t *testing.T, got types.Bool, want types.Bool) {
+	t.Helper()
+	if !got.Equal(want) {
+		t.Fatalf("round-tripped hash_colors = %v, want %v", got, want)
+	}
+}
+
+// Schema v3 exists only to decode prior state, so its shape must stay frozen. v3 originally
+// shared LineChartSchema() with v4, which meant adding hash_colors silently widened it too.
+// v3 now uses the frozen LineChartSchemaV3(). This fails if anyone points it back at the
+// shared helper, or adds hash_colors to the frozen copy.
+func TestSchemaV3DoesNotGainHashColors(t *testing.T) {
+	ctx := t.Context()
+
+	v3 := dashboardschema.V3().Type().TerraformType(ctx).String()
+	if count := strings.Count(v3, "hash_colors"); count != 0 {
+		t.Fatalf("schema v3 declares hash_colors %d times, want 0 — v3 must stay frozen", count)
+	}
+
+	// Guards the other direction: the attribute really is wired on the current schema, so a
+	// zero count above cannot be explained by the whole feature having been dropped.
+	v4 := dashboardschema.V4().Type().TerraformType(ctx).String()
+	if count := strings.Count(v4, "hash_colors"); count != 12 {
+		t.Fatalf("schema v4 declares hash_colors %d times, want 12 (8 dynamic + 4 classic widgets)", count)
+	}
+}

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -2161,6 +2161,7 @@ func expandHorizontalBarChart(ctx context.Context, chart *dashboardwidgets.Horiz
 			YAxisViewBy:       expandYAxisViewBy(chart.YAxisViewBy),
 			SortBy:            dashboardwidgets.OptionalEnumPointer(chart.SortBy, dashboardwidgets.DashboardSchemaToProtoSortBy),
 			ColorScheme:       utils.TypeStringToStringPointer(chart.ColorScheme),
+			HashColors:        chart.HashColors.ValueBoolPointer(),
 			DataModeType:      dashboardwidgets.OptionalEnumPointer(chart.DataModeType, dashboardwidgets.DashboardSchemaToProtoDataModeType),
 		},
 	}, nil
@@ -2200,6 +2201,7 @@ func expandPieChart(ctx context.Context, pieChart *dashboardwidgets.PieChartMode
 			GroupNameTemplate:  utils.TypeStringToStringPointer(pieChart.GroupNameTemplate),
 			Unit:               dashboardwidgets.OptionalEnumPointer(pieChart.Unit, dashboardwidgets.DashboardSchemaToProtoUnit),
 			ColorScheme:        utils.TypeStringToStringPointer(pieChart.ColorScheme),
+			HashColors:         pieChart.HashColors.ValueBoolPointer(),
 			DataModeType:       dashboardwidgets.OptionalEnumPointer(pieChart.DataModeType, dashboardwidgets.DashboardSchemaToProtoDataModeType),
 		},
 	}, nil
@@ -2912,6 +2914,7 @@ func expandBarChart(ctx context.Context, chart *dashboardwidgets.BarChartModel) 
 			Unit:              dashboardwidgets.OptionalEnumPointer(chart.Unit, dashboardwidgets.DashboardSchemaToProtoUnit),
 			SortBy:            dashboardwidgets.OptionalEnumPointer(chart.SortBy, dashboardwidgets.DashboardSchemaToProtoSortBy),
 			ColorScheme:       utils.TypeStringToStringPointer(chart.ColorScheme),
+			HashColors:        chart.HashColors.ValueBoolPointer(),
 			DataModeType:      dashboardwidgets.OptionalEnumPointer(chart.DataModeType, dashboardwidgets.DashboardSchemaToProtoDataModeType),
 		},
 	}, nil
@@ -4222,6 +4225,7 @@ func widgetModelAttr() map[string]attr.Type {
 						"group_name_template": types.StringType,
 						"unit":                types.StringType,
 						"color_scheme":        types.StringType,
+						"hash_colors":         types.BoolType,
 						"data_mode_type":      types.StringType,
 					},
 				},
@@ -4269,6 +4273,7 @@ func widgetModelAttr() map[string]attr.Type {
 						"unit":           types.StringType,
 						"sort_by":        types.StringType,
 						"color_scheme":   types.StringType,
+						"hash_colors":    types.BoolType,
 						"data_mode_type": types.StringType,
 					},
 				},
@@ -4359,6 +4364,7 @@ func widgetModelAttr() map[string]attr.Type {
 						"unit":           types.StringType,
 						"sort_by":        types.StringType,
 						"color_scheme":   types.StringType,
+						"hash_colors":    types.BoolType,
 						"display_on_bar": types.BoolType,
 						"y_axis_view_by": types.StringType,
 						"data_mode_type": types.StringType,
@@ -4992,6 +4998,7 @@ func flattenHorizontalBarChart(ctx context.Context, chart *dashboardservice.Hori
 			YAxisViewBy:       flattenYAxisViewBy(chart.YAxisViewBy),
 			SortBy:            types.StringValue(dashboardwidgets.DashboardProtoToSchemaSortBy[chart.GetSortBy()]),
 			ColorScheme:       utils.StringPointerToTypeString(chart.ColorScheme),
+			HashColors:        types.BoolPointerValue(chart.HashColors),
 			DataModeType:      types.StringValue(dashboardwidgets.DashboardProtoToSchemaDataModeType[chart.GetDataModeType()]),
 		},
 	}, nil
@@ -5414,6 +5421,7 @@ func flattenPieChart(ctx context.Context, pieChart *dashboardservice.WidgetsPieC
 			GroupNameTemplate:  utils.StringPointerToTypeString(pieChart.GroupNameTemplate),
 			Unit:               types.StringValue(dashboardwidgets.DashboardProtoToSchemaUnit[pieChart.GetUnit()]),
 			ColorScheme:        utils.StringPointerToTypeString(pieChart.ColorScheme),
+			HashColors:         types.BoolPointerValue(pieChart.HashColors),
 			DataModeType:       types.StringValue(dashboardwidgets.DashboardProtoToSchemaDataModeType[pieChart.GetDataModeType()]),
 		},
 	}, nil
@@ -5631,6 +5639,7 @@ func flattenBarChart(ctx context.Context, barChart *dashboardservice.BarChart) (
 			Unit:              types.StringValue(dashboardwidgets.DashboardProtoToSchemaUnit[barChart.GetUnit()]),
 			SortBy:            types.StringValue(dashboardwidgets.DashboardProtoToSchemaSortBy[barChart.GetSortBy()]),
 			ColorScheme:       utils.StringPointerToTypeString(barChart.ColorScheme),
+			HashColors:        types.BoolPointerValue(barChart.HashColors),
 			DataModeType:      types.StringValue(dashboardwidgets.DashboardProtoToSchemaDataModeType[barChart.GetDataModeType()]),
 		},
 	}, nil

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -2287,6 +2287,117 @@ resource "coralogix_dashboard" "test" {
 	})
 }
 
+// hash_colors is a plain Optional bool on all four widgets. The last step removes it from the
+// config entirely: if the API echoed hashColors: false for an omitted field, that step would
+// leave a permanent diff and the attribute would need Optional+Computed with a false default.
+func TestAccCoralogixResourceDashboardHashColors(t *testing.T) {
+	name := dashboardOpenAPIFixtureName(t.Name())
+	config := func(hashColors string) string {
+		return fmt.Sprintf(`
+resource "coralogix_dashboard" "test" {
+  name        = %q
+  description = "Testing hash_colors on the classic widgets"
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+
+  layout = {
+    sections = [{
+      rows = [{
+        height = 19
+        widgets = [
+          {
+            title = "line chart"
+            definition = {
+              line_chart = {
+                query_definitions = [{
+                  query = { logs = { aggregations = [{ type = "count" }] } }
+                  %[2]s
+                }]
+              }
+            }
+          },
+          {
+            title = "bar chart"
+            definition = {
+              bar_chart = {
+                query = { logs = { aggregation = { type = "count" } } }
+                %[2]s
+              }
+            }
+          },
+          {
+            title = "horizontal bar chart"
+            definition = {
+              horizontal_bar_chart = {
+                query = { logs = { aggregation = { type = "count" } } }
+                %[2]s
+              }
+            }
+          },
+          {
+            title = "pie chart"
+            definition = {
+              pie_chart = {
+                query            = { logs = { aggregation = { type = "count" } } }
+                label_definition = {}
+                %[2]s
+              }
+            }
+          },
+        ]
+      }]
+    }]
+  }
+}
+`, name, hashColors)
+	}
+
+	widgetPaths := []string{
+		"layout.sections.0.rows.0.widgets.0.definition.line_chart.query_definitions.0.hash_colors",
+		"layout.sections.0.rows.0.widgets.1.definition.bar_chart.hash_colors",
+		"layout.sections.0.rows.0.widgets.2.definition.horizontal_bar_chart.hash_colors",
+		"layout.sections.0.rows.0.widgets.3.definition.pie_chart.hash_colors",
+	}
+	checks := func(value string) resource.TestCheckFunc {
+		funcs := []resource.TestCheckFunc{resource.TestCheckResourceAttrSet(dashboardResourceName, "id")}
+		for _, path := range widgetPaths {
+			funcs = append(funcs, resource.TestCheckResourceAttr(dashboardResourceName, path, value))
+		}
+		return resource.ComposeAggregateTestCheckFunc(funcs...)
+	}
+	checksUnset := func() resource.TestCheckFunc {
+		funcs := []resource.TestCheckFunc{resource.TestCheckResourceAttrSet(dashboardResourceName, "id")}
+		for _, path := range widgetPaths {
+			funcs = append(funcs, resource.TestCheckNoResourceAttr(dashboardResourceName, path))
+		}
+		return resource.ComposeAggregateTestCheckFunc(funcs...)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config("hash_colors = true"),
+				Check:  checks("true"),
+			},
+			{
+				Config: config("hash_colors = false"),
+				Check:  checks("false"),
+			},
+			{
+				Config: config(""),
+				Check:  checksUnset(),
+			},
+			testAccDashboardImportStep(),
+		},
+	})
+}
+
 func TestAccCoralogixResourceDashboardManualAnnotation(t *testing.T) {
 	name := dashboardOpenAPIFixtureName(t.Name())
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
### Description

`hash_colors` was already wired on every `dynamic` visualization, but it was missing on four other widgets. This adds it to all of them:

- `line_chart.query_definitions[*]`
- `bar_chart`
- `horizontal_bar_chart`
- `pie_chart`

When true, each series takes a color from a hash of its name and `color_scheme` is ignored. The Coralogix UI calls this `Legend Color Hashing`.

```hcl
bar_chart = {
  query       = { logs = { aggregation = { type = "count" } } }
  hash_colors = true
}
```

The attribute is a plain `Optional` bool — no `Computed`, no default. Removing it from the configuration clears it and leaves an empty follow-up plan, so the API does not echo `false` for an omitted field.

Two notes for reviewers:

1. **Schema v3 stays frozen.** It previously shared `LineChartSchema()` with v4, so widening the helper would have changed a prior schema used only to decode old state. v3 now uses a frozen `LineChartSchemaV3()` copy. `TestSchemaV3DoesNotGainHashColors` guards this, and the v3 schema type is byte-identical to `master`.
2. **The eight existing `dynamic` sites** now call the shared `HashColorsSchema()` helper. Schema-only change — it gives them a description in the generated docs and keeps the wording consistent. Their model, expand and flatten were already correct.

Adding the attribute also required a matching entry in `widgetModelAttr()`, the hand-maintained `attr.Type` map describing each widget. Without it every apply fails with a `Value Conversion Error` at `Path: layout`.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceDashboardHashColors'

--- PASS: TestAccCoralogixResourceDashboardHashColors (19.68s)
PASS
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider     20.597s
```

The test covers set `true` → set `false` → remove the attribute → import. The removal step is the regression guard: it fails if the API ever starts echoing `false`.

Also verified manually against a live environment, including reading a dashboard whose state was written by released v3.10.1 before the attribute existed. That plan was empty, which is what makes the v3 change safe.