### PR TITLE
Deprecate coralogix_rules_group data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 #### data-source/coralogix_rules_group
-- DEPRECATE: Warn that this data source will be removed in 5.0.0. Use `coralogix_parsing_rules` instead.
+- DEPRECATE: Warn that this data source is deprecated and will be removed in a future version. Use `coralogix_parsing_rules` instead.
 
 # Release 3.14.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 #### data-source/coralogix_rules_group
 - DEPRECATE: Warn that this data source is deprecated and will be removed in a future version. Use `coralogix_parsing_rules` instead.
 
+#### resource/coralogix_rules_group
+- DOC: The deprecation warning now says the resource will be removed in a future version.
+
+#### resource/coralogix_enrichment
+- DOC: The deprecation warning now says the resource will be removed in a future version.
+
+#### data-source/coralogix_enrichment
+- DOC: The deprecation warning now says the data source will be removed in a future version.
+
+#### resource/coralogix_data_set
+- DOC: The deprecation warning now says Data Sets will be removed in a future version.
+
 # Release 3.14.1
 
 #### provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+#### data-source/coralogix_rules_group
+- DEPRECATE: Warn that this data source will be removed in 5.0.0. Use `coralogix_parsing_rules` instead.
+
 # Release 3.14.1
 
 #### provider

--- a/docs/data-sources/rules_group.md
+++ b/docs/data-sources/rules_group.md
@@ -3,12 +3,12 @@
 page_title: "coralogix_rules_group Data Source - terraform-provider-coralogix"
 subcategory: ""
 description: |-
-  
+  DEPRECATED. Please use coralogix_parsing_rules instead.
 ---
 
 # coralogix_rules_group (Data Source)
 
-
+**DEPRECATED**. Please use `coralogix_parsing_rules` instead.
 
 ## Example Usage
 

--- a/docs/resources/data_set.md
+++ b/docs/resources/data_set.md
@@ -3,12 +3,12 @@
 page_title: "coralogix_data_set Resource - terraform-provider-coralogix"
 subcategory: ""
 description: |-
-  Note: Data Sets will be removed in version 5.0.0 of the Terraform Provider. Please use coralogix_data_enrichments instead.
+  Note: Data Sets are deprecated and will be removed in a future version of the Terraform Provider. Please use coralogix_data_enrichments instead.
 ---
 
 # coralogix_data_set (Resource)
 
-**Note:** Data Sets will be removed in version 5.0.0 of the Terraform Provider. Please use `coralogix_data_enrichments` instead.
+**Note:** Data Sets are deprecated and will be removed in a future version of the Terraform Provider. Please use `coralogix_data_enrichments` instead.
 
 ## Example Usage
 

--- a/internal/provider/enrichment_rules/data_source_coralogix_enrichment.go
+++ b/internal/provider/enrichment_rules/data_source_coralogix_enrichment.go
@@ -41,7 +41,7 @@ func DataSourceCoralogixEnrichment() *schema.Resource {
 		ReadContext: dataSourceCoralogixEnrichmentRead,
 
 		Schema:             enrichmentSchema,
-		DeprecationMessage: "This data source will be phased out in 5.0.0. Please use `coralogix_data_enrichments` instead.",
+		DeprecationMessage: "This data source is deprecated and will be removed in a future version. Please use `coralogix_data_enrichments` instead.",
 		Description:        "**DEPRECATED**. Please use `coralogix_data_enrichments` instead.",
 	}
 }

--- a/internal/provider/enrichment_rules/resource_coralogix_data_set.go
+++ b/internal/provider/enrichment_rules/resource_coralogix_data_set.go
@@ -60,9 +60,9 @@ func ResourceCoralogixDataSet() *schema.Resource {
 			Update: schema.DefaultTimeout(120 * time.Second),
 			Delete: schema.DefaultTimeout(30 * time.Second),
 		},
-		Description:        "**Note:** Data Sets will be removed in version 5.0.0 of the Terraform Provider. Please use `coralogix_data_enrichments` instead.",
+		Description:        "**Note:** Data Sets are deprecated and will be removed in a future version of the Terraform Provider. Please use `coralogix_data_enrichments` instead.",
 		Schema:             DataSetSchema(),
-		DeprecationMessage: "Data Sets will be removed in version 5.0.0 of the Terraform Provider. Please use `coralogix_data_enrichments` instead.",
+		DeprecationMessage: "Data Sets are deprecated and will be removed in a future version of the Terraform Provider. Please use `coralogix_data_enrichments` instead.",
 	}
 }
 

--- a/internal/provider/enrichment_rules/resource_coralogix_enrichment.go
+++ b/internal/provider/enrichment_rules/resource_coralogix_enrichment.go
@@ -92,7 +92,7 @@ func ResourceCoralogixEnrichment() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Second),
 			Delete: schema.DefaultTimeout(30 * time.Second),
 		},
-		DeprecationMessage: "This resource will be phased out in 5.0.0. Please use `coralogix_data_enrichments` instead.",
+		DeprecationMessage: "This resource is deprecated and will be removed in a future version. Please use `coralogix_data_enrichments` instead.",
 		Description:        "**DEPRECATED**. Please use `coralogix_data_enrichments` instead.",
 		Schema:             EnrichmentSchema(),
 	}

--- a/internal/provider/parsing_rules/data_source_coralogix_rules_group.go
+++ b/internal/provider/parsing_rules/data_source_coralogix_rules_group.go
@@ -38,7 +38,9 @@ func DataSourceCoralogixRulesGroup() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceCoralogixRulesGroupRead,
 
-		Schema: rulesGroupSchema,
+		Schema:             rulesGroupSchema,
+		DeprecationMessage: "This data source will be removed in 5.0.0. Please use coralogix_parsing_rules instead.",
+		Description:        "**DEPRECATED**. Please use `coralogix_parsing_rules` instead.",
 	}
 }
 

--- a/internal/provider/parsing_rules/data_source_coralogix_rules_group.go
+++ b/internal/provider/parsing_rules/data_source_coralogix_rules_group.go
@@ -39,7 +39,7 @@ func DataSourceCoralogixRulesGroup() *schema.Resource {
 		ReadContext: dataSourceCoralogixRulesGroupRead,
 
 		Schema:             rulesGroupSchema,
-		DeprecationMessage: "This data source will be removed in 5.0.0. Please use coralogix_parsing_rules instead.",
+		DeprecationMessage: "This data source is deprecated and will be removed in a future version. Please use coralogix_parsing_rules instead.",
 		Description:        "**DEPRECATED**. Please use `coralogix_parsing_rules` instead.",
 	}
 }

--- a/internal/provider/parsing_rules/resource_coralogix_rules_group.go
+++ b/internal/provider/parsing_rules/resource_coralogix_rules_group.go
@@ -90,7 +90,7 @@ func ResourceCoralogixRulesGroup() *schema.Resource {
 
 		CustomizeDiff:      validateRuleGroupOrders,
 		Schema:             RulesGroupSchema(),
-		DeprecationMessage: "This resource will be removed in 5.0.0. Please use coralogix_parsing_rules instead.",
+		DeprecationMessage: "This resource is deprecated and will be removed in a future version. Please use coralogix_parsing_rules instead.",
 		Description:        "**DEPRECATED** Rule-group is list of rule-subgroups with 'and' (&&) operation between. For more info please review - https://coralogix.com/docs/log-parsing-rules/ .",
 	}
 }
@@ -117,7 +117,13 @@ func validateRuleGroupOrdersInConfig(rawConfig cty.Value) error {
 		return nil
 	}
 	subgroupValues := subgroups.AsValueSlice()
+	if err := checkOrders("rule_subgroups", collectSubgroupOrders(subgroupValues)); err != nil {
+		return err
+	}
+	return validateSubgroupRuleOrders(subgroupValues)
+}
 
+func collectSubgroupOrders(subgroupValues []cty.Value) []configuredOrder {
 	subgroupOrders := make([]configuredOrder, 0, len(subgroupValues))
 	for i, subgroup := range subgroupValues {
 		if subgroup.IsNull() || !subgroup.IsKnown() || !subgroup.Type().HasAttribute("order") {
@@ -126,10 +132,10 @@ func validateRuleGroupOrdersInConfig(rawConfig cty.Value) error {
 		}
 		subgroupOrders = append(subgroupOrders, readConfiguredOrder(i, subgroup.GetAttr("order")))
 	}
-	if err := checkOrders("rule_subgroups", subgroupOrders); err != nil {
-		return err
-	}
+	return subgroupOrders
+}
 
+func validateSubgroupRuleOrders(subgroupValues []cty.Value) error {
 	for i, subgroup := range subgroupValues {
 		if subgroup.IsNull() || !subgroup.IsKnown() || !subgroup.Type().HasAttribute("rules") {
 			continue
@@ -142,7 +148,6 @@ func validateRuleGroupOrdersInConfig(rawConfig cty.Value) error {
 			return err
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
### Description

The `coralogix_rules_group` resource is already deprecated in favor of `coralogix_parsing_rules`. This change applies the same deprecation to the `coralogix_rules_group` data source.

Deprecated types now say they will be removed in a future version, instead of naming a specific provider version. That applies to `coralogix_rules_group`, `coralogix_enrichment`, and `coralogix_data_set`.

Existing configurations continue to work.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
Not run. This change only updates deprecation warnings.
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
data-source/coralogix_rules_group: DEPRECATE: Warn that this data source is deprecated and will be removed in a future version. Use coralogix_parsing_rules instead.
resource/coralogix_rules_group, resource/coralogix_enrichment, data-source/coralogix_enrichment, resource/coralogix_data_set: DOC: Deprecation warnings now say these types will be removed in a future version.
```

### References

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment