### PR TITLE
fix(webhook): mark credential attributes as sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_webhook
+- FIX: Mark the credential-bearing attributes `pager_duty.service_key`, `jira.api_token` and `custom.headers` as sensitive, so their values are redacted from Terraform plan and apply output. `custom.headers` is marked as a whole because a map cannot mark individual keys, and it is where an `Authorization` header goes. These values are still written to state; keeping a secret out of state needs a write-only attribute, which is tracked separately.
+
 #### provider
 - FIX: A malformed `domain` is now reported as a configuration error instead of becoming a malformed API host. A value such as `" "` used to produce the gRPC target `ng-api-grpc.:443` and fail later as an opaque dial error. The check is structural only — it rejects what cannot be a host at all, and accepts AWS PrivateLink hosts, customer-specific private hosts, and internal names that use underscores or non-ASCII labels — and it covers the `domain` argument and the `CORALOGIX_DOMAIN` environment variable on both halves of the muxed provider.
 - FIX: The `domain` argument's conflict rule named `domain` instead of `env`, so it never emitted anything. Setting `env` and `domain` together was already rejected by `env`'s own rule; both attributes now report the conflict.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 #### resource/coralogix_webhook
-- FIX: Mark the credential-bearing attributes `pager_duty.service_key`, `jira.api_token` and `custom.headers` as sensitive, so their values are redacted from Terraform plan and apply output. `custom.headers` is marked as a whole because a map cannot mark individual keys, and it is where an `Authorization` header goes. These values are still written to state; keeping a secret out of state needs a write-only attribute, which is tracked separately.
+- FIX: Mark the credential-bearing attributes `pager_duty.service_key`, `jira.api_token` and `custom.headers` as sensitive, so their values are redacted from Terraform plan and apply output. `custom.headers` is marked as a whole because a map cannot mark individual keys, and it is where an `Authorization` header goes. Reading a webhook through `data.coralogix_webhook` is not covered: the resource-to-data-source schema conversion drops the flag, which is fixed separately. These values are still written to state; keeping a secret out of state needs a write-only attribute, which is tracked separately.
 
 #### provider
 - FIX: A malformed `domain` is now reported as a configuration error instead of becoming a malformed API host. A value such as `" "` used to produce the gRPC target `ng-api-grpc.:443` and fail later as an opaque dial error. The check is structural only — it rejects what cannot be a host at all, and accepts AWS PrivateLink hosts, customer-specific private hosts, and internal names that use underscores or non-ASCII labels — and it covers the `domain` argument and the `CORALOGIX_DOMAIN` environment variable on both halves of the muxed provider.

--- a/docs/data-sources/webhook.md
+++ b/docs/data-sources/webhook.md
@@ -50,7 +50,7 @@ data "coralogix_webhook" "imported_webhook_by_name" {
 
 Read-Only:
 
-- `headers` (Map of String) Webhook headers. Map of string to string.
+- `headers` (Map of String) Webhook headers. Map of string to string. Marked sensitive because headers commonly carry credentials, such as an `Authorization` value.
 - `method` (String) Webhook method. can be one of: get, post, put
 - `payload` (String) Webhook payload. JSON string.
 - `url` (String) Webhook URL.

--- a/docs/data-sources/webhook.md
+++ b/docs/data-sources/webhook.md
@@ -50,7 +50,7 @@ data "coralogix_webhook" "imported_webhook_by_name" {
 
 Read-Only:
 
-- `headers` (Map of String) Webhook headers. Map of string to string. Marked sensitive because headers commonly carry credentials, such as an `Authorization` value.
+- `headers` (Map of String) Webhook headers. Map of string to string. Headers commonly carry credentials, such as an `Authorization` value.
 - `method` (String) Webhook method. can be one of: get, post, put
 - `payload` (String) Webhook payload. JSON string.
 - `url` (String) Webhook URL.

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -161,7 +161,7 @@ resource "coralogix_alert" "alert_with_webhook" {
 
 Optional:
 
-- `headers` (Map of String) Webhook headers. Map of string to string.
+- `headers` (Map of String, Sensitive) Webhook headers. Map of string to string. Marked sensitive because headers commonly carry credentials, such as an `Authorization` value.
 - `method` (String) Webhook method. can be one of: get, post, put
 - `payload` (String) Webhook payload. JSON string.
 - `url` (String) Webhook URL.
@@ -210,7 +210,7 @@ Required:
 
 Optional:
 
-- `api_token` (String) Jira API token.
+- `api_token` (String, Sensitive) Jira API token.
 - `email` (String) email.
 - `project_key` (String) Jira project key.
 
@@ -244,7 +244,7 @@ Required:
 
 Optional:
 
-- `service_key` (String) PagerDuty service key.
+- `service_key` (String, Sensitive) PagerDuty service key.
 
 
 <a id="nestedatt--sendlog"></a>

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -161,7 +161,7 @@ resource "coralogix_alert" "alert_with_webhook" {
 
 Optional:
 
-- `headers` (Map of String, Sensitive) Webhook headers. Map of string to string. Marked sensitive because headers commonly carry credentials, such as an `Authorization` value.
+- `headers` (Map of String, Sensitive) Webhook headers. Map of string to string. Headers commonly carry credentials, such as an `Authorization` value.
 - `method` (String) Webhook method. can be one of: get, post, put
 - `payload` (String) Webhook payload. JSON string.
 - `url` (String) Webhook URL.

--- a/internal/provider/integrations/resource_coralogix_webhook.go
+++ b/internal/provider/integrations/resource_coralogix_webhook.go
@@ -398,8 +398,9 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					"headers": schema.MapAttribute{
 						Optional:            true,
 						Computed:            true,
+						Sensitive:           true,
 						ElementType:         types.StringType,
-						MarkdownDescription: "Webhook headers. Map of string to string.",
+						MarkdownDescription: "Webhook headers. Map of string to string. Marked sensitive because headers commonly carry credentials, such as an `Authorization` value.",
 					},
 					"payload": schema.StringAttribute{
 						Optional:            true,
@@ -487,6 +488,7 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Attributes: map[string]schema.Attribute{
 					"service_key": schema.StringAttribute{
 						Optional:            true,
+						Sensitive:           true,
 						MarkdownDescription: "PagerDuty service key.",
 					},
 				},
@@ -622,6 +624,7 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Attributes: map[string]schema.Attribute{
 					"api_token": schema.StringAttribute{
 						Optional:            true,
+						Sensitive:           true,
 						MarkdownDescription: "Jira API token.",
 					},
 					"email": schema.StringAttribute{

--- a/internal/provider/integrations/resource_coralogix_webhook.go
+++ b/internal/provider/integrations/resource_coralogix_webhook.go
@@ -400,7 +400,7 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Computed:            true,
 						Sensitive:           true,
 						ElementType:         types.StringType,
-						MarkdownDescription: "Webhook headers. Map of string to string. Marked sensitive because headers commonly carry credentials, such as an `Authorization` value.",
+						MarkdownDescription: "Webhook headers. Map of string to string. Headers commonly carry credentials, such as an `Authorization` value.",
 					},
 					"payload": schema.StringAttribute{
 						Optional:            true,

--- a/internal/provider/integrations/webhook_sensitive_test.go
+++ b/internal/provider/integrations/webhook_sensitive_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// The credential-bearing webhook attributes must stay sensitive so their values
+// are redacted from plan and apply output.
+func TestWebhookCredentialAttributesAreSensitive(t *testing.T) {
+	var r WebhookResource
+	var resp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema: %v", resp.Diagnostics)
+	}
+
+	for _, tc := range []struct{ block, attr string }{
+		{"custom", "headers"},
+		{"pager_duty", "service_key"},
+		{"jira", "api_token"},
+	} {
+		t.Run(tc.block+"."+tc.attr, func(t *testing.T) {
+			nested, ok := resp.Schema.Attributes[tc.block].(schema.SingleNestedAttribute)
+			if !ok {
+				t.Fatalf("%s is not a single nested attribute", tc.block)
+			}
+			attr, ok := nested.Attributes[tc.attr]
+			if !ok {
+				t.Fatalf("%s.%s not found", tc.block, tc.attr)
+			}
+			if !attr.IsSensitive() {
+				t.Errorf("%s.%s must be sensitive", tc.block, tc.attr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Three `coralogix_webhook` attributes hold a secret the user supplies, and none of them were marked sensitive. Terraform printed their values in plan and apply output, and in CI logs.

| Attribute | What it holds |
|---|---|
| `pager_duty.service_key` | PagerDuty integration key |
| `jira.api_token` | Jira API token |
| `custom.headers` | arbitrary headers — where an `Authorization` value goes |

Before this change the resource had **no** sensitive attributes at all.

## Why these three, and why `headers` as a whole

`service_key` and `api_token` are credentials by definition — the proto types them as plain `google.protobuf.StringValue` with no redaction, and the API returns them verbatim, so nothing upstream was protecting them.

`headers` is a `map<string, string>` on the wire. Terraform cannot mark individual map keys, so it is marked whole. That redacts `Content-Type` alongside `Authorization`, which is the cost of the map shape. Marking nothing was worse.

## What this does not do

It does **not** keep secrets out of the state file. The values are still written to state exactly as before; only the terminal output changes. Keeping a secret out of state requires write-only attributes, which are a larger change and tracked separately. Anyone whose concern is a scanner reading the state file is not helped by this PR, and should not read it as a fix for that.

## Deviations worth a reviewer's attention

**Webhook URLs are deliberately excluded.** `slack.url`, `microsoft_teams.url`, `microsoft_teams_workflow.url` and `opsgenie.url` embed a secret token in the URL itself, so a case exists for marking them too. I left them alone: it is a judgement call with a wider blast radius, it makes debugging a misconfigured endpoint harder, and it deserves its own decision rather than being smuggled in here. Happy to add them if reviewers disagree.

**No type changes, so no migration.** `Sensitive` does not alter an attribute's type. The resource stays at `Version: 0` and needs no state upgrader.

**Interaction with the pending `Sensitive`-propagation fix.** The webhook data source derives its schema from this resource via `FrameworkDatasourceSchemaFromFrameworkResourceSchema`. That converter currently drops the `sensitive` flag, which is why the regenerated `docs/data-sources/webhook.md` picks up the new description but not the `Sensitive` marker. Once the converter fix lands, these attributes become sensitive on the data source too and the docs need regenerating again. Nothing here depends on that landing first.

## Evidence

- `TestWebhookCredentialAttributesAreSensitive` (new, unit) asserts all three are sensitive. I ran a negative control: removing `Sensitive` from `service_key` makes it fail with `pager_duty.service_key must be sensitive`, so it is not passing vacuously.
- Verified the flag reaches Terraform core, not just our schema struct, by reading the attribute off the tfprotov6 `GetProviderSchema` response — `Sensitive=true` for all three. That response is what core uses to decide redaction.
- Acceptance-tested apply → read → second plan against a live tenant with a real PagerDuty key and an `Authorization` header. Values round-trip verbatim and the second plan is empty, so nothing about set/unset behaviour changed. That run also confirms the API returns these secrets unredacted, which is why marking them here is the only lever available.
- `go build`, `go vet` and the full unit sweep pass (17 packages, 0 failures). `gofmt` reports only `internal/clientset/rest/client.go`, which is unformatted on master already and untouched here.

## Note on running the webhook acceptance tests locally

These tests pass in CI and do give real coverage — the shard log on this PR shows `TestAccCoralogixResourcePagerDutyWebhook — PASS`. But they cannot be run in isolation:

```
go test -run 'PagerDutyWebhook'                    → panic: interface conversion: interface {} is nil, not *clientset.ClientSet
go test -run '(GeoIpEnrichment|PagerDutyWebhook)'  → ok
```

`testAccCheckWebhookDestroy` reads the API client from `testAccProvider.Meta()`. `testAccProvider` is the shared SDKv2 provider, and its `Meta()` is only populated once a test using the SDKv2 factories has run. Webhook tests use the framework factories, so they rely on some earlier test in the same binary having configured it. CI's broad `-run` patterns always include one; a targeted local run does not.

Fifteen test files share this pattern, so it is pre-existing and not webhook-specific. Not fixed here. It is why the acceptance evidence above comes from a standalone test rather than the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

