### PR TITLE
test(dashboards): keep the arm drift test under the cyclomatic limit

### DIFF
--- a/internal/provider/dashboards/dashboard_widgets/dynamic_test.go
+++ b/internal/provider/dashboards/dashboard_widgets/dynamic_test.go
@@ -1440,22 +1440,8 @@ func TestExpandDynamicRangeMappingUsesTheSharedMinMaxRules(t *testing.T) {
 // union check, so two visualizations reach conversion and the dispatch keeps the
 // first and discards the rest.
 func TestDynamicVisualizationArmsMatchTheSchema(t *testing.T) {
-	dynamic, ok := DynamicSchema().(schema.SingleNestedAttribute)
-	if !ok {
-		t.Fatalf("expected the dynamic widget schema to be a single nested attribute, got %T", DynamicSchema())
-	}
-	visualization, ok := dynamic.Attributes["visualization"].(schema.SingleNestedAttribute)
-	if !ok {
-		t.Fatalf("expected visualization to be a single nested attribute, got %T", dynamic.Attributes["visualization"])
-	}
-
-	arms := make(map[string]bool)
-	for _, arm := range dynamicVisualizationArms(&DynamicVisualizationModel{}) {
-		if arms[arm.name] {
-			t.Errorf("%q is listed twice in dynamicVisualizationArms", arm.name)
-		}
-		arms[arm.name] = true
-	}
+	visualization := dynamicVisualizationAttribute(t)
+	arms := dynamicArmNames(t)
 
 	for name := range visualization.Attributes {
 		if !arms[name] {
@@ -1469,7 +1455,47 @@ func TestDynamicVisualizationArmsMatchTheSchema(t *testing.T) {
 		}
 	}
 
-	// The validator carries its own copy of the same names.
+	dynamicAssertValidatorGuardsEveryArm(t, visualization, arms)
+
+	// Every arm must report itself selected when, and only when, its field is
+	// set - otherwise the list compiles and still counts nothing.
+	for _, arm := range dynamicVisualizationArms(&DynamicVisualizationModel{Geomap: &DynamicGeomapModel{}}) {
+		if want := arm.name == "geomap"; arm.selected != want {
+			t.Errorf("with only geomap set, %q reported selected=%v", arm.name, arm.selected)
+		}
+	}
+
+	t.Logf("%d visualization arm(s) agree across the model, the schema and the validator", len(arms))
+}
+
+func dynamicVisualizationAttribute(t *testing.T) schema.SingleNestedAttribute {
+	t.Helper()
+	dynamic, ok := DynamicSchema().(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("expected the dynamic widget schema to be a single nested attribute, got %T", DynamicSchema())
+	}
+	visualization, ok := dynamic.Attributes["visualization"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("expected visualization to be a single nested attribute, got %T", dynamic.Attributes["visualization"])
+	}
+	return visualization
+}
+
+func dynamicArmNames(t *testing.T) map[string]bool {
+	t.Helper()
+	arms := make(map[string]bool)
+	for _, arm := range dynamicVisualizationArms(&DynamicVisualizationModel{}) {
+		if arms[arm.name] {
+			t.Errorf("%q is listed twice in dynamicVisualizationArms", arm.name)
+		}
+		arms[arm.name] = true
+	}
+	return arms
+}
+
+// The validator carries its own copy of the same names.
+func dynamicAssertValidatorGuardsEveryArm(t *testing.T, visualization schema.SingleNestedAttribute, arms map[string]bool) {
+	t.Helper()
 	var validated []string
 	for _, candidate := range visualization.Validators {
 		if oneOf, ok := candidate.(ExactlyOneOfChildrenValidator); ok {
@@ -1487,14 +1513,4 @@ func TestDynamicVisualizationArmsMatchTheSchema(t *testing.T) {
 	if len(validated) != len(arms) {
 		t.Errorf("ExactlyOneOfChildren guards %d names but there are %d arms", len(validated), len(arms))
 	}
-
-	// Every arm must report itself selected when, and only when, its field is
-	// set — otherwise the list compiles and still counts nothing.
-	for _, arm := range dynamicVisualizationArms(&DynamicVisualizationModel{Geomap: &DynamicGeomapModel{}}) {
-		if want := arm.name == "geomap"; arm.selected != want {
-			t.Errorf("with only geomap set, %q reported selected=%v", arm.name, arm.selected)
-		}
-	}
-
-	t.Logf("%d visualization arm(s) agree across the model, the schema and the validator", len(arms))
 }


### PR DESCRIPTION
Test-only. One function split into four, no behaviour change.

### Why

`TestDynamicVisualizationArmsMatchTheSchema` is at complexity **17**, over the `-over=15` limit that `.pre-commit-config.yaml` enforces via `go-cyclo`. It blocks anyone committing locally with the hooks installed.

**No CI workflow runs pre-commit**, so nothing failed and it reached master unnoticed. Worth knowing more generally: `gofmt`, `goimports`, `go vet`, `golangci-lint` and `go-cyclo` only run for people who have the hooks set up.

This split already landed once, inside #674. #683 reverted that whole merge to remove the unenforced-limit validators, and took the unrelated cyclo fix with it — my oversight when I opened the revert.

### What changed

The test now delegates to three helpers: the schema lookup, the arm-name collection, and the validator comparison. Same assertions, same order.

### Evidence

Mutating `dynamicVisualizationArms` so `geomap` reads the `Heatmap` field still fails the test, so the split did not weaken the check — that wrong-field case is the one a names-only comparison would miss.

```
gocyclo -over 15 internal/provider/dashboards/dashboard_widgets/   # clean
go test ./internal/...                                            # clean
```

### Not included, on purpose

`TestAnnotationScopeSpecificWidgetsRoundTrip` is at 16 and has been since before this epic. Leaving it alone keeps this diff to the one function I introduced.

Adding `go-cyclo` to CI would stop this recurring, but that is a workflow change with its own blast radius and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)