### PR TITLE
fix(dashboards): keep a metric annotation's orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### resource/coralogix_dashboard
+- FIX: A metric annotation keeps its `orientation`. The Coralogix UI offers `vertical` and `horizontal` on a metrics-source annotation and the API stores the choice, but the provider had no attribute, so a horizontal annotation read back as vertical and the next apply reset it. Manual and Dataprime annotations already had the attribute. Omit it to accept what the API returns, which is `vertical`.
+
 #### provider
 - FIX: A malformed `domain` is now reported as a configuration error instead of becoming a malformed API host. A value such as `" "` used to produce the gRPC target `ng-api-grpc.:443` and fail later as an opaque dial error. The check is structural only — it rejects what cannot be a host at all, and accepts AWS PrivateLink hosts, customer-specific private hosts, and internal names that use underscores or non-ASCII labels — and it covers the `domain` argument and the `CORALOGIX_DOMAIN` environment variable on both halves of the muxed provider.
 - FIX: The `domain` argument's conflict rule named `domain` instead of `env`, so it never emitted anything. Setting `env` and `domain` together was already rejected by `env`'s own rule; both attributes now report the conflict.

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -383,6 +383,7 @@ Read-Only:
 
 - `labels` (List of String)
 - `message_template` (String)
+- `orientation` (String) Draw the annotation as a `vertical` line marking a moment in time, or a `horizontal` line marking a value. The API returns `vertical` when nothing is chosen.
 - `promql_query` (String)
 - `strategy` (Attributes) (see [below for nested schema](#nestedatt--annotations--source--metrics--strategy))
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -1711,6 +1711,7 @@ Optional:
 
 - `labels` (List of String)
 - `message_template` (String)
+- `orientation` (String) Draw the annotation as a `vertical` line marking a moment in time, or a `horizontal` line marking a value. The API returns `vertical` when nothing is chosen.
 
 <a id="nestedatt--annotations--source--metrics--strategy"></a>
 ### Nested Schema for `annotations.source.metrics.strategy`

--- a/internal/provider/dashboards/dashboard_schema/v4.go
+++ b/internal/provider/dashboards/dashboard_schema/v4.go
@@ -1361,6 +1361,15 @@ func dashboardSchemaAttributesV4() map[string]schema.Attribute {
 						Attributes: map[string]schema.Attribute{
 							"metrics": schema.SingleNestedAttribute{
 								Attributes: map[string]schema.Attribute{
+									"orientation": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+										Default:  stringdefault.StaticString("vertical"),
+										Validators: []validator.String{
+											stringvalidator.OneOf("vertical", "horizontal"),
+										},
+										MarkdownDescription: "Draw the annotation as a `vertical` line marking a moment in time, or a `horizontal` line marking a value. The API returns `vertical` when nothing is chosen.",
+									},
 									"promql_query": schema.StringAttribute{
 										Required: true,
 									},

--- a/internal/provider/dashboards/resource_coralogix_dashboard.go
+++ b/internal/provider/dashboards/resource_coralogix_dashboard.go
@@ -397,6 +397,7 @@ type DashboardAnnotationMetricSourceModel struct {
 	Strategy        types.Object `tfsdk:"strategy"` //DashboardAnnotationMetricStrategyModel
 	MessageTemplate types.String `tfsdk:"message_template"`
 	Labels          types.List   `tfsdk:"labels"` //types.String
+	Orientation     types.String `tfsdk:"orientation"`
 }
 
 type DashboardAnnotationSpansOrLogsSourceModel struct {
@@ -1870,6 +1871,7 @@ func expandMetricSource(ctx context.Context, metric types.Object) (*dashboardser
 		Strategy:        strategy,
 		MessageTemplate: utils.TypeStringToStringPointer(metricObject.MessageTemplate),
 		Labels:          labels,
+		Orientation:     expandManualAnnotationOrientation(metricObject.Orientation).Ptr(),
 	}, nil
 }
 
@@ -4753,6 +4755,7 @@ func manualRangeStrategyModelAttr() map[string]attr.Type {
 
 func annotationsMetricsSourceModelAttr() map[string]attr.Type {
 	return map[string]attr.Type{
+		"orientation":  types.StringType,
 		"promql_query": types.StringType,
 		"strategy": types.ObjectType{
 			AttrTypes: metricStrategyModelAttr(),
@@ -7484,6 +7487,7 @@ func flattenDashboardAnnotationMetricSourceModel(ctx context.Context, metricSour
 		Strategy:        strategy,
 		MessageTemplate: utils.StringPointerToTypeString(metricSource.MessageTemplate),
 		Labels:          utils.StringSliceToTypeStringList(metricSource.GetLabels()),
+		Orientation:     flattenManualAnnotationOrientation(metricSource.GetOrientation()),
 	}
 
 	return types.ObjectValueFrom(ctx, annotationsMetricsSourceModelAttr(), metricSourceObject)

--- a/internal/provider/resource_coralogix_dashboard_test.go
+++ b/internal/provider/resource_coralogix_dashboard_test.go
@@ -3083,6 +3083,108 @@ resource "coralogix_dashboard" "test" {
 	})
 }
 
+func TestAccCoralogixResourceDashboardMetricAnnotationOrientation(t *testing.T) {
+	name := dashboardOpenAPIFixtureName(t.Name())
+	// orientationLine is a whole HCL line so the omitted case is expressible too
+	config := func(orientationLine string) string {
+		return fmt.Sprintf(`
+resource "coralogix_dashboard" "test" {
+  name        = %q
+  description = "Testing metric annotation orientation"
+  time_frame = {
+    relative = {
+      duration = "seconds:900"
+    }
+  }
+
+  annotations = [{
+    name    = "metric marker"
+    enabled = true
+    source = {
+      metrics = {
+        promql_query = "up"
+        %s
+        strategy     = {}
+      }
+    }
+  }]
+
+  layout = {
+    sections = [{
+      rows = [{
+        height = 10
+        widgets = [{
+          title = "placeholder"
+          width = 0
+          definition = {
+            line_chart = {
+              query_definitions = [{
+                query = {
+                  logs = {
+                    aggregations = [{
+                      type = "count"
+                    }]
+                  }
+                }
+              }]
+              legend = {
+                is_visible = false
+              }
+            }
+          }
+        }]
+      }]
+    }]
+  }
+}
+`, name, orientationLine)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDashboardDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config(`orientation = "horizontal"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dashboardResourceName, "annotations.0.source.metrics.orientation", "horizontal"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			testAccDashboardImportStep(),
+			{
+				// changing the orientation must reach the API rather than drift
+				Config: config(`orientation = "vertical"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dashboardResourceName, "annotations.0.source.metrics.orientation", "vertical"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				// omitting it must settle on what the API returns, not diff forever
+				Config: config(""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dashboardResourceName, "annotations.0.source.metrics.orientation", "vertical"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccCoralogixResourceDashboardDataprimeAnnotation(t *testing.T) {
 	name := dashboardOpenAPIFixtureName(t.Name())
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
A metric annotation can be drawn as a vertical line marking a moment in time, or a horizontal line marking a value. The Coralogix UI offers both on a metrics-source annotation, and the API stores the choice — but the provider had no attribute for it.

The result was silent: a dashboard with a horizontal metric annotation read back as vertical, and the next apply reset it in the backend. No error, no warning, no diff to notice. The dashboard simply stopped looking the way it was built.

## Why this was missed

Three of the annotation sources carry an orientation in the API. Two of them already had the attribute:

| Annotation source | API has it | Provider had it |
|---|---|---|
| `manual` | yes | yes |
| `dataprime` | yes | yes |
| `metrics` | yes | **no** |

So this is filling in the one gap in an existing pattern, not adding a new concept.

## How it was found, and why the schema shape is what it is

Found while checking whether the UI writes a *different* annotation field. Creating a metric annotation through the UI and reading it back over the API returned:

```json
"orientation": "ANNOTATION_ORIENTATION_VERTICAL_UNSPECIFIED"
```

That value came back on an annotation where orientation was never touched, which settles the schema shape: **the API always returns a value**, so the attribute has to be `Optional + Computed`. A plain `Optional` would fail the apply with "was null, but now …". The static default of `"vertical"` is safe here precisely because it is not a wrapper field — the enum's zero value *is* vertical, so the default matches what the API returns for an unset value rather than inventing data.

This mirrors `manual` and `dataprime` exactly, including the default and the `OneOf` validator, and reuses their two existing conversion helpers unchanged.

## Scope

Nothing else changes. `Sensitive`-style flags aside, adding an attribute does not alter any other attribute's type, so the resource stays at schema version 4 and needs no state upgrader.

One thing worth a reviewer's eye: `annotationsMetricsSourceModelAttr()` is shared with the state-upgrade path, and adding a key to a shared attribute map can change the type of state already on disk. It is safe here because the upgrader refreshes from the API and re-flattens rather than translating stored values, so every attribute is rebuilt at the current type. The migration tests were run to confirm rather than assumed — see below. The frozen v1–v3 schemas define their own annotation blocks inline, so none of them were touched.

## Evidence

`TestAccCoralogixResourceDashboardMetricAnnotationOrientation` is new, and covers apply → read → second plan, import, an explicit change, and removal:

1. `horizontal` applies and reads back, with an empty follow-up plan
2. import round-trips
3. changing to `vertical` reaches the API instead of drifting
4. omitting the attribute settles on what the API returns rather than diffing forever

**Both directions were verified by breaking them.** A passing test proves nothing until it is known to fail when the code is wrong:

- removing the flatten → `Provider produced inconsistent result after apply`
- removing the expand → same failure
- restoring both → green

The API behaviour was confirmed directly, not inferred from the generated types: writing `ANNOTATION_ORIENTATION_HORIZONTAL` to a metrics annotation over the API was accepted and read back unchanged.

**Confirmed against a dashboard built in the Coralogix UI, not only against one Terraform created.** A metric annotation was set to horizontal in the UI, and the stored value read back as `ANNOTATION_ORIENTATION_HORIZONTAL`; running that real dashboard through this branch's flatten produces `orientation = "horizontal"`. On `master` the same dashboard loses the value. So the shape this fixes is one a stock UI produces, not a synthetic one.

Also run green: the full unit sweep (17 packages), the sibling `ManualAnnotation` and `DataprimeAnnotation` acceptance tests, `OpenAPIAnnotationBranches`, `OneOfTransitions`, the REST hydration tests, the frozen-prior-schema tests, and the registry-backed dashboard state migration tests.

## Not included, on purpose

The other annotation field this investigation started from — `intervalResolution` on a metrics source — is not added here. It exists in the API but has no control anywhere in the annotation panel, and the UI does not write it, so no dashboard is currently losing it. It belongs with the rest of that feature's work rather than in a one-field fix.

The `orientation` attribute is not added to the frozen v1–v3 schemas. They exist only to decode stored state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

