### PR TITLE
Deprecate coralogix_action is_hidden as a per-user UI preference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+#### resource/coralogix_action
+- DEPRECATE: Warn that `is_hidden` is a per-user UI preference, not a property of the action, and will be removed in a future version.
+
+#### data-source/coralogix_action
+- DEPRECATE: Document that `is_hidden` is a per-user UI preference, not a property of the action, and will be removed in a future version.
+
 #### data-source/coralogix_rules_group
 - DEPRECATE: Warn that this data source is deprecated and will be removed in a future version. Use `coralogix_parsing_rules` instead.
 

--- a/docs/data-sources/action.md
+++ b/docs/data-sources/action.md
@@ -29,7 +29,7 @@ data "coralogix_action" "imported_action" {
 
 - `applications` (Set of String) Applies the action for specific applications.
 - `created_by` (String) The user who created the action.
-- `is_hidden` (Boolean) Determines weather the action will be shown at the action menu.
+- `is_hidden` (Boolean) Deprecated: `is_hidden` is a per-user UI preference, not a property of the action. It will be removed in a future version.
 - `is_private` (Boolean) Determines weather the action will be shared with the entire team. Can be set to false only by admin.
 - `name` (String) Action name.
 - `source_type` (String) By selecting the data type, you can make sure that the action will be displayed only in the relevant context. Can be one of ["DataMap" "Log"]

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -47,7 +47,7 @@ resource "coralogix_action" "action" {
 ### Optional
 
 - `applications` (Set of String) Applies the action for specific applications.
-- `is_hidden` (Boolean) Determines weather the action will be shown at the action menu.
+- `is_hidden` (Boolean, Deprecated) Deprecated: `is_hidden` is a per-user UI preference, not a property of the action. It will be removed in a future version.
 - `is_private` (Boolean) Determines weather the action will be shared with the entire team. Can be set to false only by admin.
 - `subsystems` (Set of String) Applies the action for specific subsystems.
 

--- a/internal/provider/actions/resource_coralogix_action.go
+++ b/internal/provider/actions/resource_coralogix_action.go
@@ -126,7 +126,8 @@ func (r *ActionResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
-				MarkdownDescription: "Determines weather the action will be shown at the action menu.",
+				DeprecationMessage:  "`is_hidden` is a per-user UI preference, not a property of the action. It will be removed in a future version.",
+				MarkdownDescription: "Deprecated: `is_hidden` is a per-user UI preference, not a property of the action. It will be removed in a future version.",
 			},
 			"source_type": schema.StringAttribute{
 				Required: true,


### PR DESCRIPTION
The field is not a property of the action, so Terraform should stop treating it as one in a future major version.