### PR TITLE
test: isolate team-singleton acceptance tests in ephemeral teams

### DIFF
--- a/.claude/skills/ephemeral-team-for-singleton-tests/SKILL.md
+++ b/.claude/skills/ephemeral-team-for-singleton-tests/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: ephemeral-team-for-singleton-tests
+description: "Use when writing or fixing acceptance tests for team-wide singleton resources (coralogix_archive_logs, archive_metrics, archive_retentions, tco_policies_*, quota_allocation_rule_set, ip_access, data_enrichments) that flake under concurrent CI runs. Isolates the test in a disposable team. Do NOT use for ID-addressed resources — unique names suffice there."
+---
+
+# Ephemeral team per singleton acceptance test
+
+**Trigger:** a test mutates one-per-team state (ID-less API, atomic list overwrite, hardcoded resource ID) and concurrent workflow runs clobber each other.
+
+**Fix:** prepend the harness's provider override to every `TestStep` config:
+
+```go
+providerConfig := ephemeralteam.ProviderConfig(t) // "" when CORALOGIX_ORG_API_KEY unset
+// ...
+Config: providerConfig + testAccMyResourceConfig(),
+```
+
+`internal/ephemeralteam` creates a team with the org-scoped `CORALOGIX_ORG_API_KEY`, mints a team key, and deletes the team only if the test passed (kept + logged on failure; names start with `tf-acc-ephemeral`).
+
+**Why:** the framework provider gives the HCL `api_key` precedence over `CORALOGIX_API_KEY`, so the injected team key redirects the whole test into the fresh team. The SDKv2 provider has the opposite precedence — this does NOT work for SDKv2 resources (e.g. `coralogix_enrichment`).

--- a/.claude/skills/ephemeral-team-for-singleton-tests/SKILL.md
+++ b/.claude/skills/ephemeral-team-for-singleton-tests/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ephemeral-team-for-singleton-tests
-description: "Use when writing or fixing acceptance tests for team-wide singleton resources (coralogix_archive_logs, archive_metrics, archive_retentions, tco_policies_*, quota_allocation_rule_set, ip_access, data_enrichments) that flake under concurrent CI runs. Isolates the test in a disposable team. Do NOT use for ID-addressed resources — unique names suffice there."
+description: "Use when an acceptance test mutates team-wide singleton state (archive, TCO, quota, ip_access, enrichments) and flakes under concurrent CI runs. Isolates the test in a disposable team."
 ---
 
 # Ephemeral team per singleton acceptance test
 
-**Trigger:** a test mutates one-per-team state (ID-less API, atomic list overwrite, hardcoded resource ID) and concurrent workflow runs clobber each other.
+**Trigger:** a test mutates one-per-team state (ID-less API, atomic list overwrite, hardcoded resource ID) and concurrent workflow runs clobber each other. Applies to `coralogix_archive_logs`, `archive_metrics`, `archive_retentions`, `tco_policies_*`, `quota_allocation_rule_set`, `ip_access`, `data_enrichments`. Do NOT use for ID-addressed resources — unique names suffice there.
 
 **Fix:** prepend the harness's provider override to every `TestStep` config:
 

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -76,7 +76,11 @@ jobs:
         env:
           CORALOGIX_ENV: ${{ secrets.CORALOGIX_ENV }}
           CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
-          TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}          
+          # Org-scoped key (org-teams:Manage + team API key creation). When set,
+          # team-singleton tests provision an ephemeral team per test instead of
+          # mutating the shared team. See internal/ephemeralteam.
+          CORALOGIX_ORG_API_KEY: ${{ secrets.CORALOGIX_ORG_API_KEY }}
+          TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
           AWS_TEST_ROLE: ${{ secrets.AWS_TEST_ROLE }}
           ARCHIVE_LOGS_BUCKET: ${{ secrets.ARCHIVE_LOGS_BUCKET }}
           ARCHIVE_METRICS_BUCKET: ${{ secrets.ARCHIVE_METRICS_BUCKET }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -112,6 +112,11 @@ jobs:
         env:
           CORALOGIX_ENV: ${{ secrets.CORALOGIX_ENV }}
           CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
+          # Org-scoped key (org-teams:Manage + team API key creation). When set,
+          # team-singleton tests provision an ephemeral team per test instead of
+          # mutating the shared team. See internal/ephemeralteam. The singleton
+          # tests (archive, TCO, quota, ip_access) run in this catch-all job.
+          CORALOGIX_ORG_API_KEY: ${{ secrets.CORALOGIX_ORG_API_KEY }}
           TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
           AWS_TEST_ROLE: ${{ secrets.AWS_TEST_ROLE }}
           ARCHIVE_LOGS_BUCKET: ${{ secrets.ARCHIVE_LOGS_BUCKET }}

--- a/internal/ephemeralteam/ephemeralteam.go
+++ b/internal/ephemeralteam/ephemeralteam.go
@@ -221,13 +221,23 @@ func Acquire(t *testing.T) *Team {
 			t.Logf("ephemeralteam: test failed; keeping team %d (%s) for inspection", teamID, name)
 			return
 		}
-		_, httpResp, err := cs.Teams().TeamServiceDeleteTeam(context.Background(), teamID).Execute()
-		if err != nil {
-			t.Errorf("ephemeralteam: deleting team %d: %s", teamID,
-				utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResp, err), "Delete", nil))
-			return
+		// Deletion is best-effort: the backend refuses DeleteTeam while the
+		// org's quota ledger is being rebalanced (e.g. "DailyQuota must be
+		// greater than 0.01" when the org's default team is over its quota).
+		// A leaked, prefix-named team is sweepable later; failing a green
+		// test over it is not, so retry and then warn instead of erroring.
+		var lastErr string
+		for attempt := 1; attempt <= 3; attempt++ {
+			_, httpResp, err := cs.Teams().TeamServiceDeleteTeam(context.Background(), teamID).Execute()
+			if err == nil {
+				t.Logf("ephemeralteam: deleted team %d (%s)", teamID, name)
+				return
+			}
+			lastErr = utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResp, err), "Delete", nil)
+			time.Sleep(time.Duration(attempt) * 2 * time.Second)
 		}
-		t.Logf("ephemeralteam: deleted team %d (%s)", teamID, name)
+		t.Logf("ephemeralteam: WARNING: could not delete team %d (%s); leaving it for the sweeper: %s",
+			teamID, name, lastErr)
 	})
 
 	keyName := name + "-key"

--- a/internal/ephemeralteam/ephemeralteam.go
+++ b/internal/ephemeralteam/ephemeralteam.go
@@ -1,0 +1,293 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ephemeralteam provisions a disposable Coralogix team for acceptance
+// tests that mutate team-wide singleton state (archive settings, TCO policies,
+// archive retentions, quota allocation rules, IP access, data enrichments).
+//
+// Running those tests against the shared CI team means concurrent workflow
+// runs clobber each other's state. This harness gives each test its own team:
+//
+//  1. Create a team in the organization of the CORALOGIX_ORG_API_KEY key.
+//  2. Mint a team-scoped API key for the new team.
+//  3. Return a `provider "coralogix" {}` HCL block pinned to that key, which
+//     the test prepends to its configuration. The plugin-framework provider
+//     gives configuration precedence over the CORALOGIX_API_KEY environment
+//     variable, so the test runs fully inside the ephemeral team.
+//  4. On test success the team is deleted (its daily quota returns to the
+//     organization). On failure the team is kept and its ID is logged so the
+//     state can be inspected; stale teams are recognizable by the
+//     TeamNamePrefix and can be swept by a scheduled cleanup.
+//
+// The harness is opt-in: when CORALOGIX_ORG_API_KEY is unset, ProviderConfig
+// returns an empty string and the test falls back to the shared team exactly
+// as before. The org key must carry org-teams:Manage, org-teams:ReadConfig,
+// and the ability to create team-level API keys.
+//
+// Limitation: this only isolates resources served by the plugin-framework
+// provider. The legacy SDKv2 provider resolves CORALOGIX_API_KEY before the
+// provider block, so SDKv2 resources (e.g. coralogix_enrichment) ignore the
+// injected key.
+package ephemeralteam
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	apikeysservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/api_keys_service"
+	teamsservice "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/teams_service"
+
+	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
+	"github.com/coralogix/terraform-provider-coralogix/internal/utils"
+)
+
+// OrgAPIKeyEnvVar holds the org-scoped API key that is allowed to create and
+// delete teams. The harness is a no-op when it is unset.
+const OrgAPIKeyEnvVar = "CORALOGIX_ORG_API_KEY"
+
+// TeamNamePrefix marks teams created by this harness so leaked teams (kept
+// after a failure, or orphaned by a killed run) can be found and swept.
+const TeamNamePrefix = "tf-acc-ephemeral"
+
+var envAliasToSDKRegion = map[string]string{
+	"APAC1":   "AP1",
+	"APAC2":   "AP2",
+	"APAC3":   "AP3",
+	"EUROPE1": "EU1",
+	"EUROPE2": "EU2",
+	"USA1":    "US1",
+	"USA2":    "US2",
+	"USA3":    "US3",
+}
+
+// DefaultTeamKeyPermissions is granted to the minted team key. It is the
+// documented "Legacy Api Key" permission set (see docs/guides/api-keys.md),
+// which covers the team-wide configuration surfaces the singleton acceptance
+// tests exercise.
+var DefaultTeamKeyPermissions = []string{
+	"alerts:ReadConfig",
+	"alerts:UpdateConfig",
+	"cloud-metadata-enrichment:ReadConfig",
+	"cloud-metadata-enrichment:UpdateConfig",
+	"data-usage:Read",
+	"geo-enrichment:ReadConfig",
+	"geo-enrichment:UpdateConfig",
+	"grafana:Read",
+	"grafana:Update",
+	"livetail:Read",
+	"logs.alerts:ReadConfig",
+	"logs.alerts:UpdateConfig",
+	"logs.data-setup#low:ReadConfig",
+	"logs.data-setup#low:UpdateConfig",
+	"logs.events2metrics:ReadConfig",
+	"logs.events2metrics:UpdateConfig",
+	"logs.tco:ReadPolicies",
+	"logs.tco:UpdatePolicies",
+	"metrics.alerts:ReadConfig",
+	"metrics.alerts:UpdateConfig",
+	"metrics.data-analytics#high:Read",
+	"metrics.data-analytics#low:Read",
+	"metrics.data-setup#high:ReadConfig",
+	"metrics.data-setup#high:UpdateConfig",
+	"metrics.data-setup#low:ReadConfig",
+	"metrics.data-setup#low:UpdateConfig",
+	"metrics.recording-rules:ReadConfig",
+	"metrics.recording-rules:UpdateConfig",
+	"metrics.tco:ReadPolicies",
+	"metrics.tco:UpdatePolicies",
+	"outbound-webhooks:ReadConfig",
+	"outbound-webhooks:UpdateConfig",
+	"parsing-rules:ReadConfig",
+	"parsing-rules:UpdateConfig",
+	"security-enrichment:ReadConfig",
+	"security-enrichment:UpdateConfig",
+	"serverless:Read",
+	"service-catalog:Read",
+	"service-catalog:ReadApdexConfig",
+	"service-catalog:ReadDimensionsConfig",
+	"service-catalog:ReadSLIConfig",
+	"service-catalog:Update",
+	"service-catalog:UpdateApdexConfig",
+	"service-catalog:UpdateDimensionsConfig",
+	"service-catalog:UpdateSLIConfig",
+	"service-map:Read",
+	"source-mapping:UploadMapping",
+	"spans.alerts:ReadConfig",
+	"spans.alerts:UpdateConfig",
+	"spans.data-api#high:ReadData",
+	"spans.data-api#low:ReadData",
+	"spans.data-setup#low:ReadConfig",
+	"spans.data-setup#low:UpdateConfig",
+	"spans.events2metrics:ReadConfig",
+	"spans.events2metrics:UpdateConfig",
+	"spans.tco:ReadPolicies",
+	"spans.tco:UpdatePolicies",
+	"team-actions:ReadConfig",
+	"team-actions:UpdateConfig",
+	"team-api-keys-security-settings:Manage",
+	"team-api-keys-security-settings:ReadConfig",
+	"team-api-keys:Manage",
+	"team-api-keys:ReadConfig",
+	"team-custom-enrichment:ReadConfig",
+	"team-custom-enrichment:ReadData",
+	"team-custom-enrichment:UpdateConfig",
+	"team-custom-enrichment:UpdateData",
+	"team-dashboards:Read",
+	"team-dashboards:Update",
+	"team-quota:Manage",
+	"team-quota:Read",
+	"user-actions:ReadConfig",
+	"user-actions:UpdateConfig",
+	"user-dashboards:Read",
+	"user-dashboards:Update",
+	"version-benchmark-tags:Read",
+	"version-benchmark-tags:Update",
+}
+
+// Team is a disposable Coralogix team owned by a single acceptance test.
+type Team struct {
+	ID     int64
+	Name   string
+	APIKey string
+}
+
+// ProviderConfig provisions an ephemeral team for the test and returns the
+// provider override block to prepend to every TestStep configuration. It
+// returns "" when CORALOGIX_ORG_API_KEY is unset, in which case the test runs
+// against the shared team from CORALOGIX_API_KEY as before.
+func ProviderConfig(t *testing.T) string {
+	t.Helper()
+	team := Acquire(t)
+	if team == nil {
+		return ""
+	}
+	return team.ProviderConfig()
+}
+
+// Acquire creates an ephemeral team plus a team-scoped API key and registers
+// a cleanup that deletes the team only when the test passed. It returns nil
+// when CORALOGIX_ORG_API_KEY is unset.
+func Acquire(t *testing.T) *Team {
+	t.Helper()
+	// resource.Test skips without TF_ACC, but this helper runs before it —
+	// don't provision a team for a test that is about to be skipped.
+	if os.Getenv("TF_ACC") == "" {
+		return nil
+	}
+	orgKey := os.Getenv(OrgAPIKeyEnvVar)
+	if orgKey == "" {
+		return nil
+	}
+
+	cs, err := newOrgClientSet(orgKey)
+	if err != nil {
+		t.Fatalf("ephemeralteam: %s", err)
+	}
+	ctx := context.Background()
+
+	name := fmt.Sprintf("%s-%d", TeamNamePrefix, time.Now().UnixNano())
+	createResp, httpResp, err := cs.Teams().
+		TeamServiceCreateTeamInOrg(ctx).
+		TeamServiceCreateTeamInOrgRequest(teamsservice.TeamServiceCreateTeamInOrgRequest{
+			TeamName: name,
+		}).
+		Execute()
+	if err != nil {
+		t.Fatalf("ephemeralteam: creating team %q: %s", name,
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResp, err), "Create", nil))
+	}
+	teamID := createResp.TeamId.GetId()
+	t.Logf("ephemeralteam: created team %d (%s)", teamID, name)
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("ephemeralteam: test failed; keeping team %d (%s) for inspection", teamID, name)
+			return
+		}
+		_, httpResp, err := cs.Teams().TeamServiceDeleteTeam(context.Background(), teamID).Execute()
+		if err != nil {
+			t.Errorf("ephemeralteam: deleting team %d: %s", teamID,
+				utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResp, err), "Delete", nil))
+			return
+		}
+		t.Logf("ephemeralteam: deleted team %d (%s)", teamID, name)
+	})
+
+	keyName := name + "-key"
+	hashed := false
+	keyResp, httpResp, err := cs.APIKeys().
+		ApiKeysServiceCreateApiKey(ctx).
+		CreateApiKeyRequest(apikeysservice.CreateApiKeyRequest{
+			Name:   &keyName,
+			Hashed: &hashed,
+			Owner:  &apikeysservice.Owner{TeamId: &teamID},
+			KeyPermissions: &apikeysservice.CreateApiKeyRequestKeyPermissions{
+				Permissions: DefaultTeamKeyPermissions,
+			},
+		}).
+		Execute()
+	if err != nil {
+		t.Fatalf("ephemeralteam: creating API key for team %d: %s", teamID,
+			utils.FormatOpenAPIErrors(cxsdkOpenapi.NewAPIError(httpResp, err), "Create", nil))
+	}
+	if keyResp.GetValue() == "" {
+		t.Fatalf("ephemeralteam: backend returned an empty API key value for team %d", teamID)
+	}
+
+	return &Team{ID: teamID, Name: name, APIKey: keyResp.GetValue()}
+}
+
+// ProviderConfig renders the provider override block that pins the Coralogix
+// provider to this team's API key.
+func (tm *Team) ProviderConfig() string {
+	if domain := os.Getenv("CORALOGIX_DOMAIN"); domain != "" {
+		return fmt.Sprintf(`provider "coralogix" {
+  domain  = %q
+  api_key = %q
+}
+
+`, domain, tm.APIKey)
+	}
+	return fmt.Sprintf(`provider "coralogix" {
+  env     = %q
+  api_key = %q
+}
+
+`, strings.ToUpper(os.Getenv("CORALOGIX_ENV")), tm.APIKey)
+}
+
+func newOrgClientSet(orgKey string) (*clientset.ClientSet, error) {
+	if domain := os.Getenv("CORALOGIX_DOMAIN"); domain != "" {
+		grpcTarget, err := clientset.GrpcTargetFromDomain(domain)
+		if err != nil {
+			return nil, fmt.Errorf("resolving gRPC target for domain %q: %w", domain, err)
+		}
+		return clientset.NewClientSet(domain, orgKey, grpcTarget), nil
+	}
+	region := strings.ToUpper(os.Getenv("CORALOGIX_ENV"))
+	if region == "" {
+		return nil, fmt.Errorf("CORALOGIX_ENV or CORALOGIX_DOMAIN must be set")
+	}
+	if short, ok := envAliasToSDKRegion[region]; ok {
+		region = short
+	}
+	region = strings.ToLower(region)
+	return clientset.NewClientSet(region, orgKey, cxsdk.CoralogixGrpcEndpointFromRegion(region)), nil
+}

--- a/internal/provider/resource_coralogix_archive_logs_test.go
+++ b/internal/provider/resource_coralogix_archive_logs_test.go
@@ -23,6 +23,8 @@ import (
 	cxsdkOpenapi "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 	archiveLogs "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/target_service"
 	"github.com/coralogix/terraform-provider-coralogix/internal/clientset"
+	"github.com/coralogix/terraform-provider-coralogix/internal/ephemeralteam"
+
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -36,13 +38,30 @@ func TestAccCoralogixResourceResourceArchiveLogs(t *testing.T) {
 	if archiveLogsBucket == "" {
 		t.Skip("ARCHIVE_LOGS_BUCKET must be set for this acceptance test")
 	}
+	// Archive-logs settings are a team-wide singleton. When
+	// CORALOGIX_ORG_API_KEY is set, the test runs inside its own ephemeral
+	// team so concurrent CI runs cannot clobber each other's settings. The
+	// shared-team cleanup and destroy checks below use the environment API
+	// key, so they only apply on the shared-team path.
+	providerConfig := ephemeralteam.ProviderConfig(t)
+	usingEphemeralTeam := providerConfig != ""
+	checkDestroy := testAccCheckArchiveLogsDestroy
+	if usingEphemeralTeam {
+		checkDestroy = nil
+	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccArchivePreCheck(t) },
+		PreCheck: func() {
+			if usingEphemeralTeam {
+				testAccPreCheck(t)
+			} else {
+				testAccArchivePreCheck(t)
+			}
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckArchiveLogsDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCoralogixResourceArchiveLogs(),
+				Config: providerConfig + testAccCoralogixResourceArchiveLogs(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(archiveLogsResourceName, "bucket", archiveLogsBucket),
 					resource.TestCheckResourceAttr(archiveLogsResourceName, "active", "true"),
@@ -54,7 +73,7 @@ func TestAccCoralogixResourceResourceArchiveLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCoralogixResourceArchiveLogsUpdate(),
+				Config: providerConfig + testAccCoralogixResourceArchiveLogsUpdate(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(archiveLogsResourceName, "bucket", archiveLogsBucket),
 					resource.TestCheckResourceAttr(archiveLogsResourceName, "active", "false"),


### PR DESCRIPTION
### Description

Acceptance tests for team-wide **singleton** resources (`coralogix_archive_logs`, `archive_metrics`, `archive_retentions`, `tco_policies_*`, `quota_allocation_rule_set`, `ip_access`, `data_enrichments`) mutate one-per-team backend state. Since #678, overlapping runs are serialized via a workflow concurrency group and this repo has its own dedicated team — which stops the clobbering, but at the cost of queueing every PR behind every other run, and it doesn't protect against local `make testacc` runs hitting the CI team.

This PR adds an opt-in ephemeral-team harness (`internal/ephemeralteam`) that removes the need for serialization for singleton tests, piloted on the archive-logs test (CX-56593):

1. When `CORALOGIX_ORG_API_KEY` is set, the test creates a disposable team (`TeamServiceCreateTeamInOrg`) named `tf-acc-ephemeral-<nanos>`.
2. It mints a team-scoped API key for that team (`ApiKeysServiceCreateApiKey` with `owner.team_id`, unhashed so the value is returned) with the documented Legacy-Api-Key permission set.
3. The harness returns a `provider "coralogix" {}` HCL block pinned to the new key, prepended to every `TestStep` config. The plugin-framework provider gives configuration precedence over `CORALOGIX_API_KEY`, so the whole test runs inside the fresh team.
4. `t.Cleanup` deletes the team **only when the test passed** (its daily quota returns to the org). On failure the team is kept and its ID logged for inspection.

When `CORALOGIX_ORG_API_KEY` is unset (today's state), the harness returns `""` and tests behave exactly as before — safe, incremental rollout.

On the ephemeral path, the shared-team archive cleanup pre-check and `CheckDestroy` are skipped: they operate through the environment API key, i.e. on the shared team, which the ephemeral test doesn't touch.

**Reviewer notes / limitations:**
- The org key must carry `org-teams:Manage`, `org-teams:ReadConfig`, and team-API-key creation. No such key exists in CI secrets yet, so the ephemeral path is **not yet verified against a live environment**; the pilot keeps working through the shared-team path meanwhile.
- This only isolates plugin-framework resources. The SDKv2 provider resolves `CORALOGIX_API_KEY` *before* the provider block (`internal/provider/provider.go` `ConfigureContextFunc`), so SDKv2 resources (e.g. `coralogix_enrichment`) ignore the injected key.
- Follow-ups once the pilot passes live: roll out to the remaining singleton tests, drop them from the serialization queue, and extend the nightly cleanup to sweep stale `tf-acc-ephemeral-*` teams.

Sibling PRs implementing the same mechanism: coralogix/coralogix-operator#577, coralogix/eng-svc-view-as-code#119, coralogix/mgmt-mcp#128.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccCoralogixResourceResourceArchiveLogs'

Without CORALOGIX_ORG_API_KEY the harness is a no-op (verified: test compiles
and runs through the shared-team path unchanged). The ephemeral path needs an
org-scoped key, which is not yet available as a CI secret — see reviewer notes.
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
NONE
```

### References

Internal ticket: CX-56593

🤖 Generated with [Claude Code](https://claude.com/claude-code)