### PR TITLE
ci: stop Make from corrupting the acceptance skip pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,12 @@ install: build
 test:
 	echo $(TEST) | xargs -t -n4 go test ${BUILD_ARGS} $(TESTARGS) -timeout=30s -parallel=4
 
+# ACC_SKIP_PATTERN is read by the shell, not expanded by Make: environment
+# variables are recursively expanded by Make, so a regex containing `$|`
+# (end-anchor before an alternation) loses those characters to Make's $|
+# automatic variable, silently corrupting the skip pattern.
 testacc:
-	TF_ACC=1 go test ${BUILD_ARGS} $(TEST) -v $(TESTARGS) -skip '${ACC_SKIP_PATTERN}' -timeout 120m -parallel=4
+	TF_ACC=1 go test ${BUILD_ARGS} $(TEST) -v $(TESTARGS) -skip "$$ACC_SKIP_PATTERN" -timeout 120m -parallel=4
 
 testacc-dashboard:
 	TF_ACC=1 go test ${BUILD_ARGS} ./internal/provider -v -run '${DASHBOARD_ACC_PATTERN}' $(TESTARGS) -timeout 120m -parallel=4


### PR DESCRIPTION
### Description

The unsharded catch-all acceptance job builds a `-skip` regex from the shard patterns and passes it via the `ACC_SKIP_PATTERN` environment variable. GNU Make recursively expands environment-derived variables, so when the `testacc` recipe referenced `${ACC_SKIP_PATTERN}`, the `$|` sequence inside the pattern (`...Events2MetricMigration$|(^TestAccCoralogix.*(Alert|Webhook|Connector|Preset|Integration))...`) was consumed as Make's order-only automatic variable `$|`. The two alternatives fused into one impossible pattern, so **the alerts/webhook/connector/preset/integration shard tests were never skipped in the catch-all job and executed twice per workflow run**, racing each other on shared-team fixtures.

Observed blast radius (e.g. run 33743533073): `TestAccCoralogixResourcePagerdutyPreset` failing in both jobs with `400 "Preset with name ... already exists"` (fixture-name half fixed by #712), and `TestAccCoralogixResourceGlobalRouter` failing with "Provider produced inconsistent result after apply" as collateral (its notification-center targets were perturbed mid-apply by the duplicated preset test).

Fix: quote the variable for the shell (`-skip "$$ACC_SKIP_PATTERN"`) so Make never expands its contents, plus a comment documenting the footgun.

Verified:
- Before: `ACC_SKIP_PATTERN='X$|Y' make -n testacc` → `-skip 'XY'` (corrupted).
- After: the shell receives `"$ACC_SKIP_PATTERN"` verbatim and expands it with `$|` intact.
- Unset var: `-skip ""` behaves identically to the previous `-skip ''` (verified empty `-skip` does not skip anything).

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
CI-only change to test invocation; verified via `make -n testacc` expansion
before/after, and that an empty ACC_SKIP_PATTERN still runs all tests.
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
NONE
```

### References

Complements #712 (randomized preset fixture names). Surfaced while validating #702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)