### PR TITLE
chore: bump coralogix-management-sdk for Identity and Users clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### provider
+- CHORE: Bump `coralogix-management-sdk`. The OpenAPI ClientSet now exposes Identity and Users clients, which the `coralogix_user` migration off SCIM needs. No user-facing behaviour changes.
+
 # Release 3.14.0
 
 #### resource/coralogix_connector

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/coralogix/grpc-g
 require (
 	github.com/ahmetalpbalkan/go-linq v3.0.0+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260904130642-e909e13bd566
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161 h1:4KrRh0yXLKXl8dIovpoC7ACOI6Lbg7G35TzOxRpeNEo=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260904130642-e909e13bd566 h1:/WO2Ulp4T0uTV2FAKqLlnBIyit7uL64n4eB5KgsMyoY=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260904130642-e909e13bd566/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5 h1:mqmL/WJA8Cdzim6r3jmXY8uiPn9KX4AvqxjEPDRXKj4=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251017075809-7f84c876b2e5/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/dashboard_openapi_oneof_coverage_test.go
+++ b/internal/provider/dashboard_openapi_oneof_coverage_test.go
@@ -426,6 +426,8 @@ func dashboardOpenAPIOneOfCoverageManifest() map[string]dashboardOneOfModelCover
 			Branches: map[string]dashboardOneOfBranchCoverage{
 				"coordinateConfig": covered(geomap+".config.coordinate_config", dashboardOpenAPIDynamicGeoHeatTestName),
 				"awsRegionConfig":  covered(geomap+".config.aws_region_config", dashboardOpenAPIDynamicGeoHeatTestName),
+				"ibmRegionConfig":  gap(geomap + ".config.ibm_region_config"),
+				"allRegionConfig":  gap(geomap + ".config.all_region_config"),
 			},
 		},
 		"Heatmap": {
@@ -792,7 +794,7 @@ var dashboardProtoOnlyBranches = []dashboardProtoOnlyBranch{
 }
 
 // These seven protobuf oneofs are presence wrappers with one live arm, not
-// unions. They are intentionally kept out of the 216-branch generated-union
+// unions. They are intentionally kept out of the 218-branch generated-union
 // manifest and should not be confused with enums.
 var dashboardSingleArmProtoOneOfs = []string{
 	"ast/annotations/annotation.proto#Annotation.EventRecurrenceSource.Recurrence.frequency_type.weekly",
@@ -816,8 +818,8 @@ func TestDashboardOpenAPIOneOfCoverageManifest(t *testing.T) {
 	for _, branches := range generated {
 		generatedBranches += len(branches)
 	}
-	if generatedBranches != 216 {
-		t.Fatalf("generated dashboard union branches = %d, want 216", generatedBranches)
+	if generatedBranches != 218 {
+		t.Fatalf("generated dashboard union branches = %d, want 218", generatedBranches)
 	}
 
 	for model, generatedModelBranches := range generated {
@@ -856,8 +858,8 @@ func TestDashboardOpenAPIOneOfCoverageManifest(t *testing.T) {
 	for _, model := range dashboardOpenAPIOneOfCoverage {
 		manifestBranches += len(model.Branches)
 	}
-	if manifestBranches != 216 {
-		t.Errorf("manifest branches = %d, want 216", manifestBranches)
+	if manifestBranches != 218 {
+		t.Errorf("manifest branches = %d, want 218", manifestBranches)
 	}
 
 	// Both used to be api-only, because the provider validator rejected them.
@@ -881,16 +883,16 @@ func TestDashboardOpenAPIStructuredAcceptanceLifecycleDelegation(t *testing.T) {
 
 func TestDashboardProtoAndRESTOneOfReconciliation(t *testing.T) {
 	// Source inventory: 71 protobuf oneofs = 64 multi-branch unions and seven
-	// single-arm presence wrappers. The 64 unions have 216 branches.
+	// single-arm presence wrappers. The 64 unions have 218 branches.
 	const (
 		protoOneOfs            = 71
 		protoMultiBranchOneOfs = 64
-		protoMultiBranches     = 216
+		protoMultiBranches     = 218
 	)
 	if protoOneOfs-protoMultiBranchOneOfs != len(dashboardSingleArmProtoOneOfs) {
 		t.Fatalf("single-arm protobuf reconciliation is incomplete")
 	}
-	if protoMultiBranches != 216 {
+	if protoMultiBranches != 218 {
 		t.Fatalf("protobuf multi-branch count changed")
 	}
 	if len(dashboardProtoOnlyBranches) != 2 {
@@ -916,7 +918,7 @@ func TestDashboardProtoAndRESTOneOfReconciliation(t *testing.T) {
 	// The two imported FilterPathAndValues branches replace the two proto-only
 	// AnnotationEvent branches in the guarded REST inventory. Merging the two
 	// Dashboard oneofs reduces 64 source unions to 63 generated models without
-	// changing the reconciled 216 branch count.
+	// changing the reconciled 218 branch count.
 	if got := len(dashboardOpenAPIOneOfCoverage); got != 63 {
 		t.Fatalf("reconciled generated models = %d, want 63", got)
 	}
@@ -1084,8 +1086,8 @@ func assertDashboardProtoInventoryCounts(t *testing.T, protoInventory map[string
 			multiBranches += len(branches)
 		}
 	}
-	if multiBranchOneOfs != 64 || multiBranches != 216 {
-		t.Fatalf("dashboard protobuf multi-branch inventory = %d oneofs/%d branches, want 64/216", multiBranchOneOfs, multiBranches)
+	if multiBranchOneOfs != 64 || multiBranches != 218 {
+		t.Fatalf("dashboard protobuf multi-branch inventory = %d oneofs/%d branches, want 64/218", multiBranchOneOfs, multiBranches)
 	}
 }
 


### PR DESCRIPTION
### Description

Bumps `coralogix-management-sdk` to pick up the OpenAPI `ClientSet.Identity()` and `ClientSet.Users()` accessors ([SDK #685](https://github.com/coralogix/coralogix-management-sdk/pull/685)).

```
v1.9.4-0.20260831113530-20693929d161  ->  v1.9.4-0.20260904130642-e909e13bd566
```

The upcoming `coralogix_user` migration off SCIM needs both. Every Users API path carries a team id, and `IdentityService/WhoAmI` is the only way to resolve one from an API key. Consumers cannot build those two clients themselves, because `Config` keeps the base URL and auth headers in unexported fields.

Nothing consumes the new clients yet, so there is no behaviour change. This is split out so the migration PR contains only migration work.

#### Unrelated change the bump drags in

The bump also crosses an openapi-facade sync that added two branches to the `GeomapFieldConfig` union:

```
+ ibmRegionConfig    ast/widgets/dynamic.proto  GeomapIbmRegionConfig ibm_region_config = 3
+ allRegionConfig    ast/widgets/dynamic.proto  GeomapAllRegionConfig all_region_config = 4
```

That trips the dashboard union guards:

```
generated dashboard union branches = 218, want 216
dashboard protobuf multi-branch inventory = 64 oneofs/218 branches, want 64/216
```

I diffed the generated models across both SDK revisions to confirm exactly two branches were added and none removed, rather than just moving the numbers. The provider has no schema for either, so both are classified as `gap(...)` alongside the existing geomap branches, and the reconciled count moves 216 → 218. The union-bearing model count is unchanged at 63.

Wiring the two geomap branches is separate work and not attempted here.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

No acceptance test applies: this is a dependency bump with no behaviour change. The dashboard union guards are unit tests and are enforced here.

```
$ go build ./... && go vet ./...
$ go test ./...
ok      github.com/coralogix/terraform-provider-coralogix/internal/provider  1.096s
(full unit suite green)
```

Also verified the bumped SDK actually exposes what the migration needs, by constructing a ClientSet and asserting `Identity()` and `Users()` are non-nil.

### Release Note

```release-note
NONE
```

### References

- [coralogix-management-sdk#685](https://github.com/coralogix/coralogix-management-sdk/pull/685)

🤖 Generated with [Claude Code](https://claude.com/claude-code)