### PR TITLE
Add agent skill for proto-size vs Terraform implementation budget

### DIFF
--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: proto-size-impl-budget
-description: "Use when reviewing or adding a Terraform resource. Estimate size from pinned SDK fields; flag 3x overruns or vendored clients. Do NOT use for small schema tweaks or dashboard/alert widget edits."
+description: "Use when reviewing or adding a Terraform resource. Estimate size from pinned SDK fields vs all non-test Go; flag 3x overruns. Do NOT use for small schema tweaks or dashboard/alert widget edits."
 ---
 
 # SDK size vs implementation budget
 
-**Trigger:** A new or large `resource_*.go` for one management API.
+**Trigger:** A new or large resource for one management API.
 
-**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio. Compare implementation lines (schema + expand + flatten + CRUD; skip tests):
+**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
 
-- Expected: `7.8 × fields + 210`
-- Typical band: about `4×fields+180` to `12×fields+250`
+Count **all non-test, non-example `.go` lines** for that API: resource, data source, helpers, and any generated client copied into this repo. Skip tests, examples, and docs. Compare:
 
-Flag only extremes: about **3× the midpoint** or more. Also flag if the PR vendors a generated OpenAPI or SDK client into this repo. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent). Dashboard and alert are a deep-expand class (~22 lines/field); do not score other APIs against them.
+- Expected: `17 × fields`
+- Typical band: about `8×` to `23×`
 
-**Why:** The pinned SDK is the surface this provider can implement. Typical APIs are not linear enough for a linter. A large ratio still catches workarounds such as copied clients or expanding a small API like a dashboard.
+Flag only extremes: about **3× the midpoint** or more. A copied OpenAPI/SDK client is included in the line count, so it shows up here. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent). Dashboard and alert are a deep-expand class (~25 lines/field); do not score other APIs against them.
+
+**Why:** The pinned SDK is the surface this provider can implement. Typical APIs are not linear enough for a linter. Counting all Go, not only expand/flatten, is what catches a dumped generated client.

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: proto-size-impl-budget
+description: "Use when reviewing or adding a Terraform resource. Estimate size from proto fields; flag 3x overruns or vendored generated clients. Do NOT use for small schema tweaks or dashboard/alert widget edits."
+---
+
+# Proto size vs implementation budget
+
+**Trigger:** A new or large `resource_*.go` for one management API.
+
+**Fix:** Count numbered proto fields for that API in the public `coralogix/cx-management-apis` repo. If protos are missing, count fields on the generated SDK structs. If neither exists, skip the ratio. Compare implementation lines (schema + expand + flatten + CRUD; skip tests):
+
+- Expected: `7.5 × fields + 220`
+- Typical band: about `4×fields+150` to `12×fields+290`
+
+Flag only extremes: about **3× the midpoint** or more. Also flag if the PR vendors a generated OpenAPI or SDK client into this repo. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent). Dashboard and alert are a deep-expand class (~17–21 lines/field); do not score other APIs against them. Use field count, not proto lines.
+
+**Why:** Typical APIs are not linear enough for a linter. A large ratio still catches workarounds such as copied clients or expanding a small proto like a dashboard.

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: proto-size-impl-budget
-description: "Use when reviewing or adding a Terraform resource. Estimate size from proto fields; flag 3x overruns or vendored generated clients. Do NOT use for small schema tweaks or dashboard/alert widget edits."
+description: "Use when reviewing or adding a Terraform resource. Estimate size from pinned SDK fields; flag 3x overruns or vendored clients. Do NOT use for small schema tweaks or dashboard/alert widget edits."
 ---
 
-# Proto size vs implementation budget
+# SDK size vs implementation budget
 
 **Trigger:** A new or large `resource_*.go` for one management API.
 
-**Fix:** Count numbered proto fields for that API in the public `coralogix/cx-management-apis` repo. If protos are missing, count fields on the generated SDK structs. If neither exists, skip the ratio. Compare implementation lines (schema + expand + flatten + CRUD; skip tests):
+**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio. Compare implementation lines (schema + expand + flatten + CRUD; skip tests):
 
-- Expected: `7.5 × fields + 220`
-- Typical band: about `4×fields+150` to `12×fields+290`
+- Expected: `7.8 × fields + 210`
+- Typical band: about `4×fields+180` to `12×fields+250`
 
-Flag only extremes: about **3× the midpoint** or more. Also flag if the PR vendors a generated OpenAPI or SDK client into this repo. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent). Dashboard and alert are a deep-expand class (~17–21 lines/field); do not score other APIs against them. Use field count, not proto lines.
+Flag only extremes: about **3× the midpoint** or more. Also flag if the PR vendors a generated OpenAPI or SDK client into this repo. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent). Dashboard and alert are a deep-expand class (~22 lines/field); do not score other APIs against them.
 
-**Why:** Typical APIs are not linear enough for a linter. A large ratio still catches workarounds such as copied clients or expanding a small proto like a dashboard.
+**Why:** The pinned SDK is the surface this provider can implement. Typical APIs are not linear enough for a linter. A large ratio still catches workarounds such as copied clients or expanding a small API like a dashboard.

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -9,7 +9,7 @@ description: "Use when reviewing or adding a Terraform resource. Estimate size f
 
 **Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Count **this resource only**. If one gen package backs several resources (for example `policies_service` for three TCO resources), do not use the whole package. Use this resource’s types (name prefixes, or models reachable from its create/get/replace requests). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
 
-Count **all non-test, non-example `.go` lines** for **this resource**: its resource file, data source, and helpers. Skip tests, examples, and docs. If a generated client or helper is shared by several resources, do not add the whole shared pile to each one. Split those lines, or compare them to the combined SDK fields of every resource that uses them. A client copied in for this resource alone still counts here.
+Count **non-blank, non-comment** lines in non-test, non-example `.go` files for **this resource**: its resource file, data source, and helpers. Do not use `wc -l` (physical lines). Skip tests, examples, and docs. If a generated client or helper is shared by several resources, do not add the whole shared pile to each one. Split those lines, or compare them to the combined SDK fields of every resource that uses them. A client copied in for this resource alone still counts here.
 
 - Expected: `17 × fields`
 - Typical band: about `10×` to `24×`

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -7,7 +7,7 @@ description: "Use when reviewing or adding a Terraform resource. Estimate size f
 
 **Trigger:** A new or large resource for one management API.
 
-**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
+**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Count **this resource only**. If one gen package backs several resources (for example `policies_service` for three TCO resources), do not use the whole package. Use this resource’s types (name prefixes, or models reachable from its create/get/replace requests). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
 
 Count **all non-test, non-example `.go` lines** for that API: resource, data source, helpers, and any generated client copied into this repo. Skip tests, examples, and docs. Compare:
 

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -9,7 +9,7 @@ description: "Use when reviewing or adding a Terraform resource. Estimate size f
 
 **Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Count **this resource only**. If one gen package backs several resources (for example `policies_service` for three TCO resources), do not use the whole package. Use this resource’s types (name prefixes, or models reachable from its create/get/replace requests). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
 
-Count **all non-test, non-example `.go` lines** for that API: resource, data source, helpers, and any generated client copied into this repo. Skip tests, examples, and docs. Compare:
+Count **all non-test, non-example `.go` lines** for **this resource**: its resource file, data source, and helpers. Skip tests, examples, and docs. If a generated client or helper is shared by several resources, do not add the whole shared pile to each one. Split those lines, or compare them to the combined SDK fields of every resource that uses them. A client copied in for this resource alone still counts here.
 
 - Expected: `17 × fields`
 - Typical band: about `10×` to `24×`

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -12,8 +12,8 @@ description: "Use when reviewing or adding a Terraform resource. Estimate size f
 Count **all non-test, non-example `.go` lines** for that API: resource, data source, helpers, and any generated client copied into this repo. Skip tests, examples, and docs. Compare:
 
 - Expected: `17 × fields`
-- Typical band: about `8×` to `23×`
+- Typical band: about `10×` to `24×`
 
-Flag only extremes: about **3× the midpoint** or more. A copied OpenAPI/SDK client is included in the line count, so it shows up here. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent). Dashboard and alert are a deep-expand class (~25 lines/field); do not score other APIs against them.
+Flag only extremes: about **3× the midpoint** or more. A copied OpenAPI/SDK client is included in the line count, so it shows up here. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent). Dashboard and alert sit in this band (~24–25×). Do not give them a separate formula.
 
 **Why:** The pinned SDK is the surface this provider can implement. Typical APIs are not linear enough for a linter. Counting all Go, not only expand/flatten, is what catches a dumped generated client.


### PR DESCRIPTION
### Description

Adds one agent skill: `.claude/skills/proto-size-impl-budget/SKILL.md`.

This is not a linter and not CI. An agent loads it when adding or reviewing a Terraform resource.

Companion operator PR: https://github.com/coralogix/coralogix-operator/pull/589

## Summary

Give agents a size check for new management-API resources: count fields on the **pinned SDK**, count **all non-test Go** for that API, and flag only large overruns.

## Measurements (short)

**Denominator:** exported JSON-tagged fields on generated model structs in the pinned `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Duplicated OpenAPI filter/error types were skipped. Live proto HEAD was not used.

**Numerator:** all non-test, non-example `.go` lines for that API (resource, data source, helpers, and any generated client copied into this repo). Tests, examples, and docs were excluded.

Typical resources, **including dashboard and alert**:

- About **17 lines per SDK field**
- Common band: about `10×` to `24×`

Dashboard is about 24×. Alert is about 25×. They sit at the top of this band. They do not get a separate formula.

A copied OpenAPI/SDK client is part of the Go count, so it lands in the ratio. That is the 8K→1K case: the resource file was in band; the dumped generated client was not.

The skill flags only extremes: about **3× the midpoint**. In-band is not a pass. The code still needs a review.

## Breaking change?

No.

## Risks

- Agents may skip the skill if the task does not match the description.
- The ratio is a tripwire, not a precise score. Small APIs have a large fixed cost, so lines/field can look high.

## Changes

| File | Change |
| --- | --- |
| `.claude/skills/proto-size-impl-budget/SKILL.md` | New agent skill |

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
NONE — agent skill only; no provider code change.
```

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
NONE
```

### References

- https://github.com/coralogix/coralogix-operator/pull/589

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment