### PR TITLE
Release 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Release 3.15.0
+
 #### resource/coralogix_alert
 - FIX: Destroying an alert that was already deleted outside Terraform failed the apply. A delete that the backend answers with `404 Not Found` now converges instead of raising a blocking diagnostic. The delete error message also correctly reads "Error deleting alert" instead of "Error reading alert".
 

--- a/internal/clientset/version.go
+++ b/internal/clientset/version.go
@@ -14,4 +14,4 @@
 
 package clientset
 
-const TF_PROVIDER_VERSION = "3.14.1"
+const TF_PROVIDER_VERSION = "3.15.0"


### PR DESCRIPTION
### Description

Cuts the release **3.15.0**.

- `CHANGELOG.md`: `# Unreleased` becomes `# Release 3.15.0`, with a fresh empty `# Unreleased` above it.
- `internal/clientset/version.go`: `TF_PROVIDER_VERSION` goes from `3.14.1` to `3.15.0`.

Contents of the release (already merged to master):

- #714 — `coralogix_fleet_configuration_group`: private preview (Beta) resource and data source.
- #732 / #722 — `coralogix_alert`: tolerate 404 on destroy; guard nil HTTP response on read/update.
- #726 — `coralogix_action`: guard nil HTTP response; converge delete on 404.
- #724 — `coralogix_action`: deprecate `is_hidden`.
- #723 — deprecate `coralogix_rules_group` data source; deprecation-warning copy updates for rules_group / enrichment / data_set.

After merge:
1. `git tag v3.15.0 <merge-sha>`
2. `git push origin v3.15.0`
3. Trigger the `release` GitHub Action from `master`

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

No new behaviour in this PR; it only versions already-merged changes.

### Release Note
Release note for [CHANGELOG](https://github.com/coralogix/terraform-provider-coralogix/blob/master/CHANGELOG.md):

```release-note
NONE
```

### References

- Previous cut: https://github.com/coralogix/terraform-provider-coralogix/pull/719
- Fleet configuration group: https://github.com/coralogix/terraform-provider-coralogix/pull/714

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

Made with [Cursor](https://cursor.com)