### PR TITLE
chore: bump coralogix-management-sdk to 20693929d

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260825080729-41b28d6c6e4f
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260825080729-41b28d6c6e4f h1:XA3uRQeE0xae05TEbw1sJFHam8KyEU+0amJFeLqPlmw=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260825080729-41b28d6c6e4f/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161 h1:4KrRh0yXLKXl8dIovpoC7ACOI6Lbg7G35TzOxRpeNEo=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5 h1:mqmL/WJA8Cdzim6r3jmXY8uiPn9KX4AvqxjEPDRXKj4=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/aaa/resource_coralogix_ip_access.go
+++ b/internal/provider/aaa/resource_coralogix_ip_access.go
@@ -261,7 +261,7 @@ func extractIpAccessRules(rules []IpAccessRuleModel) []ipaccess.IpAccess {
 func flattenCreateResponse(resp *ipaccess.CreateCompanyIpAccessSettingsResponse) IpAccessCompanySettingsModel {
 
 	rules := make([]IpAccessRuleModel, 0)
-	for _, v := range *resp.Settings.IpAccess {
+	for _, v := range resp.Settings.IpAccess {
 		rules = append(rules, flattenIPAccess(&v))
 	}
 	return IpAccessCompanySettingsModel{
@@ -273,7 +273,7 @@ func flattenCreateResponse(resp *ipaccess.CreateCompanyIpAccessSettingsResponse)
 
 func flattenReplaceResponse(resp *ipaccess.ReplaceCompanyIpAccessSettingsResponse) IpAccessCompanySettingsModel {
 	rules := make([]IpAccessRuleModel, 0)
-	for _, v := range *resp.Settings.IpAccess {
+	for _, v := range resp.Settings.IpAccess {
 		rules = append(rules, flattenIPAccess(&v))
 	}
 	return IpAccessCompanySettingsModel{
@@ -286,7 +286,7 @@ func flattenReplaceResponse(resp *ipaccess.ReplaceCompanyIpAccessSettingsRespons
 func flattenReadResponse(resp *ipaccess.GetCompanyIpAccessSettingsResponse) IpAccessCompanySettingsModel {
 	rules := make([]IpAccessRuleModel, 0)
 	if resp.Settings.IpAccess != nil {
-		for _, v := range *resp.Settings.IpAccess {
+		for _, v := range resp.Settings.IpAccess {
 			rules = append(rules, flattenIPAccess(&v))
 		}
 	}

--- a/internal/provider/ai/resource_coralogix_ai_custom_evaluation.go
+++ b/internal/provider/ai/resource_coralogix_ai_custom_evaluation.go
@@ -915,7 +915,7 @@ func (r *AICustomEvaluationResource) reconcileApplicationLinks(ctx context.Conte
 
 	for _, id := range toLink {
 		_, httpResponse, err := r.aiEvaluationsClient.
-			AiEvaluationsServiceLinkCustomEvaluation(ctx, customEvaluationID, id).
+			AiEvaluationsServiceLinkCustomEvaluation(ctx, id, customEvaluationID).
 			Execute()
 		if err != nil {
 			return fmt.Errorf("failed to link AI application %q: %s", id, utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Link", id))
@@ -924,7 +924,7 @@ func (r *AICustomEvaluationResource) reconcileApplicationLinks(ctx context.Conte
 
 	for _, id := range toUnlink {
 		_, httpResponse, err := r.aiEvaluationsClient.
-			AiEvaluationsServiceUnlinkCustomEvaluationFromApp(ctx, customEvaluationID, id).
+			AiEvaluationsServiceUnlinkCustomEvaluationFromApp(ctx, id, customEvaluationID).
 			Execute()
 		if err != nil {
 			return fmt.Errorf("failed to unlink AI application %q: %s", id, utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResponse, err), "Unlink", id))

--- a/internal/provider/alerts/resource_coralogix_alert.go
+++ b/internal/provider/alerts/resource_coralogix_alert.go
@@ -872,7 +872,7 @@ func expandLogsImmediateAlertTypeDefinition(ctx context.Context, properties *ale
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 
@@ -1064,7 +1064,7 @@ func expandLogsThresholdTypeDefinition(ctx context.Context, properties *alerts.A
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(thresholdObject) {
@@ -1256,7 +1256,7 @@ func expandLogsAnomalyAlertTypeDefinition(ctx context.Context, properties *alert
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(anomaly) {
@@ -1371,7 +1371,7 @@ func expandLogsRatioThresholdTypeDefinition(ctx context.Context, properties *ale
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(ratioThreshold) {
@@ -1536,7 +1536,7 @@ func expandLogsNewValueAlertTypeDefinition(ctx context.Context, properties *aler
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if newValue.IsNull() || newValue.IsUnknown() {
@@ -1651,7 +1651,7 @@ func expandLogsUniqueCountAlertTypeDefinition(ctx context.Context, properties *a
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(uniqueCount) {
@@ -1773,7 +1773,7 @@ func expandLogsTimeRelativeThresholdAlertTypeDefinition(ctx context.Context, pro
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(relativeThreshold) {
@@ -1883,7 +1883,7 @@ func expandMetricThresholdAlertTypeDefinition(ctx context.Context, properties *a
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(metricThreshold) {
@@ -2047,7 +2047,7 @@ func expandTracingImmediateTypeDefinition(ctx context.Context, properties *alert
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(tracingImmediate) {
@@ -2109,7 +2109,7 @@ func expandTracingThresholdTypeDefinition(ctx context.Context, properties *alert
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(tracingThreshold) {
@@ -2350,7 +2350,7 @@ func expandMetricAnomalyAlertTypeDefinition(ctx context.Context, properties *ale
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(metricAnomaly) {
@@ -2489,7 +2489,7 @@ func expandFlowAlertTypeDefinition(ctx context.Context, properties *alerts.Alert
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(flow) {
@@ -2651,7 +2651,7 @@ func expandSloThresholdAlertTypeDefinition(ctx context.Context, properties *aler
 	properties.GroupByKeys = groupBy
 	properties.IncidentsSettings = incidentsSettings
 	properties.NotificationGroup = notificationGroup
-	properties.EntityLabels = &labels
+	properties.EntityLabels = labels
 	properties.PhantomMode = alertResourceModel.PhantomMode.ValueBoolPointer()
 	properties.ActiveOn = schedule
 	if utils.ObjIsNullOrUnknown(sloThreshold) {
@@ -3106,7 +3106,7 @@ func getAlertIncidentSettings(alertDefProperties *alerts.AlertDefProperties) *al
 	}
 }
 
-func getAlertEntityLabels(alertDefProperties *alerts.AlertDefProperties) *map[string]string {
+func getAlertEntityLabels(alertDefProperties *alerts.AlertDefProperties) map[string]string {
 	if alertDefProperties.Flow != nil {
 		return alertDefProperties.EntityLabels
 	} else if alertDefProperties.LogsImmediate != nil {

--- a/internal/provider/integrations/resource_coralogix_webhook.go
+++ b/internal/provider/integrations/resource_coralogix_webhook.go
@@ -1072,7 +1072,7 @@ func expandGenericWebhook(ctx context.Context, genericWebhook *CustomWebhookMode
 		GenericWebhook: &webhooks.GenericWebhookConfig{
 			Uuid:    &uuid,
 			Method:  &method,
-			Headers: &headers,
+			Headers: headers,
 			Payload: genericWebhook.Payload.ValueStringPointer(),
 		},
 	}, nil

--- a/internal/provider/notifications/resource_coralogix_global_router.go
+++ b/internal/provider/notifications/resource_coralogix_global_router.go
@@ -327,7 +327,7 @@ func extractGlobalRouter(ctx context.Context, plan *GlobalRouterResourceModel) (
 		Fallback:        fallback,
 		FallbackTargets: fallbackTargets,
 		Disabled:        plan.Disabled.ValueBoolPointer(),
-		EntityLabels:    &entityLabels,
+		EntityLabels:    entityLabels,
 		RoutingLabels:   routingLabels,
 	}, nil
 }
@@ -416,7 +416,7 @@ func extractRoutingRule(ctx context.Context, routingModel RoutingRuleModel) (*gl
 		Name:          utils.TypeStringToStringPointer(routingModel.Name),
 		Condition:     routingModel.Condition.ValueStringPointer(),
 		Targets:       targets,
-		CustomDetails: &customDetails,
+		CustomDetails: customDetails,
 		EntityType:    &entityType,
 	}, nil
 }
@@ -479,7 +479,7 @@ func extractRoutingTarget(ctx context.Context, routingTargetModel RoutingTargetM
 	return &globalRouters.RoutingTarget{
 		ConnectorId:   routingTargetModel.ConnectorId.ValueStringPointer(),
 		PresetId:      utils.TypeStringToStringPointer(routingTargetModel.PresetId),
-		CustomDetails: &customDetails,
+		CustomDetails: customDetails,
 	}, nil
 }
 
@@ -491,7 +491,7 @@ func flattenGlobalRouter(ctx context.Context, globalRouter *globalRouters.Global
 
 	routingLabels := flattenRoutingLabels(globalRouter.RoutingLabels)
 
-	entityLabels, diags := utils.StringMapToTypeMap(ctx, globalRouter.EntityLabels)
+	entityLabels, diags := utils.StringMapToTypeMap(ctx, &globalRouter.EntityLabels)
 	if diags.HasError() {
 		return nil, diags
 	}

--- a/internal/provider/recording_rules/resource_coralogix_recording_rules_groups_set.go
+++ b/internal/provider/recording_rules/resource_coralogix_recording_rules_groups_set.go
@@ -805,7 +805,7 @@ func expandRecordingRule(ctx context.Context, rule RecordingRuleModel) (*recRule
 	return &recRuless.InRule{
 		Record: rule.Record.ValueString(),
 		Expr:   rule.Expr.ValueString(),
-		Labels: &labels,
+		Labels: labels,
 	}, nil
 }
 

--- a/internal/provider/slo_mgmt/resource_coralogix_slo_v2.go
+++ b/internal/provider/slo_mgmt/resource_coralogix_slo_v2.go
@@ -434,7 +434,7 @@ func extractSLOV2(ctx context.Context, plan *SLOV2ResourceModel) (*slos.Slo, dia
 	slo := &slos.Slo{
 		Description:               description,
 		Id:                        id,
-		Labels:                    &labels,
+		Labels:                    labels,
 		Name:                      name,
 		SloTimeFrame:              timeFrame,
 		TargetThresholdPercentage: &targetThresholdPct,
@@ -627,7 +627,7 @@ func flattenRequestBasedSLI(ctx context.Context, slo *slos.Slo) (*SLOV2ResourceM
 		return nil, diags
 	}
 
-	labels, diags := utils.StringMapToTypeMap(ctx, slo.Labels)
+	labels, diags := utils.StringMapToTypeMap(ctx, &slo.Labels)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -693,7 +693,7 @@ func flattenWindowBasedSLI(ctx context.Context, slo *slos.Slo) (*SLOV2ResourceMo
 		return nil, diags
 	}
 
-	labels, diags := utils.StringMapToTypeMap(ctx, slo.Labels)
+	labels, diags := utils.StringMapToTypeMap(ctx, &slo.Labels)
 	if diags.HasError() {
 		return nil, diags
 	}


### PR DESCRIPTION
Bumps `github.com/coralogix/coralogix-management-sdk` to commit `20693929d` (#681).

Source changes needed to compile against the regenerated OpenAPI client:
- Pointer maps → value maps (drop the `*` deref / `&` / `ptr.To`): ip_access `CompanyIpAccessSettings.IpAccess`, alert `EntityLabels`, SLO `Labels`, recording-rules `Labels`, global-router `EntityLabels`/`CustomDetails`, webhook `Headers`.
- `ai_evaluations`: `Link`/`UnlinkCustomEvaluation` params reordered to `(ctx, applicationId, id)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)