### PR TITLE
docs: scope the promql_query_type note to the dynamic widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - FIX: A widget can now set a `title` together with a `markdown` definition. The Coralogix UI always gives a markdown widget a title, so a dashboard exported from the UI failed to validate.
 - FIX: Editing `content_json` updates the dashboard in place instead of recreating it, so it keeps its ID and existing links to it keep working.
 - FIX: `data.coralogix_dashboard` no longer fails on a dashboard whose widgets use an attribute with a custom value type. Deriving the data-source schema from the resource's dropped `CustomType` for numeric attributes. Affects any resource whose data source derives its schema this way.
-- DOC: Time-series visualizations need `promql_query_type = "range"`. An instant query returns a single point, so the chart renders empty while the configuration looks correct.
+- DOC: A `dynamic` widget time-series visualization needs `promql_query_type = "range"` on its metrics query. An instant query returns a single point, so the chart renders empty while the configuration looks correct. Note this does not apply to the classic `line_chart`: the API has no such field on its metrics query, so only `unspecified` applies cleanly there and any other value fails the apply with an inconsistent result. That is long-standing rather than new, and is tracked separately.
 
 
 # Release 3.10.1


### PR DESCRIPTION
Changelog only, one bullet. Worth taking before the release, because the note as written sends users into a failing apply.

### The problem

The unreleased changelog says:

> Time-series visualizations need `promql_query_type = "range"`. An instant query returns a single point, so the chart renders empty while the configuration looks correct.

The classic `line_chart` **is** the time-series widget, and it cannot express that value. The SDK's `LineChartMetricsQuery` has no `PromqlQueryType` field — `EditorMode` and `SeriesLimitType`, but not that one. So the provider publishes the attribute, cannot send it, and hardcodes `types.StringValue(utils.UNSPECIFIED)` on read.

The result is that following our own advice fails:

```
Error: Provider produced inconsistent result after apply
  ...query.metrics.promql_query_type: was cty.StringVal("range"),
  but now cty.StringVal("unspecified").
```

I hit this by writing a test fixture that followed the note.

### Scope: is this new?

No. Reproduced on pristine `master` and the attribute plus the hardcoded `unspecified` are both present in **v3.10.1**; the schema entry dates to #432. So the behaviour is long-standing and this release does not make it worse — except that it would publish the misleading note for the first time, which is the only reason to act now.

### Why the note is still right for the dynamic widget

The dynamic widget's metrics query does carry the field, and the provider both sends and reads it, so the advice is accurate there. Eight other metrics queries have it too — bar chart, data table, gauge, hexagon, horizontal bar, pie chart. The line chart is the exception.

### Not included, on purpose

No code change. Fixing the line chart means either removing a published attribute, which is breaking, or rejecting anything but `unspecified`, which is a new validator on an existing attribute. That decision should not ride inside a same-day release, and it needs its own PR.

Also worth noting the changelog already carries `resolve "Inconsistent Result Error" in promql_query_type` from an earlier release, so this attribute has caused trouble before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)