### PR TITLE
release 3.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Release 3.14.0
+
 #### resource/coralogix_connector
 - FEAT: A connector field's value can be supplied write-only, so the secret is sent to the API and never written to state. Set it in `connector_config.field_values_wo`, keyed by field name, with a matching entry in `connector_config.field_values_wo_versions`; leave that field out of `fields`. Terraform holds no copy of a write-only value, so it cannot notice that a secret changed: increment the version to send a rotated one. Requires Terraform 1.11 or later. Existing configurations are unaffected. Note that importing a connector brings the secret into state, because an import has neither configuration nor prior state to say which field is managed this way; one apply afterwards removes it again. This reduces what is stored in state and does not replace securing the state file. Reading the same connector through `data.coralogix_connector` still returns the value, because a data source reads from the API and has no configuration telling it which value is managed write-only.
 - FEAT: Warn when a field value that looks like a secret is set through `connector_config.fields` rather than `field_values_wo`, naming the field to move. Importing a connector warns too, since the import is the point at which a secret is written to state.

--- a/internal/clientset/version.go
+++ b/internal/clientset/version.go
@@ -14,4 +14,4 @@
 
 package clientset
 
-const TF_PROVIDER_VERSION = "3.13.0"
+const TF_PROVIDER_VERSION = "3.14.0"


### PR DESCRIPTION
### Description

Release 3.14.0.

- `CHANGELOG.md`: `# Unreleased` becomes `# Release 3.14.0`, with a fresh empty `# Unreleased` above it.
- `internal/clientset/version.go`: `TF_PROVIDER_VERSION` goes from `3.13.0` to `3.14.0`.

Contents of the release (already merged to master):

- #705 — `coralogix_connector`: a field's value can be supplied write-only.
- #708 — `coralogix_webhook`: a credential can be supplied write-only.
- #706 — `coralogix_quota_allocation_rule_set`: improvements and fixes.

After merge:

```
git tag v3.14.0
git push origin v3.14.0
```

Then trigger the release GitHub Action from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)