### PR TITLE
feat(dashboards): warn about unknown fields in content_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 #### resource/coralogix_dashboard
+- FEAT: `content_json` now warns about fields the provider does not recognise, naming each one by its JSON path. Such fields were silently discarded, so a misspelled field looked applied but never reached the API. The check mirrors the decoder's own field matching, including its acceptance of both `camelCase` and `snake_case` spellings, so it does not warn about anything the provider actually keeps. It is a warning rather than an error, because a field can also be newer than the Coralogix SDK the provider is built against, which a configuration change cannot fix.
+
+#### resource/coralogix_dashboard
 - FIX: A metric annotation keeps its `orientation`. The Coralogix UI offers `vertical` and `horizontal` on a metrics-source annotation and the API stores the choice, but the provider had no attribute, so a horizontal annotation read back as vertical and the next apply reset it. Manual and Dataprime annotations already had the attribute. Omit it to accept what the API returns, which is `vertical`.
 
 #### provider

--- a/internal/provider/dashboards/dashboard_schema/common.go
+++ b/internal/provider/dashboards/dashboard_schema/common.go
@@ -17,6 +17,7 @@ package dashboard_schema
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	dashboardwidgets "github.com/coralogix/terraform-provider-coralogix/internal/provider/dashboards/dashboard_widgets"
@@ -153,6 +154,23 @@ func (c ContentJsonValidator) ValidateString(_ context.Context, request validato
 	err := dashboardjson.Unmarshal([]byte(request.ConfigValue.ValueString()), &dashboardservice.Dashboard{})
 	if err != nil {
 		response.Diagnostics.Append(diag.NewErrorDiagnostic("content_json validation failed", fmt.Sprintf("json content is not matching layout schema. got an err while unmarshalling - %s", err)))
+		return
+	}
+
+	// Unknown keys are discarded silently, so a misspelled field looks applied
+	// but never reaches the API. Warn rather than fail: a newer backend may
+	// accept keys this provider's pinned models do not know yet.
+	if unknown := unknownContentJSONKeys(request.ConfigValue.ValueString()); len(unknown) > 0 {
+		response.Diagnostics.Append(diag.NewAttributeWarningDiagnostic(
+			request.Path,
+			"Unknown fields in content_json",
+			fmt.Sprintf(
+				"The provider does not recognise these fields and will drop them, so they will have no effect on the dashboard:\n\n  %s\n\n"+
+					"Either a name is misspelled, or the field is newer than the Coralogix SDK this provider is built against. "+
+					"A field copied from an existing dashboard's export is usually the second case, and needs a provider release rather than a configuration change.",
+				strings.Join(unknown, "\n  "),
+			),
+		))
 	}
 }
 

--- a/internal/provider/dashboards/dashboard_schema/content_json_unknown_keys.go
+++ b/internal/provider/dashboards/dashboard_schema/content_json_unknown_keys.go
@@ -1,0 +1,130 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"unicode"
+
+	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+)
+
+// dashboardModelPackage identifies the generated models. The SDK's decoder only
+// descends into those, so anything else is an untyped subtree whose keys are
+// meaningful to the backend and must not be reported.
+var dashboardModelPackage = reflect.TypeOf(dashboardservice.Dashboard{}).PkgPath()
+
+// unknownContentJSONKeys lists the JSON paths the SDK decoder will discard.
+//
+// The traversal mirrors the decoder's own field matching: a key is known when it
+// equals a field's JSON tag or that tag's snake_case spelling, both of which the
+// decoder accepts. Mirroring it is the point, because a key this reports but the
+// decoder keeps would be a false alarm on a working configuration.
+func unknownContentJSONKeys(content string) []string {
+	var raw any
+	if err := json.Unmarshal([]byte(content), &raw); err != nil {
+		// Malformed JSON is already reported as an error by the caller.
+		return nil
+	}
+
+	var found []string
+	collectUnknownKeys(raw, reflect.TypeOf(dashboardservice.Dashboard{}), "", &found)
+	sort.Strings(found)
+	return found
+}
+
+func collectUnknownKeys(raw any, target reflect.Type, path string, found *[]string) {
+	if target == nil {
+		return
+	}
+	for target.Kind() == reflect.Pointer {
+		target = target.Elem()
+	}
+
+	switch target.Kind() {
+	case reflect.Struct:
+		object, ok := raw.(map[string]any)
+		if !ok || target.PkgPath() != dashboardModelPackage {
+			return
+		}
+		collectUnknownObjectKeys(object, target, path, found)
+	case reflect.Slice, reflect.Array:
+		items, ok := raw.([]any)
+		if !ok {
+			return
+		}
+		for i, item := range items {
+			collectUnknownKeys(item, target.Elem(), fmt.Sprintf("%s[%d]", path, i), found)
+		}
+	case reflect.Map:
+		object, ok := raw.(map[string]any)
+		if !ok || target.Key().Kind() != reflect.String {
+			return
+		}
+		// Map keys are user data, so only the values are checked.
+		for key, value := range object {
+			collectUnknownKeys(value, target.Elem(), joinPath(path, key), found)
+		}
+	}
+}
+
+func collectUnknownObjectKeys(object map[string]any, target reflect.Type, path string, found *[]string) {
+	known := make(map[string]reflect.Type, target.NumField()*2)
+	for i := 0; i < target.NumField(); i++ {
+		field := target.Field(i)
+		name := strings.Split(field.Tag.Get("json"), ",")[0]
+		if name == "" || name == "-" {
+			continue
+		}
+		known[name] = field.Type
+		if alias := snakeCaseFieldName(name); alias != name {
+			known[alias] = field.Type
+		}
+	}
+
+	for key, value := range object {
+		fieldType, ok := known[key]
+		if !ok {
+			*found = append(*found, joinPath(path, key))
+			continue
+		}
+		collectUnknownKeys(value, fieldType, joinPath(path, key), found)
+	}
+}
+
+func snakeCaseFieldName(jsonName string) string {
+	var out strings.Builder
+	for i, character := range jsonName {
+		if unicode.IsUpper(character) {
+			if i > 0 {
+				out.WriteByte('_')
+			}
+			character = unicode.ToLower(character)
+		}
+		out.WriteRune(character)
+	}
+	return out.String()
+}
+
+func joinPath(parent, field string) string {
+	if parent == "" {
+		return field
+	}
+	return parent + "." + field
+}

--- a/internal/provider/dashboards/dashboard_schema/content_json_unknown_keys_test.go
+++ b/internal/provider/dashboards/dashboard_schema/content_json_unknown_keys_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboard_schema
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/dashboardjson"
+	dashboardservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+)
+
+func TestUnknownContentJSONKeys(t *testing.T) {
+	for name, tc := range map[string]struct {
+		content string
+		want    []string
+	}{
+		"clean dashboard": {
+			content: `{"name":"x","description":"d","layout":{"sections":[]}}`,
+		},
+		"misspelled top-level field": {
+			content: `{"name":"x","descriptoin":"typo"}`,
+			want:    []string{"descriptoin"},
+		},
+		"unknown field nested in a list element": {
+			content: `{"layout":{"sections":[{"id":{"value":"a"},"rowz":[]}]}}`,
+			want:    []string{"layout.sections[0].rowz"},
+		},
+		"several are all reported, sorted": {
+			content: `{"zzz":1,"aaa":2}`,
+			want:    []string{"aaa", "zzz"},
+		},
+		// The decoder accepts both spellings, so neither may be reported.
+		"protobuf snake_case spelling is accepted": {
+			content: `{"folder_id":{"value":"f"}}`,
+		},
+		"camelCase spelling is accepted": {
+			content: `{"folderId":{"value":"f"}}`,
+		},
+		// A free-form map's keys are user data, not schema fields.
+		"keys inside an untyped map are not reported": {
+			content: `{"layout":{"sections":[{"options":{"internal":{"anythingAtAll":true}}}]}}`,
+		},
+		"malformed json is left to the error path": {
+			content: `{"name":`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := unknownContentJSONKeys(tc.content)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Whatever this reports must actually be discarded by the decoder, otherwise the
+// warning fires on a configuration that works.
+func TestUnknownContentJSONKeysAgreeWithTheDecoder(t *testing.T) {
+	for _, content := range []string{
+		`{"name":"x","layout":{"sections":[]},"folder_id":{"value":"f"}}`,
+		`{"name":"x","layout":{"sections":[]},"folderId":{"value":"f"}}`,
+		`{"name":"x","layout":{"sections":[{"rows":[]}]}}`,
+		`{"name":"x","layout":{"sections":[]},"absoluteTimeFrame":{"from":"2026-01-01T00:00:00Z","to":"2026-01-02T00:00:00Z"}}`,
+	} {
+		if got := unknownContentJSONKeys(content); len(got) > 0 {
+			t.Errorf("reported %v for content the decoder accepts: %s", got, content)
+		}
+		if err := dashboardjson.Unmarshal([]byte(content), &dashboardservice.Dashboard{}); err != nil {
+			t.Errorf("decoder rejected %s: %v", content, err)
+		}
+	}
+}
+
+// The validator must warn, never fail: a configuration carrying an unrecognised
+// key still applies, and only the key is dropped.
+func TestContentJsonValidatorWarnsOnUnknownKeys(t *testing.T) {
+	for name, tc := range map[string]struct {
+		content      string
+		wantWarnings int
+		wantErrors   int
+	}{
+		"unknown key warns": {
+			content:      `{"name":"x","layout":{"sections":[]},"descriptoin":"typo"}`,
+			wantWarnings: 1,
+		},
+		"clean content is silent": {
+			content: `{"name":"x","layout":{"sections":[]},"description":"fine"}`,
+		},
+		"malformed json still errors": {
+			content:    `{"name":`,
+			wantErrors: 1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp := &validator.StringResponse{}
+			ContentJsonValidator{}.ValidateString(context.Background(), validator.StringRequest{
+				Path:        path.Root("content_json"),
+				ConfigValue: types.StringValue(tc.content),
+			}, resp)
+
+			if got := resp.Diagnostics.WarningsCount(); got != tc.wantWarnings {
+				t.Errorf("warnings: got %d want %d (%v)", got, tc.wantWarnings, resp.Diagnostics.Warnings())
+			}
+			if got := resp.Diagnostics.ErrorsCount(); got != tc.wantErrors {
+				t.Errorf("errors: got %d want %d (%v)", got, tc.wantErrors, resp.Diagnostics.Errors())
+			}
+			if tc.wantWarnings > 0 && !strings.Contains(resp.Diagnostics.Warnings()[0].Detail(), "descriptoin") {
+				t.Errorf("warning does not name the offending key: %s", resp.Diagnostics.Warnings()[0].Detail())
+			}
+		})
+	}
+}


### PR DESCRIPTION
A dashboard written as `content_json` goes through the SDK decoder, which discards any key it does not recognise. Nothing was reported. A misspelled field looked applied, was thrown away, and the dashboard silently lacked the setting the author thought they had configured.

`content_json` now warns, naming each unrecognised field by its JSON path:

```
Warning: Unknown fields in content_json

  The provider does not recognise these fields and will drop them, so they will
  have no effect on the dashboard:

    layout.sections[0].rows[0].widgets[0].definition.barChart.legend.seriesVisibility
```

## The check mirrors the decoder rather than guessing

A warning on a key the provider actually keeps would be worse than no warning, so the traversal reproduces the decoder's own field matching exactly:

- a key is known when it matches a field's JSON tag **or that tag's `snake_case` spelling** — the decoder accepts both, so reporting `folder_id` alongside `folderId` would be a false alarm
- it descends only into generated model types, the same restriction the decoder applies, so keys inside a free-form map are user data and are left alone
- malformed JSON is left to the existing error path

## Warning, not error — deliberately

An unrecognised key has two possible causes, and only one is the author's mistake. The other is a field newer than the Coralogix SDK this provider is built against. Failing the plan would break configurations that work today and that no configuration change could fix. The message names both causes and says which is likelier for a field copied out of a dashboard export.

## It immediately found a real silent drop

Running the check against every dashboard on a live tenant surfaced `legend.seriesVisibility` on three of them, on both bar and pie charts. That field does not exist anywhere in the pinned SDK, so the provider discards it today: anyone managing one of those dashboards through `content_json` loses the setting with no indication. Closing that gap needs an SDK release and is tracked separately — this PR makes it visible instead of silent, which is the whole point.

Worth stating plainly because it is the practical consequence of merging: users whose dashboards carry such a field will now see a warning on every plan. The warning is accurate, and the alternative is continuing to drop their settings quietly.

## Evidence

- `TestUnknownContentJSONKeys` covers a clean dashboard, a misspelled top-level field, an unknown key nested inside a list element, multiple keys reported in sorted order, both accepted spellings, keys inside an untyped map, and malformed JSON.
- `TestUnknownContentJSONKeysAgreeWithTheDecoder` asserts the stronger property: for content the decoder accepts, nothing is reported. This is the false-positive guard.
- `TestContentJsonValidatorWarnsOnUnknownKeys` covers the wiring — that an unknown key produces exactly one **warning** and no error, that clean content is silent, that malformed JSON still errors, and that the message names the offending key.
- **Negative control**: removing the `snake_case` alias handling makes both the unit test and the agreement test fail, reporting `folder_id` for content the decoder accepts. The tests catch the defect that matters.
- Build, vet, gofmt clean; full unit sweep passes (17 packages); the existing `content_json` and `FromJson` acceptance tests pass unchanged; `make generate` produces no diff, since no schema attribute is added.

## Not included, on purpose

Support for `legend.seriesVisibility`. It needs an SDK release first, and bundling it here would mix a diagnostic with a feature.

Comparing full attribute *paths* rather than leaf names, which would additionally catch a field wired into expand but missing from flatten. That belongs with the systematic parity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
