### PR TITLE
release 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Release 3.12.0
+
 #### resource/coralogix_dashboard
 - FIX: An annotation keeps its `color`. The Coralogix UI offers a swatch per colour and the API stores the choice, but the provider had no attribute, so a copy of a red annotation was created as unspecified and the colour was silently lost. Valid values are `default`, `green`, `cyan`, `blue`, `purple`, `magenta`, `red`, `orange` and `yellow`. Omit the attribute for an annotation with no colour chosen: that is what the API returns, and it reads back as no value.
 - FEAT: An annotation takes a `description`. The API stores one, 0 to 4096 characters, and the Coralogix UI offers it next to the annotation name, so a dashboard built in the UI could not be expressed in Terraform.

--- a/internal/clientset/version.go
+++ b/internal/clientset/version.go
@@ -14,4 +14,4 @@
 
 package clientset
 
-const TF_PROVIDER_VERSION = "3.11.0"
+const TF_PROVIDER_VERSION = "3.12.0"


### PR DESCRIPTION
Description
Release 3.12.0


After merge:

git tag v3.12.0 <merge-sha>
git push origin v3.12.0
Trigger the release GitHub Action from master

🤖 Generated with [Claude Code](https://claude.com/claude-code)
